### PR TITLE
Add 'next' version documentation

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -32,6 +32,14 @@ version = "v0.13"
   url = "/docs/"
   dirpath = "docs"
 
+# 'Next' version
+################
+[[versions]]
+  version = "v0.14"
+  ghbranchname = "release-0.14"
+  url = "/next-docs/"
+  dirpath = "next-docs"
+
 # Archived versions
 ###################
 # Use format `v0.#-docs` for past version's dirpath

--- a/scripts/gendocs/generate
+++ b/scripts/gendocs/generate
@@ -71,8 +71,10 @@ genversion() {
 	popd
 }
 
+genversion "release-0.14" "next-docs"
 genversion "release-0.13" "docs"
 genversion "release-0.12" "v0.12-docs"
+
 ## Use the following line as a template when adding new versions to the website
 # genversion "release-0.11" "v0.11-docs"
 

--- a/scripts/update-content
+++ b/scripts/update-content
@@ -29,4 +29,5 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 	--repo-url https://github.com/cert-manager/website.git \
 	--repo-content-dir content/en/docs \
 	--output-dir "${REPO_ROOT}/content/en" \
-	--branches v0.12-docs=release-0.12
+	--branches v0.12-docs=release-0.12 \
+	--branches next-docs=release-0.14

--- a/scripts/verify-lint
+++ b/scripts/verify-lint
@@ -46,4 +46,5 @@ echo "+++ Running spell check"
   "_includes/*.html" \
   "*.html" \
   "!content/en/docs/reference/api-docs.md" \
-  "!content/en/v0.12-docs/reference/api-docs.md"
+  "!content/en/v0.12-docs/reference/api-docs.md" \
+  "!content/en/next-docs/reference/api-docs.md"


### PR DESCRIPTION
This adds the 'next' version of the docs to the website alongside previous and current versions.

I have _not_ updated the 'default' version, so a user will need to explicitly select this.

I chose `next` instead of the specific version because otherwise we'll break links when we promote a version from `v0.14-docs/` to `docs/`. At least this way we never break a URL *once we introduce it* (provided we never 'break' a URL when we remove a page, and instead replace it with a redirect).

/assign @meyskens 