### PR TITLE
update kubernetes.md

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -189,7 +189,7 @@ kind: Namespace
 metadata:
   name: cert-manager-test
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha3
 kind: Issuer
 metadata:
   name: test-selfsigned
@@ -197,7 +197,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
   name: selfsigned-cert


### PR DESCRIPTION
bumping api versions in the test-resources.yaml file section to avoid:

```
kubectl apply -f test-resources.yaml
namespace/cert-manager-test created
unable to recognize "test-resources.yaml": no matches for kind "Issuer" in version "cert-manager.io/v1alpha2"
unable to recognize "test-resources.yaml": no matches for kind "Certificate" in version "cert-manager.io/v1alpha2"
```

Signed-off-by: Kris Dockery <kris.dockery@gmail.com>