### PR TITLE
Add basic API reference docs generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You also need to ensure you have the following tool(s) installed on your system
 as they are not managed by the `scripts/` directory:
 
 * npm/nodejs
+* Golang 1.12+
 
 ### Local development
 

--- a/content/docs/reference/.gitignore
+++ b/content/docs/reference/.gitignore
@@ -1,0 +1,1 @@
+/api-docs.md

--- a/scripts/bin/gen-crd-api-reference-docs
+++ b/scripts/bin/gen-crd-api-reference-docs
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script constructs a 'content/' directory that contains content for all
+# configured versions of the documentation.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+VERSION="v0.1.5"
+
+source "${REPO_ROOT}/scripts/bin/lib.sh"
+
+gencrd="${REPO_ROOT}/bin/gen-crd-api-reference-docs"
+mkdir -p "$(dirname "$gencrd")"
+
+if ! command -v curl &>/dev/null; then
+    echo "Ensure curl command is installed"
+    exit 1
+fi
+
+if ! test -f "${gencrd}"; then
+    echo "+++ Fetching gen-crd-api-reference-docs binary and saving to bin/gen-crd-api-reference-docs"
+    detect_and_set_goos_goarch
+
+    tmpdir="$(mktemp -d)"
+    curl -Lo "${tmpdir}/file" "https://github.com/ahmetb/gen-crd-api-reference-docs/releases/download/${VERSION}/gen-crd-api-reference-docs_${GOOS}_amd64.tar.gz"
+    if [ "$GOOS" = "darwin" ]; then
+        check_sha "${tmpdir}/file" "44d9bf8f683858032e549ff2b0dbcb97508fd5df82411c6fbe95042f128b9745"
+    elif [ "$GOOS" = "linux" ]; then
+        check_sha "${tmpdir}/file" "9e14741dc9cd127082b681d4e78f3fcde95a5b70d94055142ebd16efb51998cf"
+    else
+    	echo "Unsupported OS: $GOOS"
+    	exit 1
+    fi
+
+    tar -C "$tmpdir" -xf "${tmpdir}/file"
+    mv "${tmpdir}/gen-crd-api-reference-docs" "${gencrd}"
+    chmod +x "${gencrd}"
+    rm -rf "${tmpdir}"
+fi
+
+"${gencrd}" "$@"

--- a/scripts/bin/htmltest
+++ b/scripts/bin/htmltest
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 VERSION="0.10.3"
 
 source "${REPO_ROOT}/scripts/bin/lib.sh"

--- a/scripts/bin/hugo
+++ b/scripts/bin/hugo
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 VERSION="0.59.1"
 
 source "${REPO_ROOT}/scripts/bin/lib.sh"

--- a/scripts/bin/multiversion
+++ b/scripts/bin/multiversion
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 VERSION="v0.1.0"
 
 source "${REPO_ROOT}/scripts/bin/lib.sh"

--- a/scripts/build
+++ b/scripts/build
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -26,4 +26,5 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 cd "${REPO_ROOT}"
 
 "${REPO_ROOT}/scripts/update-content"
+"${REPO_ROOT}/scripts/gendocs/generate"
 "${REPO_ROOT}/scripts/build" "$@"

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/gendocs/config.json
+++ b/scripts/gendocs/config.json
@@ -1,0 +1,29 @@
+{
+    "hideMemberFields": [
+        "TypeMeta"
+    ],
+    "hideTypePatterns": [
+        "ParseError$",
+        "List$"
+    ],
+    "externalPackages": [
+        {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/apis/meta/v1\\.Duration$",
+            "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
+        },
+        {
+            "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",
+            "docsURLTemplate": "https://godoc.org/github.com/knative/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
+        }
+    ],
+    "typeDisplayNamePrefixOverrides": {
+        "k8s.io/api/": "Kubernetes ",
+        "k8s.io/apimachinery/pkg/apis/": "Kubernetes ",
+        "k8s.io/apiextensions-apiserver/pkg/apis/": "Kubernetes "
+    },
+    "markdownDisabled": false
+}

--- a/scripts/gendocs/generate
+++ b/scripts/gendocs/generate
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script constructs a 'content/' directory that contains content for all
+# configured versions of the documentation.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+if ! command -v go &>/dev/null; then
+    echo "Ensure go command is installed"
+    exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+	export GO111MODULE="auto"
+	echo "+++ Cleaning up temporary GOPATH"
+	go clean -modcache
+	rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+# Create fake GOPATH
+echo "+++ Creating temporary GOPATH"
+export GOPATH="${tmpdir}/go"
+export GOPROXY="https://proxy.golang.org"
+export GO111MODULE="on"
+GOROOT="$(go env GOROOT)"
+export GOROOT
+mkdir -p "${GOPATH}/src/github.com/jetstack"
+gitdir="${GOPATH}/src/github.com/jetstack/cert-manager"
+echo "+++ Cloning cert-manager repository..."
+git clone "https://github.com/jetstack/cert-manager.git" "$gitdir"
+cd "$gitdir"
+
+genversion() {
+	branch="$1"
+	outputdir="$2"
+	pushd "$gitdir"
+	rm -rf vendor/
+	echo "+++ Checking out branch $branch"
+	git fetch origin "$branch"
+	git reset --hard "origin/$branch"
+	echo "+++ Running 'go mod vendor' (this may take a while)"
+	go mod vendor
+	echo "+++ Generating reference docs..."
+	"${REPO_ROOT}/scripts/bin/gen-crd-api-reference-docs" \
+		-config "${REPO_ROOT}/scripts/gendocs/config.json" \
+		-template-dir "${REPO_ROOT}/scripts/gendocs/templates" \
+		-api-dir "./pkg/apis" \
+		-out-file "${REPO_ROOT}/content/${outputdir}/reference/api-docs.md" \
+		"$@"
+	rm -rf vendor/
+	popd
+}
+
+genversion "master" "docs"
+## Use the following line as a template when adding new versions to the website
+# genversion "release-0.11" "v0.11-docs"
+
+echo "Generated reference documentation"

--- a/scripts/gendocs/templates/members.tpl
+++ b/scripts/gendocs/templates/members.tpl
@@ -1,0 +1,48 @@
+{{ define "members" }}
+
+{{ range .Members }}
+{{ if not (hiddenMember .)}}
+<tr>
+    <td>
+        <code>{{ fieldName . }}</code></br>
+        <em>
+            {{ if linkForType .Type }}
+                <a href="{{ linkForType .Type}}">
+                    {{ typeDisplayName .Type }}
+                </a>
+            {{ else }}
+                {{ typeDisplayName .Type }}
+            {{ end }}
+        </em>
+    </td>
+    <td>
+        {{ if fieldEmbedded . }}
+            <p>
+                (Members of <code>{{ fieldName . }}</code> are embedded into this type.)
+            </p>
+        {{ end}}
+
+        {{ if isOptionalMember .}}
+            <em>(Optional)</em>
+        {{ end }}
+
+        {{ safe (renderComments .CommentLines) }}
+
+    {{ if and (eq (.Type.Name.Name) "ObjectMeta") }}
+        Refer to the Kubernetes API documentation for the fields of the
+        <code>metadata</code> field.
+    {{ end }}
+
+    {{ if or (eq (fieldName .) "spec") }}
+        <br/>
+        <br/>
+        <table>
+            {{ template "members" .Type }}
+        </table>
+    {{ end }}
+    </td>
+</tr>
+{{ end }}
+{{ end }}
+
+{{ end }}

--- a/scripts/gendocs/templates/pkg.tpl
+++ b/scripts/gendocs/templates/pkg.tpl
@@ -1,0 +1,52 @@
+{{ define "packages" }}
++++
+title = "API reference docs"
++++
+
+{{ with .packages}}
+<p>Packages:</p>
+<ul>
+    {{ range . }}
+    <li>
+        <a href="#{{- packageAnchorID . -}}">{{ packageDisplayName . }}</a>
+    </li>
+    {{ end }}
+</ul>
+{{ end}}
+
+{{ range .packages }}
+    <h2 id="{{- packageAnchorID . -}}">
+        {{- packageDisplayName . -}}
+    </h2>
+
+    {{ with (index .GoPackages 0 )}}
+        {{ with .DocComments }}
+        <p>
+            {{ safe (renderComments .) }}
+        </p>
+        {{ end }}
+    {{ end }}
+
+    Resource Types:
+    <ul>
+    {{- range (visibleTypes (sortedTypes .Types)) -}}
+        {{ if isExportedType . -}}
+        <li>
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+        </li>
+        {{- end }}
+    {{- end -}}
+    </ul>
+
+    {{ range (visibleTypes (sortedTypes .Types))}}
+        {{ template "type" .  }}
+    {{ end }}
+    <hr/>
+{{ end }}
+
+<p><em>
+    Generated with <code>gen-crd-api-reference-docs</code>
+    {{ with .gitCommit }} on git commit <code>{{ . }}</code>{{end}}.
+</em></p>
+
+{{ end }}

--- a/scripts/gendocs/templates/type.tpl
+++ b/scripts/gendocs/templates/type.tpl
@@ -1,0 +1,58 @@
+{{ define "type" }}
+
+<h3 id="{{ anchorIDForType . }}">
+    {{- .Name.Name }}
+    {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias)</p>{{ end -}}
+</h3>
+{{ with (typeReferences .) }}
+    <p>
+        (<em>Appears on:</em>
+        {{- $prev := "" -}}
+        {{- range . -}}
+            {{- if $prev -}}, {{ end -}}
+            {{ $prev = . }}
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+        {{- end -}}
+        )
+    </p>
+{{ end }}
+
+
+<p>
+    {{ safe (renderComments .CommentLines) }}
+</p>
+
+{{ if .Members }}
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{ if isExportedType . }}
+        <tr>
+            <td>
+                <code>apiVersion</code></br>
+                string</td>
+            <td>
+                <code>
+                    {{apiGroup .}}
+                </code>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>kind</code></br>
+                string
+            </td>
+            <td><code>{{.Name.Name}}</code></td>
+        </tr>
+        {{ end }}
+        {{ template "members" .}}
+    </tbody>
+</table>
+{{ end }}
+
+{{ end }}

--- a/scripts/server
+++ b/scripts/server
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/server-release
+++ b/scripts/server-release
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/update-content
+++ b/scripts/update-content
@@ -23,7 +23,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 "${REPO_ROOT}/scripts/bin/multiversion" \
 	--repo-url https://github.com/cert-manager/docs.git \

--- a/scripts/update-node_modules
+++ b/scripts/update-node_modules
@@ -23,7 +23,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 cd "$REPO_ROOT"
 
 if ! command -v npm &>/dev/null; then

--- a/scripts/update-theme
+++ b/scripts/update-theme
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 cd "${REPO_ROOT}/themes/docsy"
 git submodule update -f --init

--- a/scripts/verify
+++ b/scripts/verify
@@ -18,6 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 "${REPO_ROOT}/scripts/verify-links"

--- a/scripts/verify-links
+++ b/scripts/verify-links
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/verify-release
+++ b/scripts/verify-release
@@ -25,7 +25,7 @@ set -o pipefail
 # order to ensure the final version of the site to be published passes all
 # verification steps.
 
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Run all commands relative to the repository root
 cd "${REPO_ROOT}"


### PR DESCRIPTION
Adds initial work for the reference docs generation. This will likely make `scripts/verify-release` fail as I'm going to have to update the go templates used for generating the docs to generate markdown, and generally fix them up 😄 
