### PR TITLE
Add no_list: true to release-notes page

### DIFF
--- a/content/en/docs/release-notes/_index.md
+++ b/content/en/docs/release-notes/_index.md
@@ -3,6 +3,7 @@ title: "Release Notes"
 linkTitle: "Release Notes"
 weight: 80
 type: "docs"
+no_list: true
 ---
 
 Here you will find a link to all release notes for each version release of


### PR DESCRIPTION
This tidies up the release notes index page, as described in #41 

Signed-off-by: James Munnelly <james@munnelly.eu>