### PR TITLE
Make Algolia logo link to algolia.com

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -26,7 +26,7 @@ autocomplete('#search-box', { hint: false }, [
           ${suggestion._snippetResult.content.value}
         </div>`;
       },
-      footer: '<div class="algolia-branding"><img src="/images/search-by-algolia-light-background.svg" alt="Search powered by Algolia" /></div>',
+      footer: '<div class="algolia-branding"><a href="https://algolia.com"><img src="/images/search-by-algolia-light-background.svg" alt="Search powered by Algolia" /></a></div>',
     }
   }
 ]).on('autocomplete:selected', function(event, suggestion, dataset, context) {


### PR DESCRIPTION
Make Algolia logo link to algolia.com, this doesn't seem to be required everywhere in their documentation (conflicting results) but it nice to have this linking.