### PR TITLE
Fix typo in the docs

### DIFF
--- a/content/en/docs/usage/certificate.md
+++ b/content/en/docs/usage/certificate.md
@@ -50,7 +50,7 @@ spec:
   usages:
     - server auth
     - client auth
-  # At least one of a DNS Name, USI SAN, or IP address is required.
+  # At least one of a DNS Name, URI, or IP address is required.
   dnsNames:
   - example.com
   - www.example.com


### PR DESCRIPTION
There's no such thing as a "USI" SAN, it's a URI.

Also, drop the "SAN" here; we don't repeat it for the other classes of "SAN" (e.g., "DNS Name SAN, IP Address SAN", and we're not explicitly naming the key (i.e., `uriSAN`).