### PR TITLE
link the forcing_renewal article into the FAQ

### DIFF
--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -13,3 +13,4 @@ face:
 - [How to change the Cluster Resource Namespace](./cluster-resource/)
 - [How to sync secrets across namespaces](./kubed/)
 - [Failing to create resources due to Webhook](./webhook/)
+- [How to force a certificate renewal](./forcing_renewal/)


### PR DESCRIPTION
I think that after the [2020.02.29 CAA Rechecking Bug](https://community.letsencrypt.org/t/2020-02-29-caa-rechecking-bug/114591) a lot of people will want to know how a renewal of a certificate can be forced. This should document the process.