### PR TITLE
Make kuernetes version more explict

### DIFF
--- a/content/en/docs/contributing/kind.md
+++ b/content/en/docs/contributing/kind.md
@@ -52,7 +52,7 @@ After changes have been made to the API, the Custom Resource Definitions can be
 re-generated with the following command:
 
 ```bash
-./hack/update-crds.yaml
+./hack/update-crds.sh
 ```
 
 Note that this script only apply patches to the existing CRDs not fully regenerates them.

--- a/content/en/docs/installation/compatibility.md
+++ b/content/en/docs/installation/compatibility.md
@@ -65,9 +65,9 @@ conditionally disable different components, we also ship a copy of the
 deployment files that do not include the webhook.
 
 Instead of installing with
-[`cert-manager.yaml`](https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml)
+[`cert-manager.yaml`](https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml)
 file, you should instead use the
-[`cert-manager-no-webhook.yaml`](https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager-no-webhook.yaml)
+[`cert-manager-no-webhook.yaml`](https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager-no-webhook.yaml)
 file located in the deploy directory.
 
 This is a destructive operation, as it will remove the
@@ -80,8 +80,8 @@ running the following commands.
 To re-install cert-manager without the webhook, run:
 
 ```bash
-$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager-no-webhook.yaml
+$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager-no-webhook.yaml
 ```
 
 Once you have re-installed cert-manager, you should then [restore your

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -49,7 +49,7 @@ Install the `CustomResourceDefinitions` and cert-manager itself
 $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml
 ```
 
-> **Note**: If you are running Kubernetes `v1.15` or below, you will need to add the
+> **Note**: If you are running Kubernetes `v1.15.4` or below, you will need to add the
 > `--validate=false` flag to your `kubectl apply` command above else you will
 > receive a validation error relating to the
 > `x-kubernetes-preserve-unknown-fields` field in cert-manager's

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -46,7 +46,7 @@ are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
 ```bash
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml
 ```
 
 > **Note**: If you are running Kubernetes `v1.15` or below, you will need to add the
@@ -106,7 +106,7 @@ In order to install the Helm chart, you must follow these steps.
 
 Install the `CustomResourceDefinition` resources separately.
 ```bash
-$ kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.13.0/deploy/manifests/00-crds.yaml
+$ kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.13.1/deploy/manifests/00-crds.yaml
 ```
 
 Create the namespace for cert-manager.
@@ -135,13 +135,13 @@ Install the cert-manager Helm chart.
 $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v0.13.0
+  --version v0.13.1
 
 # Helm v2
 $ helm install \
   --name cert-manager \
   --namespace cert-manager \
-  --version v0.13.0 \
+  --version v0.13.1 \
   jetstack/cert-manager
   
 ```

--- a/content/en/docs/installation/openshift.md
+++ b/content/en/docs/installation/openshift.md
@@ -61,7 +61,7 @@ are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
 ```bash
-$ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager-openshift.yaml
+$ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager-openshift.yaml
 ```
 
  > Node: The `--validate=false` flag is added to the `oc apply` command

--- a/content/en/docs/installation/upgrading/_index.md
+++ b/content/en/docs/installation/upgrading/_index.md
@@ -74,7 +74,7 @@ $ kubectl apply \
        -f https://github.com/jetstack/cert-manager/releases/download/<version>/cert-manager.yaml
 ```
 
-> Note: If you are running Kubernetes `v1.15` or below, you will need to add the
+> Note: If you are running Kubernetes `v1.15.4` or below, you will need to add the
 > `--validate=false` flag to your `kubectl apply` command above else you will
 > receive a validation error relating to the
 > `x-kubernetes-preserve-unknown-fields` field in our `CustomResourceDefinition`


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

In fact, 1.15.5 k8s would apply without any error info:
```
[root@test cert]# kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml
customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/issuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/orders.acme.cert-manager.io created
namespace/cert-manager created
serviceaccount/cert-manager-cainjector created
serviceaccount/cert-manager created
serviceaccount/cert-manager-webhook created
clusterrole.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector created
role.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
rolebinding.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:auth-delegator created
rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:webhook-authentication-reader created
clusterrole.rbac.authorization.k8s.io/cert-manager-webhook:webhook-requester created
role.rbac.authorization.k8s.io/cert-manager:leaderelection created
rolebinding.rbac.authorization.k8s.io/cert-manager:leaderelection created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrole.rbac.authorization.k8s.io/cert-manager-view created
clusterrole.rbac.authorization.k8s.io/cert-manager-edit created
service/cert-manager created
service/cert-manager-webhook created
deployment.apps/cert-manager-cainjector created
deployment.apps/cert-manager created
deployment.apps/cert-manager-webhook created
mutatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
[root@test cert]# kubectl version 
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:16:51Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:07:57Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}

```