### PR TITLE
document the case of SOA records being filtered

### DIFF
--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -87,7 +87,7 @@ spec:
 
 ## Troubleshooting
 
-### Actor 'com.cloudflare.api.token.xxxx' requires permission 'com.cloudflare.api.account.zone.list' to list zones
+### Actor `com.cloudflare.api.token.xxxx` requires permission `com.cloudflare.api.account.zone.list` to list zones
 If you get the error that your token does not have the correct permission to list zones there can be 2 causes.
 1. The token lacks the `Zone - Zone - Read` permission
 2. cert-manager identified the wrong zone name for the domain due to DNS issues.
@@ -102,4 +102,4 @@ Events:
             Error: 0: Actor 'com.cloudflare.api.token.xxxx' requires permission 'com.cloudflare.api.account.zone.list' to list zones
 ```
 
-In this case we recommend [changing your DNS01 self-check nameservers)(./#setting-nameservers-for-dns01-self-check).
+In this case we recommend [changing your DNS01 self-check nameservers](../#setting-nameservers-for-dns01-self-check).

--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -84,3 +84,22 @@ spec:
             name: cloudflare-api-key-secret
             key: api-key
 ```
+
+## Troubleshooting
+
+### Actor 'com.cloudflare.api.token.xxxx' requires permission 'com.cloudflare.api.account.zone.list' to list zones
+If you get the error that your token does not have the correct permission to list zones there can be 2 causes.
+1. The token lacks the `Zone - Zone - Read` permission
+2. cert-manager identified the wrong zone name for the domain due to DNS issues.
+
+In the case of the 2nd issue you will see an error like below:
+```
+Events:
+  Type     Reason        Age              From          Message
+  ----     ------        ----             ----          -------
+  Normal   Started       6s               cert-manager  Challenge scheduled for processing
+  Warning  PresentError  3s (x2 over 3s)  cert-manager  Error presenting challenge: Cloudflare API Error for GET "/zones?name=<TLD>" 
+            Error: 0: Actor 'com.cloudflare.api.token.xxxx' requires permission 'com.cloudflare.api.account.zone.list' to list zones
+```
+
+In this case we recommend [changing your DNS01 self-check nameservers)(./#setting-nameservers-for-dns01-self-check).

--- a/content/en/docs/faq/acme.md
+++ b/content/en/docs/faq/acme.md
@@ -144,6 +144,10 @@ If you see no error events about your DNS provider you can check the following
 Check if you can see the `_acme_challenge.domain` TXT DNS record from the public internet, or in your DNS provider's interface.
 cert-manager will check if a DNS record has been propagated by querying the cluster's DNS solver. If you are able to see it from the public internet but not from inside the cluster you might want to change [the DNS server for self-check](../../configuration/acme/dns01/#setting-nameservers-for-dns01-self-check) as some cloud providers overwrite DNS internally. 
 
+#### cert-manager identifies the wrong zone for your domain name
+cert-manager by default uses SOA (Start of Authority) records to detirmine which zone name to use at your DNS provider.
+Some DNS resolvers will filter this information, if this is the case cert-manager cannot determine the zone and it is adviced to [change the DNS server for DNS01 self-checks](../../configuration/acme/dns01/#setting-nameservers-for-dns01-self-check).
+
 ## March 2020 Let's Encrypt CAA Rechecking Bug
 Following the [announcement on March 4](https://community.letsencrypt.org/t/revoking-certain-certificates-on-march-4/114864) Let's Encrypt will be revoking a number of certificates due to a bug in the way they validate CAA records, we have created a tool to analyse your existing cert-manager managed certificates and compare their serial numbers to the publicised list of revoked certificates.
 It's advised that all users of Let's Encrypt & cert-manager run a check using this tool to ensure they do not experience any invalid certificate errors in clusters.

--- a/content/en/docs/faq/acme.md
+++ b/content/en/docs/faq/acme.md
@@ -145,8 +145,8 @@ Check if you can see the `_acme_challenge.domain` TXT DNS record from the public
 cert-manager will check if a DNS record has been propagated by querying the cluster's DNS solver. If you are able to see it from the public internet but not from inside the cluster you might want to change [the DNS server for self-check](../../configuration/acme/dns01/#setting-nameservers-for-dns01-self-check) as some cloud providers overwrite DNS internally. 
 
 #### cert-manager identifies the wrong zone for your domain name
-cert-manager by default uses SOA (Start of Authority) records to detirmine which zone name to use at your DNS provider.
-Some DNS resolvers will filter this information, if this is the case cert-manager cannot determine the zone and it is adviced to [change the DNS server for DNS01 self-checks](../../configuration/acme/dns01/#setting-nameservers-for-dns01-self-check).
+cert-manager by default uses SOA (Start of Authority) records to determine which zone name to use at your DNS provider.
+Some DNS resolvers will filter this information, if this is the case cert-manager cannot determine the zone and it is advised to [change the DNS server for DNS01 self-checks](../../configuration/acme/dns01/#setting-nameservers-for-dns01-self-check).
 
 ## March 2020 Let's Encrypt CAA Rechecking Bug
 Following the [announcement on March 4](https://community.letsencrypt.org/t/revoking-certain-certificates-on-march-4/114864) Let's Encrypt will be revoking a number of certificates due to a bug in the way they validate CAA records, we have created a tool to analyse your existing cert-manager managed certificates and compare their serial numbers to the publicised list of revoked certificates.


### PR DESCRIPTION
fixes #200

This case has been identified in https://github.com/jetstack/cert-manager/issues/3083 
v0.16 also added a more clear error message for Cloudflare.

This PR documents the specific Cloudflare error as well as a general note in the troubleshooting guide.