### PR TITLE
Add reference to .data.ca.crt in secret property

### DIFF
--- a/content/en/docs/concepts/certificate.md
+++ b/content/en/docs/concepts/certificate.md
@@ -37,10 +37,10 @@ spec:
 
 This `Certificate` will tell cert-manager to attempt to use the `Issuer` named
 `letsencrypt-prod` to obtain a certificate key pair for the `foo.example.com`
-and `bar.example.com` domains. If successful, the resulting key and certificate
-will be stored in a secret named `acme-crt-secret` with keys of `tls.key` and
-`tls.crt` respectively. This secret will live in the same namespace as the
-`Certificate` resource.
+and `bar.example.com` domains. If successful, the corresponding CA certificate,
+and resulting TLS key and certificate will be stored in a secret named 
+`acme-crt-secret`, with keys of `ca.crt`, `tls.key`, and `tls.crt` respectively.
+This secret will live in the same namespace as the `Certificate` resource. 
 
 The `dnsNames` field specifies a list of [`Subject Alternative
 Names`](https://en.wikipedia.org/wiki/Subject_Alternative_Name) to be associated


### PR DESCRIPTION
Hi, adding a `ca.crt` property to the secret appears to be a common feature of certs provisioned by cert-manager. 

I am updating the docs so that folks looking to take advantage of this secret can see that it contains the related ca.crt, too. 

Let me know if this is correct, or if I should change anything?