### PR TITLE
Explain usage of cnameStrategy: Follow in greater detail

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -113,6 +113,7 @@ Smallstep
 SOA
 subdomain
 subdomains
+(sub)domains
 subresource
 templating
 Tiller

--- a/content/en/docs/configuration/acme/dns01/_index.md
+++ b/content/en/docs/configuration/acme/dns01/_index.md
@@ -75,11 +75,22 @@ By default, cert-manager will not follow CNAME records pointing to subdomains.
 
 If granting cert-manager access to the root DNS zone is not desired, then the
 `_acme-challenge.example.com` subdomain can instead be delegated to some other,
-less privileged domain.
-Once a CNAME record has been configured to point at the desired domain, and the
-DNS configuration/credentials for the zone that *should be updated* have been
-provided, all that is left to be done is adding an additional field into the
-relevant `dns01` solver:
+less privileged domain. This could be achieved in the following way. Say, one has two zones:
+
+* `example.com`
+* `less-privileged.com`
+
+1. Create a CNAME record pointing to this less privileged domain:
+```
+_acme-challenge.example.com	IN	CNAME	_acme-challenge.less-privileged.com.
+```
+
+2. Grant cert-manager rights to update `less-privileged.com` zone 
+
+3. Provide configuration/credentials for updating this less privileged zone
+and add an additional field into the relevant `dns01` solver. Note that `selector` 
+field is still working for the original `example.com`, while credentials are provided for 
+`less-privileged.com`
 
 ```yaml
 apiVersion: cert-manager.io/v1alpha2
@@ -90,14 +101,32 @@ spec:
   acme:
     ...
     solvers:
+    - selector:
+      dnsZones:
+        - 'example.com'
     - dns01:
         # Valid values are None and Follow
         cnameStrategy: Follow
-        clouddns:
-          ...
+        route53:
+          region: eu-central-1
+          accessKeyID: <Access ID for less-privileged.com here>
+          hostedZoneID: <Zone ID for less-privileged.com here>
+          secretAccessKeySecretRef:
+            ...
 ```
 
-cert-manager will then follow CNAME records recursively in order to determine
+If you have a multitude of (sub)domains requiring separate certificates, 
+it is possible to share an aliased less-privileged domain. To achieve it one should 
+create a CNAME record for each (sub)domain like this:
+
+```txt
+_acme-challenge.example.com	    IN	CNAME	_acme-challenge.less-privileged.com.
+_acme-challenge.www.example.com	IN	CNAME	_acme-challenge.less-privileged.com.
+_acme-challenge.foo.example.com	IN	CNAME	_acme-challenge.less-privileged.com.
+_acme-challenge.bar.example.com	IN	CNAME	_acme-challenge.less-privileged.com.
+```
+
+With this configuration cert-manager will follow CNAME records recursively in order to determine
 which DNS zone to update during DNS01 challenges.
 
 


### PR DESCRIPTION
Hello! 

Recently we started using cert-manager for our development clusters and I had a hard time wrapping my head around getting `cnameStrategy: Follow` to work. 
Surprisingly, the most comprehensible doc for this case was found in the acme.sh project, but it is not easy to find if you are using an Average Joe google-fu.
So please consider merging this pull request which explains how to use `cnameStrategy: Follow` in greater detail.