### PR TITLE
Remove CRD installation step for Helm chart

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -111,18 +111,12 @@ docs](https://github.com/helm/helm/blob/240e539cec44e2b746b3541529d41f4ba01e77df
 
 In order to install the Helm chart, you must follow these steps.
 
-Install the `CustomResourceDefinition` resources separately.
-```bash
-# Kubernetes 1.15+
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager.crds.yaml
-
-# Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager-legacy.crds.yaml
-```
-
-> **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the CRDs.
+> **Note**: If you're using a Kubernetes version below `v1.15` you will need to manually install the legacy version of the CRDs.
 > This version does not have API version conversion and only supports `cert-manager.io/v1apha2` API resources. 
 
+```
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager-legacy.crds.yaml
+```
 
 Create the namespace for cert-manager.
 ```bash


### PR DESCRIPTION
Because CRDs are already included in the chart: https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager/crds