### PR TITLE
Add a page for Prometheus metrics

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -66,6 +66,7 @@ IPv6
 Istio
 Jetstack
 JSON
+Jsonnet
 Knative
 KUARD
 kubebuilder
@@ -81,6 +82,8 @@ MacOS
 metadata
 misconfiguration
 misconfigured
+mixin
+mixins
 mTLS
 nameserver
 nameservers

--- a/content/en/docs/usage/prometheus-metrics.md
+++ b/content/en/docs/usage/prometheus-metrics.md
@@ -1,0 +1,55 @@
+---
+title: "Prometheus Metrics"
+linkTitle: "Prometheus Metrics"
+weight: 100
+type: "docs"
+---
+
+To help with operations and insights into cert-manager activities, cert-manager exposes metrics in the [Prometheus](https://prometheus.io/) format from the controller component. These are available at the standard `/metrics` path of the controller component's configured http port.
+
+## Scraping Metrics
+
+How metrics are scraped will depend how you're operating your Prometheus server(s). These examples presume the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) is being used to run Prometheus, and configure Pod or Service Monitor CRDs.
+
+### Helm
+
+If you're deploying cert-manager with helm, a ServiceMonitor resource can be configured. This configuration should enable metric scraping, and the configuration can be further tweaked as decribed in the [Helm configuration documentation](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#configuration).
+
+```yaml
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true
+```
+
+### Regular Manifests
+
+If you're not using helm to deploy cert-manager and instead using the provided regular yaml manifests, this example PodMonitor should be all you need to start ingesting cert-manager metrics.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app: cert-manager
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "controller"
+  podMetricsEndpoints:
+    - port: http
+      honorLabels: true
+```
+
+## Monitoring Mixin
+
+Monitoring mixins are a way to bundle common alerts, rules, and dashboards for an application in a configurable and extensible way, using the jsonnet configuration language. A cert-manager monitoring mixin can be found here https://gitlab.com/uneeq-oss/cert-manager-mixin. Documentation on usage can be found with the cert-manager-mixin project.

--- a/content/en/docs/usage/prometheus-metrics.md
+++ b/content/en/docs/usage/prometheus-metrics.md
@@ -5,7 +5,7 @@ weight: 100
 type: "docs"
 ---
 
-To help with operations and insights into cert-manager activities, cert-manager exposes metrics in the [Prometheus](https://prometheus.io/) format from the controller component. These are available at the standard `/metrics` path of the controller component's configured http port.
+To help with operations and insights into cert-manager activities, cert-manager exposes metrics in the [Prometheus](https://prometheus.io/) format from the controller component. These are available at the standard `/metrics` path of the controller component's configured HTTP port.
 
 ## Scraping Metrics
 
@@ -13,7 +13,7 @@ How metrics are scraped will depend how you're operating your Prometheus server(
 
 ### Helm
 
-If you're deploying cert-manager with helm, a ServiceMonitor resource can be configured. This configuration should enable metric scraping, and the configuration can be further tweaked as decribed in the [Helm configuration documentation](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#configuration).
+If you're deploying cert-manager with helm, a `ServiceMonitor` resource can be configured. This configuration should enable metric scraping, and the configuration can be further tweaked as described in the [Helm configuration documentation](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#configuration).
 
 ```yaml
 prometheus:
@@ -24,7 +24,7 @@ prometheus:
 
 ### Regular Manifests
 
-If you're not using helm to deploy cert-manager and instead using the provided regular yaml manifests, this example PodMonitor should be all you need to start ingesting cert-manager metrics.
+If you're not using helm to deploy cert-manager and instead using the provided regular YAML manifests, this example `PodMonitor` should be all you need to start ingesting cert-manager metrics.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -52,4 +52,4 @@ spec:
 
 ## Monitoring Mixin
 
-Monitoring mixins are a way to bundle common alerts, rules, and dashboards for an application in a configurable and extensible way, using the jsonnet configuration language. A cert-manager monitoring mixin can be found here https://gitlab.com/uneeq-oss/cert-manager-mixin. Documentation on usage can be found with the cert-manager-mixin project.
+Monitoring mixins are a way to bundle common alerts, rules, and dashboards for an application in a configurable and extensible way, using the `jsonnet` configuration language. A cert-manager monitoring mixin can be found here https://gitlab.com/uneeq-oss/cert-manager-mixin. Documentation on usage can be found with the `cert-manager-mixin` project.

--- a/content/en/docs/usage/prometheus-metrics.md
+++ b/content/en/docs/usage/prometheus-metrics.md
@@ -52,4 +52,4 @@ spec:
 
 ## Monitoring Mixin
 
-Monitoring mixins are a way to bundle common alerts, rules, and dashboards for an application in a configurable and extensible way, using the `jsonnet` configuration language. A cert-manager monitoring mixin can be found here https://gitlab.com/uneeq-oss/cert-manager-mixin. Documentation on usage can be found with the `cert-manager-mixin` project.
+Monitoring mixins are a way to bundle common alerts, rules, and dashboards for an application in a configurable and extensible way, using the Jsonnet data templating language. A cert-manager monitoring mixin can be found here https://gitlab.com/uneeq-oss/cert-manager-mixin. Documentation on usage can be found with the `cert-manager-mixin` project.


### PR DESCRIPTION
Signed-off-by: Ben Clapp <git@bencl.app>

As suggested [here](https://github.com/jetstack/cert-manager/pull/3180#issuecomment-674700192), easier for project if we host the cert-manager-mixin in a different repo, and can reference it from the docs. 

Have also added some high level docs around the Prometheus metrics exposed by cert-manager.