### PR TITLE
State DigitalOcean access tokens need write access

### DIFF
--- a/content/en/docs/configuration/acme/dns01/digitalocean.md
+++ b/content/en/docs/configuration/acme/dns01/digitalocean.md
@@ -20,6 +20,8 @@ data:
   access-token: "base64 encoded access-token here"
   ```
 
+The access token must have write access.
+
 To create a Personal Access Token, see [DigitalOcean documentation](https://www.digitalocean.com/docs/api/create-personal-access-token).
 
 Handy direct link: https://cloud.digitalocean.com/account/api/tokens/new


### PR DESCRIPTION
If not, the DigitalOcean API will reply with 403 status codes.