### PR TITLE
Fix `helm install` command output

### DIFF
--- a/content/en/docs/tutorials/acme/ingress.md
+++ b/content/en/docs/tutorials/acme/ingress.md
@@ -162,11 +162,9 @@ An example Ingress that makes use of the controller:
         - hosts:
             - www.example.com
           secretName: example-tls
-```
 
 If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
 
-```yaml
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
I believe the output of the `helm install` command had been mistaken actual documentation.