### PR TITLE
Remove --name flag from helm installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ This will automatically run a number of checks against your changes.
 
 There is also a `./scripts/verify-release` command which will fetch all
 versions of the documentation content before running the regular `verify`
-script.
+script. 

--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ This will automatically run a number of checks against your changes.
 
 There is also a `./scripts/verify-release` command which will fetch all
 versions of the documentation content before running the regular `verify`
-script. 
+script.

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -133,8 +133,7 @@ $ helm repo update
 
 Install the cert-manager Helm chart.
 ```bash
-$ helm install \
-  --name cert-manager \
+$ helm install cert-manager \
   --namespace cert-manager \
   --version v0.13.0-alpha.0 \
   jetstack/cert-manager


### PR DESCRIPTION
As [this answer](https://stackoverflow.com/a/57964140/2199949) succinctly captures from the [Helm v3 docs](https://v3.helm.sh/docs/), the `--name` tag is no longer used.

Signed-off-by: Leif Segen <leif.nabil.segen@gmail.com>