### PR TITLE
Updated remaining incorrect references to venafi cloud enrollment pages

### DIFF
--- a/content/en/docs/configuration/venafi.md
+++ b/content/en/docs/configuration/venafi.md
@@ -6,10 +6,10 @@ type: "docs"
 ---
 
 The Venafi `Issuer` types allows you to obtain certificates from [Venafi
-Cloud](https://pki.venafi.com/venafi-cloud) and [Venafi Trust Protection
+Cloud](https://www.venafi.com/cloud) and [Venafi Trust Protection
 Platform](https://venafi.com) instances.
 
-Register your account at https://ui.venafi.cloud/enroll and get an API key from
+Create your Venafi Cloud account on this [page](https://www.venafi.com/cloud) and get an API key from
 your dashboard.
 
 You can have multiple different Venafi `Issuer` types installed within the same

--- a/content/en/docs/tutorials/venafi/venafi.md
+++ b/content/en/docs/tutorials/venafi/venafi.md
@@ -316,8 +316,8 @@ $ kubectl describe issuer -n demo venafi-issuer
 
 ### Venafi Cloud
 
-You can sign up for a Venafi Cloud account by visiting the [enroll
-page](https://www.venafi.com/platform/cloud/devops).
+You can sign up for a Venafi Cloud account by visiting the [enrollment
+page](https://www.venafi.com/cloud).
 
 Once registered, you should fetch your API key by clicking your name in the top
 right of the control panel interface.


### PR DESCRIPTION
We are moving our enrollment page for Venafi Cloud to a more stable URL. This pull request updates docs to reflect this URL.