### PR TITLE
Bump version strings for v0.12.0-beta.0 release

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,7 +1,7 @@
 # Default docs params
 # Latest cert-manager docs release/version - Default values (for Docsy Template)
 # Default GitHub branch
-latest_github_branch = "release-0.11"
+latest_github_branch = "release-0.12"
 # Default website version
 version = "v0.12"
 
@@ -38,6 +38,6 @@ version = "v0.12"
 
 [[versions]]
   version = "v0.11"
-  ghbranchname = "release-0.11"
-  url = "https://docs.cert-manager.io/en/release-0.11"
+  ghbranchname = "release-0.12"
+  url = "https://docs.cert-manager.io/en/release-0.12"
   dirpath = "external-link"

--- a/content/en/docs/installation/compatibility.md
+++ b/content/en/docs/installation/compatibility.md
@@ -65,9 +65,9 @@ conditionally disable different components, we also ship a copy of the
 deployment files that do not include the webhook.
 
 Instead of installing with
-[`cert-manager.yaml`](https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml)
+[`cert-manager.yaml`](https://github.com/jetstack/cert-manager/releases/download/v0.12.0-beta.0/cert-manager.yaml)
 file, you should instead use the
-[`cert-manager-no-webhook.yaml`](https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml)
+[`cert-manager-no-webhook.yaml`](https://github.com/jetstack/cert-manager/releases/download/v0.12.0-beta.0/cert-manager.yaml)
 file located in the deploy directory.
 
 This is a destructive operation, as it will remove the `CustomResourceDefinition`
@@ -79,8 +79,8 @@ running the following commands.
 To re-install cert-manager without the webhook, run:
 
 ```bash
-$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager-no-webhook.yaml
+$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.12.0-beta.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.12.0-beta.0/cert-manager-no-webhook.yaml
 ```
 
 Once you have re-installed cert-manager, you should then [restore your

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -46,7 +46,7 @@ are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
 ```bash
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.12.0-beta.0/cert-manager.yaml
 ```
 
 > **Note**: If you are running Kubernetes `v1.15` or below, you will need to add the
@@ -105,7 +105,7 @@ In order to install the Helm chart, you must run:
 
 Install the `CustomResourceDefinition` resources separately
 ```bash
-$ kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
+$ kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
 ```
 
 Create the namespace for cert-manager
@@ -128,7 +128,7 @@ Install the cert-manager Helm chart
 $ helm install \
   --name cert-manager \
   --namespace cert-manager \
-  --version v0.11.0 \
+  --version v0.12.0-beta.0 \
   jetstack/cert-manager
 ```
 

--- a/content/en/docs/installation/openshift.md
+++ b/content/en/docs/installation/openshift.md
@@ -68,7 +68,7 @@ are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
 ```bash
-$ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager-openshift.yaml
+$ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.12.0-beta.0/cert-manager-openshift.yaml
 ```
 
  > Node: The `--validate=false` flag is added to the `oc apply` command

--- a/content/en/docs/release-notes/release-notes-0.11.md
+++ b/content/en/docs/release-notes/release-notes-0.11.md
@@ -47,7 +47,7 @@ The changes to our CRD resources mean that upgrading requires more manual
 intervention than in previous releases.
 
 It's recommended that you backup and completely [uninstall
-cert-manager](https://docs.cert-manager.io/en/release-0.11/tasks/uninstall/)
+cert-manager](https://docs.cert-manager.io/en/release-0.12/tasks/uninstall/)
 before re-installing the `v0.11` release.
 
 You will also need to manually update all your backed up cert-manager resource

--- a/content/en/docs/tutorials/acme/ingress.md
+++ b/content/en/docs/tutorials/acme/ingress.md
@@ -224,7 +224,7 @@ sample deployment and an associated service:
 
 TODO (`@joshvanl`): move this link to the new location
 - deployment manifest:
-  [`deployment.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/deployment.yaml)
+  [`deployment.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/deployment.yaml)
 
 TODO (`@joshvanl`): include link contents
 ```yaml
@@ -233,7 +233,7 @@ example/deployment.yaml
 
 TODO (`@joshvanl`): move this link to the new location
 - service manifest:
-  [`service.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/service.yaml)
+  [`service.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/service.yaml)
 
 TODO (`@joshvanl`): include link contents
 ```yaml
@@ -246,10 +246,10 @@ To install the example service from the tutorial files straight from GitHub,
 you may use the commands:
 
 ```yaml
-$ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/deployment.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/deployment.yaml
 deployment.extensions "kuard" created
 
-$ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/service.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/service.yaml
 service "kuard" created
 ```
 
@@ -263,7 +263,7 @@ A sample ingress you can start with is:
 
 TODO (`@joshvanl`): move this link to the new location
 - ingress manifest:
-  [`ingress.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/ingress.yaml)
+  [`ingress.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/ingress.yaml)
 
 TODO (`@joshvanl`): include link contents
 ```yaml
@@ -273,7 +273,7 @@ example/ingress.yaml
 You can download the sample manifest from GitHub , edit it, and submit the manifest to Kubernetes with the command:
 
 ```yaml
-$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/ingress.yaml
+$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/ingress.yaml
 
 # edit the file in your editor, and once it is saved:
 ingress.extensions "kuard" created
@@ -387,7 +387,7 @@ expiration and updates.
 
 TODO (`@joshvanl`): fix link
 - staging issuer:
-  [`staging-issuer.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/staging-issuer.yaml)
+  [`staging-issuer.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/staging-issuer.yaml)
 
 TODO (`@joshvanl`): include file
 ```yaml
@@ -397,7 +397,7 @@ example/staging-issuer.yaml
 Once edited, apply the custom resource:
 
 ```bash
-$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/staging-issuer.yaml
+$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/staging-issuer.yaml
 issuer.cert-manager.io "letsencrypt-staging" created
 ```
 
@@ -405,7 +405,7 @@ Also create a production issuer and deploy it. As with the staging issuer, you
 will need to update this example and add in your own email address.
 
 - production issuer:
-  [`production-issuer.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/production-issuer.yaml)
+  [`production-issuer.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/production-issuer.yaml)
 
 TODO (`@joshvanl`): include file
 ```yaml
@@ -413,7 +413,7 @@ example/production-issuer.yaml
 ```
 
 ```bash
-$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/production-issuer.yaml
+$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/production-issuer.yaml
 issuer.cert-manager.io "letsencrypt-prod" created
 ```
 
@@ -486,7 +486,7 @@ Edit the ingress add the annotations that were commented out in our earlier
 example:
 
 TODO (`@joshvanl`): move this link to the new location
-- ingress TLS: [`ingress-tls.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/ingress-tls.yaml)
+- ingress TLS: [`ingress-tls.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/ingress-tls.yaml)
 
 TODO (`@joshvanl`): include link contents
 ```yaml
@@ -496,7 +496,7 @@ example/ingress-tls.yaml
 and apply it:
 
 ```bash
-$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/ingress-tls.yaml
+$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/ingress-tls.yaml
 ingress.extensions "kuard" configured
 ```
 
@@ -594,7 +594,7 @@ Now that we have confidence that everything is configured correctly, you
 can update the annotations in the ingress to specify the production issuer:
 
 TODO (`@joshvanl`): move this link to the new location
-- ingress TLS final: [`ingress-tls-final.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/ingress-tls-final.yaml)
+- ingress TLS final: [`ingress-tls-final.yaml`](https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/ingress-tls-final.yaml)
 
 TODO (`@joshvanl`): include link contents
 ```yaml
@@ -602,7 +602,7 @@ example/ingress-tls-final.yaml
 ```
 
 ```bash
-$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/docs/tutorials/acme/quick-start/example/ingress-tls-final.yaml
+$ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/docs/tutorials/acme/quick-start/example/ingress-tls-final.yaml
 ingress.extensions "kuard" configured
 ```
 

--- a/content/en/docs/usage/certificate.md
+++ b/content/en/docs/usage/certificate.md
@@ -84,7 +84,7 @@ The Certificate will be issued using the issuer named `ca-issuer` in the
 > days, 23 hours (the *full duration* remains 90 days).
 
 A full list of the fields supported on the Certificate resource can be found in
-the [API reference documentation](https://docs.cert-manager.io/en/release-0.11/reference/api-docs/#certificatespec-v1alpha2).
+the [API reference documentation](https://docs.cert-manager.io/en/release-0.12/reference/api-docs/#certificatespec-v1alpha2).
 
 ## Temporary Certificates whilst Issuing
 

--- a/scripts/gendocs/generate
+++ b/scripts/gendocs/generate
@@ -71,7 +71,7 @@ genversion() {
 	popd
 }
 
-genversion "master" "docs"
+genversion "release-0.12" "docs"
 ## Use the following line as a template when adding new versions to the website
 # genversion "release-0.11" "v0.11-docs"
 

--- a/scripts/update-content
+++ b/scripts/update-content
@@ -29,4 +29,4 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 	--repo-url https://github.com/cert-manager/website.git \
 	--repo-content-dir content/en/docs \
 	--output-dir "${REPO_ROOT}/content/en" \
-	--branches v0.12-docs=release-0.12
+	# --branches v0.12-docs=release-0.12


### PR DESCRIPTION
This also highlighted that we need to update references to files for the nginx acme quick start guide from the old `jetstack/cert-manager` repo. These files we still exist in `release-0.12`, so we can leave this as-is for now 😄 