### PR TITLE
Update kubernetes installation page

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -134,7 +134,7 @@ $ helm repo update
 Install the cert-manager Helm chart.
 ```bash
 $ helm install \
-  --name cert-manager \
+  cert-manager \
   --namespace cert-manager \
   --version v0.13.0 \
   jetstack/cert-manager


### PR DESCRIPTION
In Helm v3, the release name is now mandatory as part of the command.
The `name` flag is not exist anymore.