### PR TITLE
Remove commonName where possible

### DIFF
--- a/content/en/docs/configuration/acme/dns01/google.md
+++ b/content/en/docs/configuration/acme/dns01/google.md
@@ -108,7 +108,6 @@ spec:
   issuerRef:
     # The issuer created previously
     name: example-issuer
-  commonName: example.com
   dnsNames:
   - example.com
   - www.example.com

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -190,7 +190,8 @@ metadata:
   name: selfsigned-cert
   namespace: cert-manager-test
 spec:
-  commonName: example.com
+  dnsNames: 
+    - example.com
   secretName: selfsigned-cert-tls
   issuerRef:
     name: test-selfsigned

--- a/content/en/docs/tutorials/acme/dns-validation.md
+++ b/content/en/docs/tutorials/acme/dns-validation.md
@@ -107,8 +107,8 @@ spec:
   secretName: example-com-tls
   issuerRef:
     name: letsencrypt-staging
-  commonName: '*.example.com'
   dnsNames:
+  - '*.example.com'
   - example.com
   - foo.com
 ```

--- a/content/en/docs/tutorials/acme/http-validation.md
+++ b/content/en/docs/tutorials/acme/http-validation.md
@@ -93,7 +93,8 @@ obtained successfully, the resulting key pair will be stored in a secret called
 The certificate will have a common name of `example.com` and the [Subject
 Alternative Names
 (SANs)](https://en.wikipedia.org/wiki/Subject_Alternative_Name) will be
-`example.com` and `www.example.com`.
+`example.com` and `www.example.com`. Note that only these SANs will be respected
+by TLS clients.
 
 In our Certificate we have referenced the `letsencrypt-staging` Issuer above.
 The Issuer must be in the same namespace as the Certificate.  If you want to


### PR DESCRIPTION
This removes the use of commonName in favour of adding it's value to dnsNames.
Where it doesn't seem right to not meantion commonName a note is added.

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>