### PR TITLE
Update versions to 0.16.1

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -40,10 +40,10 @@ Install the `CustomResourceDefinitions` and cert-manager itself:
 
 ```bash
 # Kubernetes 1.15+
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.yaml
 
 # Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager-legacy.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager-legacy.yaml
 ```
 
 > **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the manifests.
@@ -148,10 +148,10 @@ Install the `CustomResourceDefinition` resources using `kubectl`:
 
 ```bash
 # Kubernetes 1.15+
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager.crds.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.crds.yaml
 
 # Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager-legacy.crds.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager-legacy.crds.yaml
 ```
 
 > **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the CRDs.
@@ -173,14 +173,14 @@ To install the cert-manager Helm chart:
 $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v0.16.0 \
+  --version v0.16.1 \
   # --set installCRDs=true
 
 # Helm v2
 $ helm install \
   --name cert-manager \
   --namespace cert-manager \
-  --version v0.16.0 \
+  --version v0.16.1 \
   jetstack/cert-manager \
   # --set installCRDs=true
 ```

--- a/content/en/docs/installation/openshift.md
+++ b/content/en/docs/installation/openshift.md
@@ -62,10 +62,10 @@ are included in a single YAML manifest file:
 Install the `CustomResourceDefinitions` and cert-manager itself
 ```bash
 # OpenShift 4+
-oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager.yaml
+oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.yaml
 
 # OpenShift 3.11
-$ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager-legacy.yaml
+$ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager-legacy.yaml
 ```
 
 > **Note**: If you're using OpenShift 3 you will need to install the legacy version of the manifests.

--- a/content/en/docs/installation/upgrading/_index.md
+++ b/content/en/docs/installation/upgrading/_index.md
@@ -34,10 +34,10 @@ before upgrading the Helm chart:
 
 ```bash
 # Kubernetes 1.15+
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager.crds.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.crds.yaml
 
 # Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager-legacy.crds.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager-legacy.crds.yaml
 ```
 
 Add the Jetstack Helm repository if you haven't already.
@@ -74,8 +74,8 @@ number you want to install:
 
 ```bash
 # Kubernetes 1.15+
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.yaml
 
 # Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager-legacy.yaml
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager-legacy.yaml
 ```

--- a/content/en/docs/installation/upgrading/upgrading-0.15-0.16.md
+++ b/content/en/docs/installation/upgrading/upgrading-0.15-0.16.md
@@ -15,9 +15,9 @@ This bug only happens during a re-apply of the v0.16 CRDs. Initial upgrade does 
 ```console
 $ curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.0-rc.2/bin/$(uname | tr '[:upper:]' '[:lower:]')/amd64/kubectl
 $ chmod +x ./kubectl
-$ ./kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager.crds.yaml
+$ ./kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.crds.yaml
 # If you use the static manifest install
-$ ./kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager.yaml
+$ ./kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.yaml
 ```
 
 ### Helm

--- a/content/en/docs/usage/kubectl-plugin.md
+++ b/content/en/docs/usage/kubectl-plugin.md
@@ -12,7 +12,7 @@ You need the `kubectl-cert-manager.tar.gz` file for the platform you're using, t
 In order to use the kubectl plugin you need its binary to be accessible under the name `kubectl-cert_manager` in your `$PATH`.
 Run the following commands to set up the plugin:
 ```console
-$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-linux-amd64.tar.gz
+$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/download/v0.16.1/kubectl-cert_manager-linux-amd64.tar.gz
 $ tar xzf kubectl-cert-manager.tar.gz
 $ sudo mv kubectl-cert_manager /usr/local/bin
 ```


### PR DESCRIPTION
Update installation instructions to use latest 0.16.1 release.
See https://github.com/jetstack/cert-manager/releases/tag/v0.16.1

Signed-off-by: Richard Wall <richard.wall@jetstack.io>