### PR TITLE
Improve route53 documentation

### DIFF
--- a/content/en/docs/configuration/acme/dns01/route53.md
+++ b/content/en/docs/configuration/acme/dns01/route53.md
@@ -103,9 +103,7 @@ Second, create the cert-manager role in Account X; this will be used as a creden
   "Statement": [
     {
       "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::YYYYYYYYYYYY:role/dns-manager"
-      },
+      "Resource": "arn:aws:iam::YYYYYYYYYYYY:role/dns-manager",
       "Action": "sts:AssumeRole"
     }
   ]


### PR DESCRIPTION
The JSON describes a trust policy not a permissions policy.
Signed-off-by: Gaston Acosta <correo@gaston.com.uy>