### PR TITLE
Make kubectl example have the same secret name

### DIFF
--- a/content/en/docs/tutorials/acme/dns-validation.md
+++ b/content/en/docs/tutorials/acme/dns-validation.md
@@ -64,7 +64,7 @@ spec:
         cloudflare:
           email: my-cloudflare-acc@example.com
           # !! Remember to create a k8s secret before
-          # kubectl create secret generic cloudflare-api-key
+          # kubectl create secret generic cloudflare-api-key-secret
           apiKeySecretRef:
             name: cloudflare-api-key-secret
             key: api-key


### PR DESCRIPTION
An easy mistake to make when copy pasting the kubectl command and not double checking, changed the name for consistency.