### PR TITLE
Add key field under privateKeySecretRef

### DIFF
--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -61,9 +61,8 @@ spec:
     email: user@example.com
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
-      # Secret resource used to store the account's private key.
-      name: example-issuer-account-secret
-      key: example-issuer-account-secret-key
+      # Secret resource that will be used to store the account's private key.
+      name: example-issuer-account-key
     # Add a single challenge solver, HTTP01 using nginx
     solvers:
     - http01:

--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -62,7 +62,8 @@ spec:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Secret resource used to store the account's private key.
-      name: example-issuer-account-key
+      name: example-issuer-account-secret
+      key: example-issuer-account-secret-key
     # Add a single challenge solver, HTTP01 using nginx
     solvers:
     - http01:


### PR DESCRIPTION
I am not 100% sure, but it worked for me. As a newbie this sent me on a search whether k8s secrets can hold only values without keys, but I don't think it's possible.

In other parts of the documentation the name *and* key are specified on secret refs, like here: https://cert-manager.io/docs/configuration/acme/dns01/google/#create-an-issuer-that-uses-clouddns