### PR TITLE
Add reference for AWS Private CA issuer

### DIFF
--- a/content/en/docs/configuration/external.md
+++ b/content/en/docs/configuration/external.md
@@ -25,5 +25,10 @@ authors are as follows:
   certificates from the [Smallstep](https://smallstep.com) [Certificate
   Authority server](https://github.com/smallstep/certificates).
 
+- [awspca-issuer](https://github.com/codingvirtues/awspca-issuer): Used to
+  request certificates from [AWS Private Certificate Authority]
+  (https://aws.amazon.com/certificate-manager/private-certificate-authority/)
+  for cloud native/hybrid environments.
+
 To create your own external issuer type, please follow the guidance in the
 [development documentation](../../contributing/external-issuers/).


### PR DESCRIPTION
Add documentation reference for AWS Private CA external issuer that helps cloud native/hybrid k8s environments that use AWS Certificate Manager to integrate with cert-manager.