### PR TITLE
Add documentation about scoped cloudflare api tokens

### DIFF
--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -5,9 +5,9 @@ weight: 30
 type: "docs"
 ---
 
-To use Cloudflare, you may use one of two types of tokens. **API Tokens** allow application-scoped keys bound to specific zones and permissions, while **API Keys** are globally-scoped keys that carry the same permissions as your account.
+To use CloudFlare, you may use one of two types of tokens. **API Tokens** allow application-scoped keys bound to specific zones and permissions, while **API Keys** are globally-scoped keys that carry the same permissions as your account.
 
-**API Tokens** are recommended for higher security, since they have more restrictive permissions and are more easily revokable.
+**API Tokens** are recommended for higher security, since they have more restrictive permissions and are more easily revocable.
 
 ## API Tokens
 

--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -13,8 +13,11 @@ To use Cloudflare, you may use one of two types of tokens. **API Tokens** allow 
 
 Tokens can be created at **User Profile > API Tokens > API Tokens**. The following settings are recommended:
 
-- Permissions: `Zone - DNS - Edit`
-- Zone Resources: `Include - <The specific zones you want covered>`
+- Permissions:
+  - `Zone - DNS - Edit`
+  - `Zone - Zone - Read`
+- Zone Resources:
+  - `Include - All Zones`
 
 To create a new `Issuer`, first make a Kubernetes secret containing your new API token:
 

--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -5,6 +5,66 @@ weight: 30
 type: "docs"
 ---
 
+To use Cloudflare, you may use one of two types of tokens. **API Tokens** allow application-scoped keys bound to specific zones and permissions, while **API Keys** are globally-scoped keys that carry the same permissions as your account.
+
+**API Tokens** are recommended for higher security, since they have more restrictive permissions and are more easily revokable.
+
+## API Tokens
+
+Tokens can be created at **User Profile > API Tokens > API Tokens**. The following settings are recommended:
+
+- Permissions: `Zone - DNS - Edit`
+- Zone Resources: `Include - <The specific zones you want covered>`
+
+To create a new `Issuer`, first make a Kubernetes secret containing your new API token:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-api-token-secret
+type: Opaque
+stringData:
+  api-token: <API Token>
+```
+
+Then in your `Issuer` manifest:
+
+```yaml
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: example-issuer
+spec:
+  acme:
+    ...
+    solvers:
+    - dns01:
+        cloudflare:
+          email: my-cloudflare-acc@example.com
+          apiTokenSecretRef:
+            name: cloudflare-api-token-secret
+            key: api-token
+```
+
+## API Keys
+
+API keys can be retrieved at **User Profile > API Tokens > API Keys > Global API Key > View**.
+
+To create a new `Issuer`, first make a Kubernetes secret containing your API key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-api-key-secret
+type: Opaque
+stringData:
+  api-key: <API Key>
+```
+
+Then in your `Issuer` manifest:
+
 ```yaml
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer


### PR DESCRIPTION
This PR adds some additional info about creating and using Cloudflare API tokens in ACME DNS01 challenges. 

Closes #49 