### PR TITLE
Fixed link pattern to CRDs on uninstall page

### DIFF
--- a/content/en/docs/installation/uninstall/kubernetes.md
+++ b/content/en/docs/installation/uninstall/kubernetes.md
@@ -63,10 +63,10 @@ $ kubectl delete namespace cert-manager
 
 Finally, delete the cert-manger
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
-using the link to the version `vX.Y` you installed:
+using the link to the version `vX.Y.Z` you installed:
 
 ```bash
-$ kubectl delete -f https://raw.githubusercontent.com/jetstack/cert-manager/release-X.Y/deploy/manifests/00-crds.yaml
+$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
 ```
 
 ## Namespace Stuck in Terminating State


### PR DESCRIPTION
Signed-off-by: David Losert <david.losert@gmx.de>

This PR fixes the outdated CRD Uninstall Link Pattern and the Issue I accidently opened in the wrong repository here:
https://github.com/jetstack/cert-manager/issues/3080