### PR TITLE
No need to create namespace

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -53,7 +53,8 @@ $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/rel
 > them again after elevating your permissions:
 
 > **Note**: By default, cert-manager will be installed into the `cert-manager`
-> namespace. It is possible to run cert-manager in a different namespace, although you > will need to make modifications to the deployment manifests.
+> namespace. It is possible to run cert-manager in a different namespace, although you
+> will need to make modifications to the deployment manifests.
 
 ```bash
 kubectl create clusterrolebinding cluster-admin-binding \

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -29,7 +29,7 @@ guides](../../configuration/).
 
 ## Installing with regular manifests
 
-All resources(the `CustomResourceDefinitions`, cert-manager, namespace, and the webhook component)
+All resources (the `CustomResourceDefinitions`, cert-manager, namespace, and the webhook component)
 are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
@@ -52,9 +52,9 @@ $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/rel
 > the above command. If you have already run the above command, you should run
 > them again after elevating your permissions:
 
-> **Note**: It installs cert-manager in cert-manager namespace by default. It is
-> possible to run cert-manager in a different namespace, although you will need to
-> make modifications to the deployment manifests or add `-n $namespace` for `kubectl apply`.
+> **Note**: By default, cert-manager will be installed into the `cert-manager`
+> namespace. It is possible to run cert-manager in a different namespace, although you > will need to make modifications to the deployment manifests or add `-n $namespace`
+> for `kubectl apply`.
 
 ```bash
 kubectl create clusterrolebinding cluster-admin-binding \

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -29,19 +29,7 @@ guides](../../configuration/).
 
 ## Installing with regular manifests
 
-In order to install cert-manager, we must first create a namespace to run it in.
-This guide will install cert-manager into the `cert-manager` namespace. It is
-possible to run cert-manager in a different namespace, although you will need to
-make modifications to the deployment manifests.
-
-
-Create a namespace to run cert-manager in
-```bash
-$ kubectl create namespace cert-manager
-```
-
-We can now go ahead and install cert-manager. All resources
-(the `CustomResourceDefinitions`, cert-manager, and the webhook component)
+All resources(the `CustomResourceDefinitions`, cert-manager, namespace, and the webhook component)
 are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
@@ -63,6 +51,10 @@ $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/rel
 > 'elevate' your own privileges to that of a 'cluster-admin' **before** running
 > the above command. If you have already run the above command, you should run
 > them again after elevating your permissions:
+
+> **Note**: It installs cert-manager in cert-manager namespace by default. It is
+> possible to run cert-manager in a different namespace, although you will need to
+> make modifications to the deployment manifests or add `-n $namespace` for `kubectl apply`.
 
 ```bash
 kubectl create clusterrolebinding cluster-admin-binding \

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -53,8 +53,7 @@ $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/rel
 > them again after elevating your permissions:
 
 > **Note**: By default, cert-manager will be installed into the `cert-manager`
-> namespace. It is possible to run cert-manager in a different namespace, although you > will need to make modifications to the deployment manifests or add `-n $namespace`
-> for `kubectl apply`.
+> namespace. It is possible to run cert-manager in a different namespace, although you > will need to make modifications to the deployment manifests.
 
 ```bash
 kubectl create clusterrolebinding cluster-admin-binding \


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Check https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml line 5546-5549, it would create cert-manager namespace.