### PR TITLE
Add description of Ingress annotations for out-of-tree Issuers

### DIFF
--- a/content/en/docs/usage/ingress.md
+++ b/content/en/docs/usage/ingress.md
@@ -59,6 +59,9 @@ trigger `Certificate` resources to be automatically created:
 - `cert-manager.io/issuer-kind`: the name of an external `Issuer`
   controller's `CustomResourceDefinition` (only necessary for out-of-tree `Issuers`)
 
+- `cert-manager.io/issuer-group`: the name of the API group of external
+  `Issuer` controller (only necessary for out-of-tree `Issuers`)
+
 - `kubernetes.io/tls-acme: "true"`: this annotation requires additional
   configuration of the ingress-shim [see below](./#optional-configuration).
   Namely, a default `Issuer` must be specified as arguments to the

--- a/content/en/docs/usage/ingress.md
+++ b/content/en/docs/usage/ingress.md
@@ -56,6 +56,9 @@ trigger `Certificate` resources to be automatically created:
   certificate required for this `Ingress`. It does not matter which namespace
   your `Ingress` resides, as `ClusterIssuers` are non-namespaced resources.
 
+- `cert-manager.io/issuer-kind`: the name of an external `Issuer`
+  controller's `CustomResourceDefinition` (only necessary for out-of-tree `Issuers`)
+
 - `kubernetes.io/tls-acme: "true"`: this annotation requires additional
   configuration of the ingress-shim [see below](./#optional-configuration).
   Namely, a default `Issuer` must be specified as arguments to the


### PR DESCRIPTION
These Ingress annotations are necessary for ingress-shim to create Certificates with out-of-tree Issuers. As such, documentation for this is helpful.