### PR TITLE
Remove '-' in matchLabels

### DIFF
--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -265,7 +265,7 @@ spec:
           class: nginx
       selector:
         matchLabels:
-        - "user-http01-solver": "true"
+          "user-http01-solver": "true"
     - dns01:
         cloudflare:
           email: user@example.com


### PR DESCRIPTION
matchLabels is an object, not a list.

Signed-off-by: Niels Slot <nielsslot@gmail.com>