### PR TITLE
Fixing documentation issue discovered during nginx walkthrough

### DIFF
--- a/content/en/docs/tutorials/acme/ingress.md
+++ b/content/en/docs/tutorials/acme/ingress.md
@@ -465,7 +465,7 @@ quickstart-example-tls   True    quickstart-example-tls   16m
 
 Cert-manager reflects the state of the process for every request in the
 certificate object. You can view this information using the
-`kubectl describe` command:
+`kubectl describe` command: 
 
 ```bash
 $ kubectl describe certificate quickstart-example-tls

--- a/content/en/docs/tutorials/acme/ingress.md
+++ b/content/en/docs/tutorials/acme/ingress.md
@@ -465,7 +465,7 @@ quickstart-example-tls   True    quickstart-example-tls   16m
 
 Cert-manager reflects the state of the process for every request in the
 certificate object. You can view this information using the
-`kubectl describe` command: 
+`kubectl describe` command:
 
 ```bash
 $ kubectl describe certificate quickstart-example-tls

--- a/content/en/docs/tutorials/acme/ingress.md
+++ b/content/en/docs/tutorials/acme/ingress.md
@@ -566,7 +566,7 @@ you should see the example KUARD running at your domain with a signed TLS
 certificate.
 
 ```bash
-$ kubectl describe certificate
+$ kubectl describe certificate quickstart-example-tls
 Name:         quickstart-example-tls
 Namespace:    default
 Labels:       <none>
@@ -603,7 +603,7 @@ Status:
     Type:                  Ready
 Events:
   Type    Reason        Age   From          Message
-ubectl describe certificate quickstart-example-tls   ----    ------        ----  ----          -------
+  ----    ------        ----  ----          -------
   Normal  Generated     18s   cert-manager  Generated new private key
   Normal  OrderCreated  18s   cert-manager  Created Order resource "quickstart-example-tls-889745041"
 ```


### PR DESCRIPTION
During the nginx walkthrough I discovered that there's an incorrect command
`kubectl describe certificate`
which should be changed to
`kubectl describe certificate quickstart-example-tls`
... oddly, down in the results of that command, it looks like part of the correct command got incorrectly pasted in the documented results, so cleaning that up as well.