### PR TITLE
Document webhook compatibility issue with EKS

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -28,6 +28,8 @@ CloudDNS
 CloudFlare
 CNAME
 CNAMEs
+CNI
+CNIs
 codebase
 CRD
 CRDs
@@ -73,6 +75,7 @@ kube-cert-manager
 KubeCon
 kubed
 kube-lego
+kubelet
 kubeprod
 Kubernetes
 labelled

--- a/content/en/docs/installation/compatibility.md
+++ b/content/en/docs/installation/compatibility.md
@@ -29,5 +29,20 @@ plane nodes in the [GKE
 docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules).
 
 
+## EKS
+
+When using a custom CNI (such as Weave or Calico) on EKS, the webhook cannot be
+reached by cert-manager. This happens because the control plane cannot be
+configured to run on a custom CNI on EKS, so the CNIs differ between control
+plane and worker nodes.
+
+To address this, the webhook can be run in the host network so it can be reached
+by cert-manager, by setting the `webhook.hostNetwork` key to true on your
+deployment, or, if using Helm, configuring it in your `values.yaml` file.
+
+Note that since kubelet uses port `10250` by default on the host network, the
+`webhook.securePort` value must be changed to a different, free port.
+
+
 ## Webhook
 Disabling the webhook is not supported anymore since `v0.14`.

--- a/content/en/docs/installation/compatibility.md
+++ b/content/en/docs/installation/compatibility.md
@@ -29,7 +29,7 @@ plane nodes in the [GKE
 docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules).
 
 
-## EKS
+## AWS EKS
 
 When using a custom CNI (such as Weave or Calico) on EKS, the webhook cannot be
 reached by cert-manager. This happens because the control plane cannot be


### PR DESCRIPTION
Document the `webhook.hostNetwork` option introduced in https://github.com/jetstack/cert-manager/pull/3113 to solve a webhook compatibility issue with EKS when using a custom CNI.