### PR TITLE
Fix docs by mentioning the 2 separate annotations

### DIFF
--- a/content/en/docs/concepts/ca-injector.md
+++ b/content/en/docs/concepts/ca-injector.md
@@ -11,8 +11,9 @@ bundle into the [webhook's](../webhook/) `ValidatingWebhookConfiguration` and
 API server to 'trust' the webhook API server.
 
 This component is configured using the `cert-manager.io/inject-apiserver-ca:
-"true"` and `cert-manager.io/inject-apiserver-ca: "true"` annotations on the
-`ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` resources.
+"true"` and `cert-manager.io/inject-ca-from: <NAMESPACE>/<CERTIFICATE>`
+annotations on the `ValidatingWebhookConfiguration` and
+`MutatingWebhookConfiguration` resources.
 
 It copies across the CA defined in the `cert-manager-webhook-ca` `Secret` over
 to the `clientConfig.caBundle` field in both the


### PR DESCRIPTION
I looked at the docs and saw 2 same annotations. In an [older version](https://docs.cert-manager.io/en/release-0.11/reference/cainjector.html) I saw 2 different annotations, so I guess I'll make a PR to fix it.