### PR TITLE
update ingress.md

### DIFF
--- a/content/en/docs/tutorials/acme/ingress.md
+++ b/content/en/docs/tutorials/acme/ingress.md
@@ -90,7 +90,12 @@ You can get more details about `nginx-ingress` and how it works from the
 Use `helm` to install an NGINX Ingress controller:
 
 ```bash
+
+# for helm version 2
 $ helm install stable/nginx-ingress --name quickstart
+
+# for helm version 3
+$ helm install quickstart stable/nginx-ingress
 
 NAME:   quickstart
 LAST DEPLOYED: Sat Nov 10 10:25:06 2018


### PR DESCRIPTION
adds a command for deploying the stable/nginx-ingress chart with helm3

details:
running the following command with helm3 will generate an error:
$ helm install stable/nginx-ingress --name quickstart
Error: unknown flag: --name
$ helm install stable/nginx-ingress quickstart
Error: failed to download "quickstart" (hint: running `helm repo update` may help)