### PR TITLE
Clean up EAB docs and add docs about reusing ACME accounts

### DIFF
--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -100,7 +100,7 @@ ACME server
 > 
 > You can then create the Secret resource with: 
 > 
->     kubectl create secret generic eab-secret --from-literal \
+>     $ kubectl create secret generic eab-secret --from-literal \
 >       secret={base64 encoded secret key}
 
 An example of an ACME issuer with an External Account Binding is as follows.
@@ -133,8 +133,9 @@ spec:
 You may want to reuse a single ACME account across multiple clusters. This
 might especially be useful when using EAB. If the `disableAccountKeyGeneration`
 field is set, cert-manager will not create a new ACME account and use the
-existing key specified in `privateKeySecretRef`.
-
+existing key specified in `privateKeySecretRef`. Note that the 
+`Issuer`/`ClusterIssuer` will not be ready and will continue to retry until the 
+`Secret` is provided.
 
 ```yaml
 apiVersion: cert-manager.io/v1beta1

--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -138,7 +138,7 @@ existing key specified in `privateKeySecretRef`. Note that the
 `Secret` is provided.
 
 ```yaml
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: my-acme-server-with-existing-acme-account

--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -93,8 +93,8 @@ URL string of your external account symmetric MAC key
 containing your External Account Binding when registering the account with the
 ACME server
 
-> Note: In _most_ cases, the MAC key must be base64URL-encoded. The following 
-> command will base64-encode a key and convert it to base64URL:
+> Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
+> following command will base64-encode a key and convert it to `base64URL`:
 > 
 >     $ echo 'my-secret-key' | base64 | sed -e 's/+/-/g' -e 's///_/g' -e 's/=//g'
 > 

--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -83,17 +83,25 @@ external account such as a CA custom database. This is typically not needed for
 most cert-manager users unless you know it is explicitly needed.
 
 External Account Bindings require three fields on an ACME `Issuer` which
-represents your ACME account. These fields are; the `keyID` of which your
-external account binding is indexed by the external account manager,
-`keySecretRef` which references a secret containing a base 64 encoded URL
-string of your external account symmetric MAC key, and finally `keyAlgorithm`,
-the MAC algorithm used to sign the JSON web string containing your External
-Account Binding when registering the account with the ACME server.
+represents your ACME account. These fields are:
 
-> Note: The command `base64` is useful for encoding your MAC key if it is not
-> already `$ echo 'my-secret-key' | base64`, you can then create the Secret
-> resource with: `kubectl create secret generic eab-secret --from-literal
-> secret={base64 encoded secret key}`
+- `keyID` - the key ID of which your external account binding is indexed by the
+external account manager
+- `keySecretRef` - the name and key of a secret containing a base 64 encoded 
+URL string of your external account symmetric MAC key
+- `keyAlgorithm` - the MAC algorithm used to sign the JSON web string 
+containing your External Account Binding when registering the account with the
+ACME server
+
+> Note: In _most_ cases, the MAC key must be base64URL-encoded. The following 
+> command will base64-encode a key and convert it to base64URL:
+> 
+>     $ echo 'my-secret-key' | base64 | sed -e 's/+/-/g' -e 's///_/g' -e 's/=//g'
+> 
+> You can then create the Secret resource with: 
+> 
+>     kubectl create secret generic eab-secret --from-literal \
+>       secret={base64 encoded secret key}
 
 An example of an ACME issuer with an External Account Binding is as follows.
 
@@ -118,6 +126,27 @@ spec:
     - http01:
         ingress:
           class: nginx
+```
+
+### Reusing an ACME Account
+
+You may want to reuse a single ACME account across multiple clusters. This
+might especially be useful when using EAB. If the `disableAccountKeyGeneration`
+field is set, cert-manager will not create a new ACME account and use the
+existing key specified in `privateKeySecretRef`.
+
+
+```yaml
+apiVersion: cert-manager.io/v1beta1
+kind: ClusterIssuer
+metadata:
+  name: my-acme-server-with-existing-acme-account
+spec:
+  acme:
+    email: user@example.com
+    disableAccountKeyGeneration: true
+    privateKeySecretRef:
+      name: example-issuer-account-key
 ```
 
 


### PR DESCRIPTION
Resolves #228 and provides documentation for jetstack/cert-manager#3141.

I recognize that the first patch could be applicable for existing releases, while the docs on reusing ACME accounts only applies to the next release. If you'd prefer me split it up, I can do that. But, seeing it's mostly a cleanup, I didn't feel it was absolutely critical to get it into older release docs. I'll be happy to make them two separate commits to make cherry-picking easier. Your call!

Signed-off-by: Michael Irwin <mikesir87@gmail.com>

