### PR TITLE
Removing Helmfile install as it has fallen behind

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -248,22 +248,6 @@ supported backends.
 
 ## Alternative installation methods
 
-### Helmfile
-
-Helmfile is a declarative spec for deploying helm charts. 
-
-'cert-manager-installer': https://github.com/zakkg3/cert-manager-installer
-It's an easy and automated way to install cert-manager.
-
-Note: This is an external link and it's not officially maintained by cert-manager
-but by the community.
-
-```bash
-$ git clone git@github.com:zakkg3/cert-manager-installer.git
-$ cd cert-manager-installer
-$ helmfile sync
-```
-
 ### kubeprod
 
 [Bitnami Kubernetes Production


### PR DESCRIPTION
When looking into the Helmfile deployment method I noticed it currently uses 0.8, we should remove it from the documentation for now to not confuse users with installing older versions.