### PR TITLE
Update release-process documentation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -53,6 +53,7 @@ eTLD
 FastDNS
 GCE
 GCLB
+gcloud
 GCP
 GKE
 HashiCorp

--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -58,11 +58,11 @@ cert-manager.
 If the pull request contains a critical bug fix then this should be cherry picked in to the current stable cert-manager branch 
 and [released as a patch release](../release-process/#patch-releases).
 
-To trigger the cherry-pick process, add a comment to the Github PR 
+To trigger the cherry-pick process, add a comment to the GitHub PR.
 For example:
 ```
 /cherry-pick release-x.y
 ```
 
-The jetstack-bot will then create a new branch and a PR against the release branch,
+The `jetstack-bot` will then create a new branch and a PR against the release branch,
 which should be reviewed, approved and merged using the process described above.

--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -56,7 +56,7 @@ cert-manager.
 ### Cherry Picking
 
 If the pull request contains a critical bug fix then this should be cherry picked in to the current stable cert-manager branch 
-and [released as a patch release](release-process.md#patch-releases).
+and [released as a patch release](../release-process/#patch-releases).
 
 To trigger the cherry-pick process, add a comment to the Github PR 
 For example:

--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -61,7 +61,7 @@ and [released as a patch release](release-process.md#patch-releases).
 To trigger the cherry-pick process, add a comment to the Github PR 
 For example:
 ```
-/cherry-pick release-x.y.z
+/cherry-pick release-x.y
 ```
 
 The jetstack-bot will then create a new branch and a PR against the release branch,

--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -51,6 +51,18 @@ testing. To make sure the changes get merged, keep an eye out for reviews which
 can have multiple cycles.
 
 Once code has been merged, your changes will appear in the next minor release of
-cert-manager. If the pull request is a critical bug fix then this will probably
-also be cherry picked to the current stable version of cert-manager as a patch
-release.
+cert-manager. 
+
+### Cherry Picking
+
+If the pull request contains a critical bug fix then this should be cherry picked in to the current stable cert-manager branch 
+and [released as a patch release](release-process.md#patch-releases).
+
+To trigger the cherry-pick process, add a comment to the Github PR 
+For example:
+```
+/cherry-pick release-x.y.z
+```
+
+The jetstack-bot will then create a new branch and a PR against the release branch,
+which should be reviewed, approved and merged using the process described above.

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -76,7 +76,7 @@ So you must now complete the release process quickly otherwise users of the late
 6.1 Visit the draft GithHub release and paste in the release notes that you generated earlier.
 6.2 Click "publish" to make the GitHub release live.
 
-Finally, create a new tag taken from the release branch, e.g.`v0.5.0`.
+7. Finally, create a new tag taken from the release branch, e.g.`v0.5.0`.
 
 ## Patch releases
 
@@ -138,7 +138,7 @@ So you must now complete the release process quickly otherwise users of the late
 4.1 Visit the draft GithHub release and paste in the release notes that you generated earlier.
 4.2 Click "publish" to make the GitHub release live.
 
-Finally, create a new tag taken from the release branch, e.g. `v0.5.1`.
+5. Finally, create a new tag taken from the release branch, e.g. `v0.5.1`.
 
 ## Release Notes
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -15,6 +15,7 @@ First ensure that you have all the tools and permissions required to perform a c
 1. Install [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md)
 2. Install [cert-manager release tooling](https://github.com/cert-manager/release)
 3. Get permission to use the "cert-manager-release" project in Google Cloud Platform.
+4. You must have time to complete all the steps in the release process (~1h).
 
 ## Minor releases
 
@@ -66,6 +67,9 @@ If the last step succeeded, you can now re-run the `cmrel publish` with the `--n
 ```
 cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
+
+NOTE: At this stage there will be a draft release on Github and a live release on HelmHub.
+So you must now complete the release process quickly otherwise users of the latest release on HelmHub will encounter errors.
 
 Finally, create a new tag taken from the release branch, e.g.`v0.5.0`.
 
@@ -120,6 +124,9 @@ If the last step succeeded, you can now re-run the `cmrel publish` with the `--n
 ```
 cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
+
+NOTE: At this stage there will be a draft release on Github and a live release on HelmHub.
+So you must now complete the release process quickly otherwise users of the latest release on HelmHub will encounter errors.
 
 Finally, create a new tag taken from the release branch, e.g. `v0.5.1`.
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -77,9 +77,7 @@ release branch.
 
 > Note: This process document is WIP and may be incomplete
 
-Bugs that need to be fixed in a patch release should be cherry picked into the
-appropriate release branch using the `./hack/cherry-pick-pr.sh` script in this
-repository.
+Bugs that need to be fixed in a patch release should be [cherry picked into the appropriate release branch](contributing-flow.md#cherry-picking).
 
 The process for cutting a patch release is as follows:
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -52,7 +52,7 @@ To stage a release of the 'release-1.0' branch to the default staging bucket,
 overriding the release version as 'v1.0.0':
 
 ```#bash
- cmrel stage --git-ref=release-1.0 --release-version=v1.0.0
+cmrel stage --git-ref=release-1.0 --release-version=v1.0.0
 ```
 
 Look for a build URL and visit it in Google Cloud Console.
@@ -166,3 +166,22 @@ $GOPATH/bin/release-notes --github-repo cert-manager --github-org jetstack --req
 3. Add additional blurb, notable items and characterize change log.
 
 
+
+## Final Release
+
+* Same as alpha beta release, but also
+* Release notes back to last minor release
+
+### Rollover testing infra
+* Remove last release (0.16.x)
+* Make release-1.0 the last release
+    * Copy release-next > release-previous
+* Make PR
+* Before merging, 
+    * Create new release branches in cert-manager and website repos
+* https://github.com/jetstack/testing/pull/397
+### Rollover documentation
+
+* Merge master into release-next
+* Merge release-next into master
+* https://github.com/cert-manager/website/pull/309

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -102,14 +102,14 @@ You can view the progress by clicking the Google Cloud Build URL in the output o
 
 6.2 Next publish the release artifacts for real
 
-If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, helm hub etc.
+If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, [Helm Hub] etc.
 
 ```bash
 cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
 
-NOTE: At this stage there will be a draft release on Github and a live release on HelmHub.
-So you must now complete the release process quickly otherwise users of the latest release on HelmHub will encounter errors.
+NOTE: At this stage there will be a draft release on Github and a live release on [Helm Hub].
+So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors.
 
 7. Publish the GitHub release
 
@@ -189,14 +189,14 @@ You can view the progress by clicking the Google Cloud Build URL in the output o
 
 4.2 Next publish the release artifacts for real
 
-If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, helm hub etc.
+If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, [Helm Hub] etc.
 
 ```bash
 cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
 
-NOTE: At this stage there will be a draft release on Github and a live release on HelmHub.
-So you must now complete the release process quickly otherwise users of the latest release on HelmHub will encounter errors.
+NOTE: At this stage there will be a draft release on Github and a live release on [Helm Hub].
+So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors.
 
 5. Publish the GitHub release
 
@@ -255,3 +255,7 @@ The token is required only to avoid rate-limits imposed on anonymous API users.
 * Merge master into release-next
 * Merge release-next into master
 * https://github.com/cert-manager/website/pull/309
+
+## Links
+
+* [Helm Hub](https://charts.jetstack.io)

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -39,6 +39,15 @@ The process for cutting a minor release is as follows:
 
 3. Push it to the `jetstack/cert-manager` repository
 
+4. Run `cmrel stage`
+
+To stage a release of the 'release-1.0' branch to the default staging bucket,
+overriding the release version as 'v1.0.0':
+
+```#bash
+ cmrel stage --git-ref=release-1.0 --release-version=v1.0.0
+```
+
 4. [Create release notes](#release-notes)
 
 Finally, create a new tag taken from the release branch, e.g.`v0.5.0`.
@@ -67,10 +76,17 @@ Bugs that need to be fixed in a patch release should be [cherry picked into the 
 
 The process for cutting a patch release is as follows:
 
-1. Iterate on review feedback (hopefully this will be minimal) and submit
-   changes to `master` of cert-manager, performing a rebase of release-x.y.
+1. Run `cmrel stage`
+
+To stage a release of the 'release-0.16' branch to the default staging bucket,
+overriding the release version as 'v0.16.1':
+
+```#bash
+ cmrel stage --git-ref=release-0.16 --release-version=v0.16.1
+```
 
 2. [Create release notes](#release-notes)
+
 
 Finally, create a new tag taken from the release branch, e.g. `v0.5.1`.
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -50,6 +50,23 @@ overriding the release version as 'v1.0.0':
 
 4. [Create release notes](#release-notes)
 
+5. Run `cmrel publish`
+
+5.1. First do a dry-run, to ensure that all the staged resources are valid.
+
+```
+cmrel publish --release-name <RELEASE_NAME>
+```
+Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
+
+5.2 Next publish the release artifacts for real
+
+If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, helm hub etc.
+
+```
+cmrel publish --nomock --release-name <RELEASE_NAME>
+```
+
 Finally, create a new tag taken from the release branch, e.g.`v0.5.0`.
 
 ## Patch releases
@@ -87,6 +104,22 @@ overriding the release version as 'v0.16.1':
 
 2. [Create release notes](#release-notes)
 
+3. Run `cmrel publish`
+
+3.1. First do a dry-run, to ensure that all the staged resources are valid.
+
+```
+cmrel publish --release-name <RELEASE_NAME>
+```
+Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
+
+3.2 Next publish the release artifacts for real
+
+If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, helm hub etc.
+
+```
+cmrel publish --nomock --release-name <RELEASE_NAME>
+```
 
 Finally, create a new tag taken from the release branch, e.g. `v0.5.1`.
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -31,18 +31,7 @@ The process for cutting a minor release is as follows:
 
 3. Push it to the `jetstack/cert-manager` repository
 
-4. Gather release notes since the previous release:
-
-Download, install and run the latest version of release-notes:
-
-```bash
-$ go get k8s.io/release; go install $GOPATH/src/k8s.io/release/cmd/release-notes/.
-$ mkdir -p design/release-notes/release-*X.Y*
-$ export GITHUB_TOKEN=*your-token*
-$ $GOPATH/bin/release-notes -release-version v*X.Y* -github-repo cert-manager -github-org jetstack -requiredAuthor "" -start-sha=$(git rev-parse *X.Y-1.0*) -end-sha=$(git rev-parse HEAD) -output design/release-notes/release-*X.Y*/draft-release-notes.md
-```
-Add additional blurb, notable items and characterize change log.
-
+4. [Create release notes](#release-notes)
 
 Finally, create a new tag taken from the release branch, e.g.`v0.5.0`.
 
@@ -73,15 +62,25 @@ The process for cutting a patch release is as follows:
 1. Iterate on review feedback (hopefully this will be minimal) and submit
    changes to `master` of cert-manager, performing a rebase of release-x.y.
 
-2. Gather release notes since the previous release:
-
-```bash
-$ go get k8s.io/release; go install $GOPATH/src/k8s.io/release/cmd/release-notes/.
-$ mkdir -p design/release-notes/release-*X.Y*
-$ export GITHUB_TOKEN=*your-token*
-$ $GOPATH/bin/release-notes -release-version v*X.Y* -github-repo cert-manager -github-org jetstack -requiredAuthor "" -start-sha=$(git rev-parse *X.Y.Z-1*) -end-sha=$(git rev-parse release-*X.Y*) -output design/release-notes/release-*X.Y*/draft-release-notes-*Z*.md
-```
-
-Add additional blurb, notable items and characterize change log.
+2. [Create release notes](#release-notes)
 
 Finally, create a new tag taken from the release branch, e.g. `v0.5.1`.
+
+## Release Notes
+
+1. Download and install the latest version of [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md).
+
+2. Run as follows, substituting the current and last versions where appropriate:
+
+```bash
+export GITHUB_TOKEN=*your-token*
+export RELEASE_VERSION=*x.y.z*
+export BRANCH=*release-x.y*
+export END_REV=*x.y.z*
+export START_REV=*x.?.?*
+$GOPATH/bin/release-notes --github-repo cert-manager --github-org jetstack --required-author "" --output release-notes.md
+```
+
+3. Add additional blurb, notable items and characterize change log.
+
+

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -27,22 +27,11 @@ The process for cutting a minor release is as follows:
 
 1. Ensure upgrading document exists.
 
-2. Ensure all strings of versions have been updated.
+2. Create a new release branch (e.g. `release-0.5`)
 
-- in the [`jetstack/cert-manager`](https://github.com/jetstack/cert-manager)
-  repository
- - `deploy/charts/cert-manager/README.md`
-- in the [`cert-manager/webisite`](https://github.com/cert-manager/website)
-  repository
- - `content/en/docs/installation/compatibility.md`
- - `content/en/docs/installation/kubernetes.md`
- - `content/en/docs/installation/openshift.md`
+3. Push it to the `jetstack/cert-manager` repository
 
-3. Create a new release branch (e.g. `release-0.5`)
-
-4. Push it to the `jetstack/cert-manager` repository
-
-5. Gather release notes since the previous release:
+4. Gather release notes since the previous release:
 
 Download, install and run the latest version of release-notes:
 
@@ -81,18 +70,10 @@ Bugs that need to be fixed in a patch release should be [cherry picked into the 
 
 The process for cutting a patch release is as follows:
 
-1. Ensure all strings of versions have been updated:
-
-- `deploy/charts/cert-manager/README.md`
-- `docs/getting-started/install/kubernetes.rst`
-- `docs/getting-started/install/openshift.rst`
-- `docs/getting-started/webhook.rst`
-- `docs/tutorials/acme/quick-start/index.rst`
-
-2. Iterate on review feedback (hopefully this will be minimal) and submit
+1. Iterate on review feedback (hopefully this will be minimal) and submit
    changes to `master` of cert-manager, performing a rebase of release-x.y.
 
-3. Gather release notes since the previous release:
+2. Gather release notes since the previous release:
 
 ```bash
 $ go get k8s.io/release; go install $GOPATH/src/k8s.io/release/cmd/release-notes/.

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -12,15 +12,15 @@ new release of cert-manager.
 
 First ensure that you have all the tools and permissions required to perform a cert-manager release:
 
-1. Install [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md)
-2. Install [cert-manager release tooling](https://github.com/cert-manager/release)
+1. Install [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md).
+2. Install [cert-manager release tooling](https://github.com/cert-manager/release).
 3. Get permission to use the "cert-manager-release" project in Google Cloud Platform.
 4. You must have time to complete all the steps in the release process (~1 hour).
-5. Install [Gcloud SDK / CLI](https://cloud.google.com/sdk/)
-5.1. [Run gcloud auth login](https://cloud.google.com/sdk/docs/authorizing#running_gcloud_auth_login)
-6. Get a GitHub access token 
-   Go to your GitHub profile page and set up a token. 
-   It does not need any privileges. 
+5. Install [Gcloud SDK / CLI](https://cloud.google.com/sdk/).
+   [Run gcloud auth login](https://cloud.google.com/sdk/docs/authorizing#running_gcloud_auth_login).
+6. Get a GitHub access token.
+   Go to your GitHub profile page and set up a token.
+   It does not need any privileges.
    It is used only by the release-notes tool to avoid API rate limiting.
 
 ## Minor releases
@@ -40,94 +40,96 @@ some of these goals are missed, in order to keep up release velocity.
 
 The process for cutting a minor release is as follows:
 
-1. Ensure upgrading document exists. 
+1. Ensure upgrading document exists.
    (not necessary for alpha releases)
 
 2. Create or update the release branch
 
-If this is the first (`alpha1`) release, then you will need to create the release branch:
+    If this is the first (`alpha1`) release, then you will need to create the release branch:
 
-```bash
-git fetch --all
-git checkout -b release-1.0 origin/master
-```
+    ```bash
+    git fetch --all
+    git checkout -b release-1.0 origin/master
+    ```
 
-If there has already been an `alpha1` release, the release branch will already exist,
-so you will need to update it with the latest commits from the master branch, as follows:
+    If there has already been an `alpha1` release, the release branch will already exist,
+    so you will need to update it with the latest commits from the master branch, as follows:
 
-```bash
-git fetch --all
-git branch --force release-1.0 origin/release-1.0
-git checkout release-1.0
-git merge --ff-only origin/master
-```
+    ```bash
+    git fetch --all
+    git branch --force release-1.0 origin/release-1.0
+    git checkout release-1.0
+    git merge --ff-only origin/master
+    ```
 
 3. Push it to the `jetstack/cert-manager` repository
 
-git push --set-upstream origin
+    ```bash
+    git push --set-upstream origin
+    ```
 
 4. [Create release notes](#release-notes)
 
-Sanity check the notes, checking that the notes contain details of all the features and bug fixes that you expect to be in the release.
+    Sanity check the notes, checking that the notes contain details of all the features and bug fixes that you expect to be in the release.
 
 5. Run `cmrel stage`
 
-In this example we stage a release using the 'release-1.0' branch,
-setting  the release version to `v1.0.0`:
+    In this example we stage a release using the 'release-1.0' branch,
+    setting  the release version to `v1.0.0`:
 
-```bash
-cmrel stage --branch=release-1.0 --release-version=v1.0.0
-```
+    ```bash
+    cmrel stage --branch=release-1.0 --release-version=v1.0.0
+    ```
 
-This step takes ~10 minutes.
-It will build all Docker images and create all the manifest files and upload them to a storage bucket on Google Cloud.
-These artifacts will be published / released in the next steps.
+    This step takes ~10 minutes.
+    It will build all Docker images and create all the manifest files and upload them to a storage bucket on Google Cloud.
+    These artifacts will be published / released in the next steps.
 
-The final line of output contains URL of the bucket containing the release artifacts.
-The final segment in that URL contains the `RELEASE_NAME`, which you will need in the next step.
+    The final line of output contains URL of the bucket containing the release artifacts.
+    The final segment in that URL contains the `RELEASE_NAME`, which you will need in the next step.
 
 6. Run `cmrel publish`
 
-6.1. First do a dry-run, to ensure that all the staged resources are valid.
+   1. First do a dry-run, to ensure that all the staged resources are valid.
 
-```bash
-cmrel publish --release-name <RELEASE_NAME>
-```
+       ```bash
+       cmrel publish --release-name <RELEASE_NAME>
+       ```
 
-Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
-E.g. Given `gs://cert-manager-release/stage/gcb/release/v1.0.0-219b7934ac499c7818526597cf635a922bddd22e`, 
-the `RELEASE_NAME` would be `v1.0.0-219b7934ac499c7818526597cf635a922bddd22e`.
+        Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
+        E.g. Given `gs://cert-manager-release/stage/gcb/release/v1.0.0-219b7934ac499c7818526597cf635a922bddd22e`,
+        the `RELEASE_NAME` would be `v1.0.0-219b7934ac499c7818526597cf635a922bddd22e`.
 
-You can view the progress by clicking the Google Cloud Build URL in the output of this command.
+        You can view the progress by clicking the Google Cloud Build URL in the output of this command.
 
-6.2 Next publish the release artifacts for real
+   2. Next publish the release artifacts for real.
 
-If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release artifacts to GitHub, `Quay.io`, [Helm Hub] etc.
+        If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release artifacts to GitHub, `Quay.io`, [Helm Hub] etc.
 
-```bash
-cmrel publish --nomock --release-name <RELEASE_NAME>
-```
+       ```bash
+       cmrel publish --nomock --release-name <RELEASE_NAME>
+       ```
 
-NOTE: At this stage there will be a draft release on GitHub and a live release on [Helm Hub].
-So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors,
-because the manual CRD install URL will not be available yet.
+        NOTE: At this stage there will be a draft release on GitHub and a live release on [Helm Hub].
+        So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors,
+        because the manual CRD install URL will not be available yet.
 
 7. Publish the GitHub release
 
-7.1 Visit the draft GitHub release and paste in the release notes that you generated earlier.
+   1. Visit the draft GitHub release and paste in the release notes that you generated earlier.
 
-You will need to manually edit the content to match the style of earlier releases.
-In particular:
- * Remove package related changes
- * Replace links to `@jetstack-bot`, in cherry-pick PRs, with links to the GitHub handle of the author of the original PR.
+        You will need to manually edit the content to match the style of earlier releases.
+        In particular:
 
-7.2 Click "publish" to make the GitHub release live.
+       * Remove package related changes
+       * Replace links to `@jetstack-bot`, in cherry-pick PRs, with links to the GitHub handle of the author of the original PR.
 
-This will create a Git tag automatically.
+   2. Click "publish" to make the GitHub release live.
+      This will create a Git tag automatically.
 
-8. Finally post a link to the release tag to all cert-manager channels on Slack
+8. Finally post a link to the release tag to all cert-manager channels on Slack.
 
-E.g. `https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 :tada:`
+    E.g. `https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 :tada:`
 
 ### Final Release
 
@@ -178,69 +180,71 @@ The process for cutting a patch release is as follows:
 
 1. Ensure that all PRs have been cherry-picked into the release branch.
 
-Bugs that need to be fixed in a patch release should be [cherry picked into the appropriate release branch](../contributing-flow/#cherry-picking).
+    Bugs that need to be fixed in a patch release should be [cherry picked into the appropriate release branch](../contributing-flow/#cherry-picking).
 
 2. [Create release notes](#release-notes)
 
-Sanity check the notes, checking that the notes contain details of all the PRs that have been cherry-picked into the release branch.
+    Sanity check the notes, checking that the notes contain details of all the PRs that have been cherry-picked into the release branch.
 
 3. Run `cmrel stage`
 
-In this example we stage a release using the 'release-1.0' branch,
-setting the release version to `v1.0.2`:
+    In this example we stage a release using the 'release-1.0' branch,
+    setting the release version to `v1.0.2`:
 
-```bash
-cmrel stage --branch=release-1.0 --release-version=v1.0.2
-```
+    ```bash
+    cmrel stage --branch=release-1.0 --release-version=v1.0.2
+    ```
 
-This step takes ~10 minutes.
-It will build all Docker images and create all the manifest files and upload them to a storage bucket on Google Cloud.
-These artifacts will be published / released in the next steps.
+    NOTE: This step takes ~10 minutes.
+    It will build all Docker images and create all the manifest files and upload them to a storage bucket on Google Cloud.
+    These artifacts will be published / released in the next steps.
 
-The final line of output contains URL of the bucket containing the release artifacts.
-The final segment in that URL contains the `RELEASE_NAME`, which you will need in the next step.
+    The final line of output contains URL of the bucket containing the release artifacts.
+    The final segment in that URL contains the `RELEASE_NAME`, which you will need in the next step.
 
 4. Run `cmrel publish`
 
-4.1. First do a dry-run, to ensure that all the staged resources are valid.
+   1. First do a dry-run, to ensure that all the staged resources are valid.
 
-```bash
-cmrel publish --release-name <RELEASE_NAME>
-```
-Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
-E.g. Given `gs://cert-manager-release/stage/gcb/release/v1.0.2-219b7934ac499c7818526597cf635a922bddd22e`, 
-the `RELEASE_NAME` would be `v1.0.2-219b7934ac499c7818526597cf635a922bddd22e`.
+       ```bash
+       cmrel publish --release-name <RELEASE_NAME>
+       ```
 
-You can view the progress by clicking the Google Cloud Build URL in the output of this command.
+        Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
+        E.g. Given `gs://cert-manager-release/stage/gcb/release/v1.0.2-219b7934ac499c7818526597cf635a922bddd22e`,
+        the `RELEASE_NAME` would be `v1.0.2-219b7934ac499c7818526597cf635a922bddd22e`.
 
-4.2 Next publish the release artifacts for real
+        You can view the progress by clicking the Google Cloud Build URL in the output of this command.
 
-If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release artifacts to GitHub, `Quay.io`, [Helm Hub] etc.
+   2. Next publish the release artifacts for real.
 
-```bash
-cmrel publish --nomock --release-name <RELEASE_NAME>
-```
+        If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument
+        to actually publish the release artifacts to GitHub, `Quay.io`, [Helm Hub] etc.
 
-NOTE: At this stage there will be a draft release on GitHub and a live release on [Helm Hub].
-So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors,
-because the manual CRD install URL will not be available yet.
+        ```bash
+        cmrel publish --nomock --release-name <RELEASE_NAME>
+        ```
+
+        NOTE: At this stage there will be a draft release on GitHub and a live release on [Helm Hub].
+        So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors,
+        because the manual CRD install URL will not be available yet.
 
 5. Publish the GitHub release
 
-5.1 Visit the draft GitHub release and paste in the release notes that you generated earlier.
+   1. Visit the draft GitHub release and paste in the release notes that you generated earlier.
 
-You will need to manually edit the content to match the style of earlier releases.
-In particular:
- * Remove package related changes
- * Replace links to `@jetstack-bot`, in cherry-pick PRs, with links to the GitHub handle of the author of the original PR.
+        You will need to manually edit the content to match the style of earlier releases.
+      In particular:
 
-5.2 Click "publish" to make the GitHub release live.
+      * Remove package related changes
+      * Replace links to `@jetstack-bot`, in cherry-pick PRs, with links to the GitHub handle of the author of the original PR.
 
-This will create a Git tag automatically.
+   2. Click "publish" to make the GitHub release live.
+      This will create a Git tag automatically.
 
-6. Finally post a link to the release tag to all cert-manager channels on Slack
+6. Finally post a link to the release tag to all cert-manager channels on Slack.
 
-E.g. `https://github.com/jetstack/cert-manager/releases/tag/v1.0.2 :tada:`
+    E.g. `https://github.com/jetstack/cert-manager/releases/tag/v1.0.2 :tada:`
 
 ## Release Notes
 
@@ -248,22 +252,20 @@ E.g. `https://github.com/jetstack/cert-manager/releases/tag/v1.0.2 :tada:`
 
 2. Run as follows, substituting the current and last versions where appropriate:
 
-```bash
-export GITHUB_TOKEN=*your-token*
-export RELEASE_VERSION=1.0.0
-export BRANCH=release-1.0
-export END_REV=release-1.0
-export START_REV=v0.16.1
-$GOPATH/bin/release-notes --github-repo cert-manager --github-org jetstack --required-author "jetstack-bot" --output release-notes.md
-```
+    ```bash
+    export GITHUB_TOKEN=*your-token*
+    export RELEASE_VERSION=1.0.0
+    export BRANCH=release-1.0
+    export END_REV=release-1.0
+    export START_REV=v0.16.1
+    $GOPATH/bin/release-notes --github-repo cert-manager --github-org jetstack --required-author "jetstack-bot" --output release-notes.md
+    ```
 
-NOTE: The GitHub token needs only read-only permission to the cert-manager repository. 
-The token is required only to avoid rate-limits imposed on anonymous API users.
+    NOTE: The GitHub token needs read-only permission to the cert-manager repository. 
+    The token is required only to avoid rate-limits imposed on anonymous API users.
 
 3. Add additional blurb, notable items and characterize change log.
 
-
-
 ## Links
 
-* [Helm Hub](https://charts.jetstack.io)
+ [Helm Hub]: https://charts.jetstack.io

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -15,7 +15,7 @@ First ensure that you have all the tools and permissions required to perform a c
 1. Install [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md)
 2. Install [cert-manager release tooling](https://github.com/cert-manager/release)
 3. Get permission to use the "cert-manager-release" project in Google Cloud Platform.
-4. You must have time to complete all the steps in the release process (~1h).
+4. You must have time to complete all the steps in the release process (~1 hour).
 5. Install [Gcloud SDK / CLI](https://cloud.google.com/sdk/)
 5.1. [Run gcloud auth login](https://cloud.google.com/sdk/docs/authorizing#running_gcloud_auth_login)
 6. Get a GitHub access token 
@@ -45,14 +45,14 @@ The process for cutting a minor release is as follows:
 
 2. Create or update the release branch
 
-If this is the first (alpha1) release, then you will need to create the release branch:
+If this is the first (`alpha1`) release, then you will need to create the release branch:
 
 ```bash
 git fetch --all
 git checkout -b release-1.0 origin/master
 ```
 
-If there has already been an alpha1 release, the release branch will already exist,
+If there has already been an `alpha1` release, the release branch will already exist,
 so you will need to update it with the latest commits from the master branch, as follows:
 
 ```bash
@@ -73,7 +73,7 @@ Sanity check the notes, checking that the notes contain details of all the featu
 5. Run `cmrel stage`
 
 In this example we stage a release using the 'release-1.0' branch,
-setting  the release version to 'v1.0.0':
+setting  the release version to `v1.0.0`:
 
 ```bash
 cmrel stage --branch=release-1.0 --release-version=v1.0.0
@@ -84,7 +84,7 @@ It will build all Docker images and create all the manifest files and upload the
 These artifacts will be published / released in the next steps.
 
 The final line of output contains URL of the bucket containing the release artifacts.
-The final segment in that URL contains the RELEASE_NAME, which you will need in the next step.
+The final segment in that URL contains the `RELEASE_NAME`, which you will need in the next step.
 
 6. Run `cmrel publish`
 
@@ -95,31 +95,31 @@ cmrel publish --release-name <RELEASE_NAME>
 ```
 
 Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
-E.g. Given gs://cert-manager-release/stage/gcb/release/v1.0.0-219b7934ac499c7818526597cf635a922bddd22e, 
-the RELEASE_NAME would be v1.0.0-219b7934ac499c7818526597cf635a922bddd22e.
+E.g. Given `gs://cert-manager-release/stage/gcb/release/v1.0.0-219b7934ac499c7818526597cf635a922bddd22e`, 
+the `RELEASE_NAME` would be `v1.0.0-219b7934ac499c7818526597cf635a922bddd22e`.
 
 You can view the progress by clicking the Google Cloud Build URL in the output of this command.
 
 6.2 Next publish the release artifacts for real
 
-If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, [Helm Hub] etc.
+If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release artifacts to GitHub, `Quay.io`, [Helm Hub] etc.
 
 ```bash
 cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
 
-NOTE: At this stage there will be a draft release on Github and a live release on [Helm Hub].
+NOTE: At this stage there will be a draft release on GitHub and a live release on [Helm Hub].
 So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors,
 because the manual CRD install URL will not be available yet.
 
 7. Publish the GitHub release
 
-7.1 Visit the draft GithHub release and paste in the release notes that you generated earlier.
+7.1 Visit the draft GitHub release and paste in the release notes that you generated earlier.
 
 You will need to manually edit the content to match the style of earlier releases.
 In particular:
  * Remove package related changes
- * Replace links to @jetstack-bot, in cherry-pick PRs, with links to the GitHub handle of the author of the original PR.
+ * Replace links to `@jetstack-bot`, in cherry-pick PRs, with links to the GitHub handle of the author of the original PR.
 
 7.2 Click "publish" to make the GitHub release live.
 
@@ -127,7 +127,7 @@ This will create a Git tag automatically.
 
 8. Finally post a link to the release tag to all cert-manager channels on Slack
 
-E.g. https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 :tada:
+E.g. `https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 :tada:`
 
 ## Patch releases
 
@@ -162,7 +162,7 @@ Sanity check the notes, checking that the notes contain details of all the PRs t
 3. Run `cmrel stage`
 
 In this example we stage a release using the 'release-1.0' branch,
-setting the release version to 'v1.0.2':
+setting the release version to `v1.0.2`:
 
 ```bash
 cmrel stage --branch=release-1.0 --release-version=v1.0.2
@@ -173,7 +173,7 @@ It will build all Docker images and create all the manifest files and upload the
 These artifacts will be published / released in the next steps.
 
 The final line of output contains URL of the bucket containing the release artifacts.
-The final segment in that URL contains the RELEASE_NAME, which you will need in the next step.
+The final segment in that URL contains the `RELEASE_NAME`, which you will need in the next step.
 
 4. Run `cmrel publish`
 
@@ -183,31 +183,31 @@ The final segment in that URL contains the RELEASE_NAME, which you will need in 
 cmrel publish --release-name <RELEASE_NAME>
 ```
 Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
-E.g. Given gs://cert-manager-release/stage/gcb/release/v1.0.2-219b7934ac499c7818526597cf635a922bddd22e, 
-the RELEASE_NAME would be v1.0.2-219b7934ac499c7818526597cf635a922bddd22e.
+E.g. Given `gs://cert-manager-release/stage/gcb/release/v1.0.2-219b7934ac499c7818526597cf635a922bddd22e`, 
+the `RELEASE_NAME` would be `v1.0.2-219b7934ac499c7818526597cf635a922bddd22e`.
 
 You can view the progress by clicking the Google Cloud Build URL in the output of this command.
 
 4.2 Next publish the release artifacts for real
 
-If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, [Helm Hub] etc.
+If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release artifacts to GitHub, `Quay.io`, [Helm Hub] etc.
 
 ```bash
 cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
 
-NOTE: At this stage there will be a draft release on Github and a live release on [Helm Hub].
+NOTE: At this stage there will be a draft release on GitHub and a live release on [Helm Hub].
 So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors,
 because the manual CRD install URL will not be available yet.
 
 5. Publish the GitHub release
 
-5.1 Visit the draft GithHub release and paste in the release notes that you generated earlier.
+5.1 Visit the draft GitHub release and paste in the release notes that you generated earlier.
 
 You will need to manually edit the content to match the style of earlier releases.
 In particular:
  * Remove package related changes
- * Replace links to @jetstack-bot, in cherry-pick PRs, with links to the GitHub handle of the author of the original PR.
+ * Replace links to `@jetstack-bot`, in cherry-pick PRs, with links to the GitHub handle of the author of the original PR.
 
 5.2 Click "publish" to make the GitHub release live.
 
@@ -215,7 +215,7 @@ This will create a Git tag automatically.
 
 6. Finally post a link to the release tag to all cert-manager channels on Slack
 
-E.g. https://github.com/jetstack/cert-manager/releases/tag/v1.0.2 :tada:
+E.g. `https://github.com/jetstack/cert-manager/releases/tag/v1.0.2 :tada:`
 
 ## Release Notes
 
@@ -232,7 +232,7 @@ export START_REV=v0.16.1
 $GOPATH/bin/release-notes --github-repo cert-manager --github-org jetstack --required-author "jetstack-bot" --output release-notes.md
 ```
 
-NOTE: The GitHub token needs only readonly permission to the cert-manager repository. 
+NOTE: The GitHub token needs only read-only permission to the cert-manager repository. 
 The token is required only to avoid rate-limits imposed on anonymous API users.
 
 3. Add additional blurb, notable items and characterize change log.
@@ -245,13 +245,14 @@ The token is required only to avoid rate-limits imposed on anonymous API users.
 * Release notes back to last minor release
 
 ### Rollover testing infra
-* Remove last release (0.16.x)
+* Remove last release (`0.16.x`)
 * Make release-1.0 the last release
     * Copy release-next > release-previous
 * Make PR
 * Before merging, 
-    * Create new release branches in cert-manager and website repos
+    * Create new release branches in cert-manager and website repositories
 * https://github.com/jetstack/testing/pull/397
+
 ### Rollover documentation
 
 * Merge master into release-next

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -8,6 +8,14 @@ type: "docs"
 This document aims to outline the process that should be followed for cutting a
 new release of cert-manager.
 
+## Prerequisites
+
+First ensure that you have all the tools and permissions required to perform a cert-manager release:
+
+1. Install [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md)
+2. Install [cert-manager release tooling](https://github.com/cert-manager/release)
+3. Get permission to use the "cert-manager-release" project in Google Cloud Platform.
+
 ## Minor releases
 
 A minor release is a backwards-compatible 'feature' release.  It can contain new

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -129,6 +129,31 @@ This will create a Git tag automatically.
 
 E.g. `https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 :tada:`
 
+### Final Release
+
+After releasing one or more alpha and beta releases,
+you will release the final version.
+For the final release, you should follow the process described above with the following changes and additional steps:
+
+#### Full Release notes
+
+The release notes for the final release should include all changes since the last minor release.
+
+#### Rollover testing infra
+
+After releasing the final release you will need to update the testing infrastructure,
+so that it uses the latest release as `release-previous`,
+and you will need to create a new release branch in the cert-manager repository which will be treated as `release-next`,
+and both these branches will be tested periodically.
+
+For example see the PR  [Prepare testing for the cert-manager `v1.0` release](https://github.com/jetstack/testing/pull/397).
+
+#### Rollover documentation
+
+You will also need to update the versions and branches in the cert-manager website configuration.
+
+For example see the PR [Configure website for the `v1.0` release](https://github.com/cert-manager/website/pull/309).
+
 ## Patch releases
 
 A patch release contains critical bug fixes for the project.  They are managed on
@@ -238,26 +263,6 @@ The token is required only to avoid rate-limits imposed on anonymous API users.
 3. Add additional blurb, notable items and characterize change log.
 
 
-
-## Final Release
-
-* Same as alpha beta release, but also
-* Release notes back to last minor release
-
-### Rollover testing infra
-* Remove last release (`0.16.x`)
-* Make release-1.0 the last release
-    * Copy release-next > release-previous
-* Make PR
-* Before merging, 
-    * Create new release branches in cert-manager and website repositories
-* https://github.com/jetstack/testing/pull/397
-
-### Rollover documentation
-
-* Merge master into release-next
-* Merge release-next into master
-* https://github.com/cert-manager/website/pull/309
 
 ## Links
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -153,7 +153,7 @@ The process for cutting a patch release is as follows:
 
 1. Ensure that all PRs have been cherry-picked into the release branch.
 
-Bugs that need to be fixed in a patch release should be [cherry picked into the appropriate release branch](contributing-flow.md#cherry-picking).
+Bugs that need to be fixed in a patch release should be [cherry picked into the appropriate release branch](../contributing-flow/#cherry-picking).
 
 2. [Create release notes](#release-notes)
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -71,6 +71,11 @@ cmrel publish --nomock --release-name <RELEASE_NAME>
 NOTE: At this stage there will be a draft release on Github and a live release on HelmHub.
 So you must now complete the release process quickly otherwise users of the latest release on HelmHub will encounter errors.
 
+6. Publish the GitHub release
+
+6.1 Visit the draft GithHub release and paste in the release notes that you generated earlier.
+6.2 Click "publish" to make the GitHub release live.
+
 Finally, create a new tag taken from the release branch, e.g.`v0.5.0`.
 
 ## Patch releases
@@ -127,6 +132,11 @@ cmrel publish --nomock --release-name <RELEASE_NAME>
 
 NOTE: At this stage there will be a draft release on Github and a live release on HelmHub.
 So you must now complete the release process quickly otherwise users of the latest release on HelmHub will encounter errors.
+
+4. Publish the GitHub release
+
+4.1 Visit the draft GithHub release and paste in the release notes that you generated earlier.
+4.2 Click "publish" to make the GitHub release live.
 
 Finally, create a new tag taken from the release branch, e.g. `v0.5.1`.
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -109,7 +109,8 @@ cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
 
 NOTE: At this stage there will be a draft release on Github and a live release on [Helm Hub].
-So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors.
+So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors,
+because the manual CRD install URL will not be available yet.
 
 7. Publish the GitHub release
 
@@ -196,7 +197,8 @@ cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
 
 NOTE: At this stage there will be a draft release on Github and a live release on [Helm Hub].
-So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors.
+So you must now complete the release process quickly otherwise users of the latest release on [Helm Hub] will encounter errors,
+because the manual CRD install URL will not be available yet.
 
 5. Publish the GitHub release
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -16,6 +16,7 @@ First ensure that you have all the tools and permissions required to perform a c
 2. Install [cert-manager release tooling](https://github.com/cert-manager/release)
 3. Get permission to use the "cert-manager-release" project in Google Cloud Platform.
 4. You must have time to complete all the steps in the release process (~1h).
+5. Gcloud CLI
 
 ## Minor releases
 
@@ -34,11 +35,16 @@ some of these goals are missed, in order to keep up release velocity.
 
 The process for cutting a minor release is as follows:
 
-1. Ensure upgrading document exists.
+1. Ensure upgrading document exists. 
+   (not necessary for alpha releases)
 
-2. Create a new release branch (e.g. `release-0.5`)
+2. Fast forward the release branch to master (e.g. `release-0.5`)
+
+git merge --ff-only origin/master
 
 3. Push it to the `jetstack/cert-manager` repository
+
+git push --set-upstream origin
 
 4. Run `cmrel stage`
 
@@ -48,6 +54,8 @@ overriding the release version as 'v1.0.0':
 ```#bash
  cmrel stage --git-ref=release-1.0 --release-version=v1.0.0
 ```
+
+Look for a build URL and visit it in Google Cloud Console.
 
 4. [Create release notes](#release-notes)
 
@@ -147,12 +155,12 @@ So you must now complete the release process quickly otherwise users of the late
 2. Run as follows, substituting the current and last versions where appropriate:
 
 ```bash
-export GITHUB_TOKEN=*your-token*
-export RELEASE_VERSION=*x.y.z*
-export BRANCH=*release-x.y*
-export END_REV=*x.y.z*
-export START_REV=*x.?.?*
-$GOPATH/bin/release-notes --github-repo cert-manager --github-org jetstack --required-author "" --output release-notes.md
+export GITHUB_TOKEN=1cf8fd6e181e7433dd964272a96d93bc015edbb0
+export RELEASE_VERSION=1.0.0
+export BRANCH=release-1.0
+export END_REV=release-1.0
+export START_REV=v0.16.1
+$GOPATH/bin/release-notes --github-repo cert-manager --github-org jetstack --required-author "jetstack-bot" --output release-notes.md
 ```
 
 3. Add additional blurb, notable items and characterize change log.

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -56,7 +56,7 @@ git push --set-upstream origin
 To stage a release of the 'release-1.0' branch to the default staging bucket,
 overriding the release version as 'v1.0.0':
 
-```#bash
+```bash
 cmrel stage --branch=release-1.0 --release-version=v1.0.0
 ```
 
@@ -66,7 +66,7 @@ Look for a build URL and visit it in Google Cloud Console.
 
 5.1. First do a dry-run, to ensure that all the staged resources are valid.
 
-```
+```bash
 cmrel publish --release-name <RELEASE_NAME>
 ```
 
@@ -76,7 +76,7 @@ You can view the progress by clicking the Google Cloud Build URL in the output o
 
 If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, helm hub etc.
 
-```
+```bash
 cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
 
@@ -128,7 +128,7 @@ Sanity check the notes, checking that the notes contain details of all the PRs t
 To stage a release of the 'release-1.0' branch to the default staging bucket,
 overriding the release version as 'v1.0.2':
 
-```#bash
+```bash
 cmrel stage --branch=release-1.0 --release-version=v1.0.2
 ```
 
@@ -143,7 +143,7 @@ The final segment in that URL contains the RELEASE_NAME, which you will need in 
 
 3.1. First do a dry-run, to ensure that all the staged resources are valid.
 
-```
+```bash
 cmrel publish --release-name <RELEASE_NAME>
 ```
 Where `<RELEASE_NAME>` is the unique build ID printed by the earlier `cmrel stage` command.
@@ -154,7 +154,7 @@ the RELEASE_NAME would be v1.0.2-219b7934ac499c7818526597cf635a922bddd22e.
 
 If the last step succeeded, you can now re-run the `cmrel publish` with the `--nomock` argument to actually publish the release articacts to Github, quay.io, helm hub etc.
 
-```
+```bash
 cmrel publish --nomock --release-name <RELEASE_NAME>
 ```
 


### PR DESCRIPTION
* Document the cherry-pick process
* Remove instructions for replacing version numbers in the cert-manager repo
* Document how to use the release-notes tool
* Document how to use cmrel
* Document some pre-requisites
