### PR TITLE
Use DocSearch

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,5 +1,5 @@
 var versionName = "docs"
-let versionMatch = window.location.href.match(/v(.*)-docs\//) 
+let versionMatch = window.location.pathname.match(/v(.*)-docs\//) 
 if (versionMatch && versionMatch[1]) { // check if we matched a version
   versionName = `v${versionMatch[1]}-docs`
 }

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,34 +1,15 @@
-var client = algoliasearch('18N9PEKHUC', '29ab24453d2b70065a76b4e1a6a82abc');
-var indexName = "cert-manager-latest"
+var versionName = "docs"
 let versionMatch = window.location.href.match(/v(.*)-docs\//) 
 if (versionMatch && versionMatch[1]) { // check if we matched a version
-  indexName = `cert-manager-v${versionMatch[1]}`
+  versionName = `v${versionMatch[1]}-docs`
 }
-var index = client.initIndex(indexName);
 
-autocomplete('#search-box', { hint: false }, [
-  {
-    source: autocomplete.sources.hits(index, { hitsPerPage: 5 }),
-    attributesToSnippet: [
-      "content:10"
-    ],
-    displayKey: 'title',
-    clearOnSelected: true,
-    templates: {
-      empty: "Nothing found",
-      suggestion: function(suggestion) {
-        console.log(suggestion._snippetResult)
-        return `
-        <div>
-          <a href="${suggestion.uri.replace("en","")}">${suggestion._highlightResult.title.value}</a>
-        </div>
-        <div class="search-snippet">
-          ${suggestion._snippetResult.content.value}
-        </div>`;
-      },
-      footer: '<div class="algolia-branding"><a href="https://algolia.com"><img src="/images/search-by-algolia-light-background.svg" alt="Search powered by Algolia" /></a></div>',
-    }
-  }
-]).on('autocomplete:selected', function(event, suggestion, dataset, context) {
-    window.location.assign(suggestion.uri.replace("en",""));
+docsearch({
+  apiKey: 'e335fb22ca2fd2d96b4ba95b703430eb',
+  indexName: 'cert-manager',
+  inputSelector: '#search-box',
+  algoliaOptions: {
+    'facetFilters': [ `version:${versionName}` ]
+  },
+  debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,28 @@
+
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+{{ hugo.Generator }}
+{{ if eq (getenv "HUGO_ENV") "production" }}
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+{{ else }}
+<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+{{ end }}
+{{ range .AlternativeOutputFormats -}}
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{ end -}}
+{{ partialCached "favicons.html" . }}
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+{{- template "_internal/opengraph.html" . -}}
+{{- template "_internal/google_news.html" . -}}
+{{- template "_internal/schema.html" . -}}
+{{- template "_internal/twitter_cards.html" . -}}
+{{ if eq (getenv "HUGO_ENV") "production" }}
+{{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
+{{ partialCached "head-css.html" . "asdf" }}
+<script
+  src="https://code.jquery.com/jquery-3.3.1.min.js"
+  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  crossorigin="anonymous"></script>
+{{ partial "hooks/head-end.html" . }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,8 +1,7 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/algoliasearch/3.35.1/algoliasearch.min.js" integrity="sha256-k5vAt55RMe6XgN8dqlVTcCQfRCs0oI/aSWXQxnZBYBU=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/autocomplete.js/0.37.1/autocomplete.min.js" integrity="sha256-YVWQosorZnr6fALvOW9VALYuInld27RkSPkElGBdCaU=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 {{ $jsBase := resources.Get "js/base.js" }}
 {{ $jsAnchor := resources.Get "js/anchor.js" }}
 {{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home }}


### PR DESCRIPTION
This is a PR for using Algolia's DocSearch instead of InstantSearch.

The configuration is at https://github.com/algolia/docsearch-configs/blob/master/configs/cert-manager.json

This PR is now ready for full review