### PR TITLE
corrects auth values for tokenSecretRef

### DIFF
--- a/content/en/docs/configuration/vault.md
+++ b/content/en/docs/configuration/vault.md
@@ -142,7 +142,6 @@ spec:
     caBundle: <base64 encoded caBundle PEM file>
     auth:
       tokenSecretRef:
-        secretRef:
           name: cert-manager-vault-token
           key: token
 ```


### PR DESCRIPTION
Signed-off-by: Sergey Braun <dev@skra.space>

According to [crd-issuers.yaml](https://github.com/jetstack/cert-manager/blob/master/deploy/crds/crd-issuers.yaml), field secretRef doesn't exist on tokenSecretRef.