### PR TITLE
Add documentation for GKE workload identity

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -169,3 +169,5 @@ kubelet
 awspca
 Cloudflare
 TLDs
+ingress-nginx
+external-dns

--- a/content/en/docs/configuration/acme/dns01/google.md
+++ b/content/en/docs/configuration/acme/dns01/google.md
@@ -25,10 +25,12 @@ DNS01 challenge. To enable this, a GCP service account must be created with the
 > Console.
 
 ```bash
-$ export PROJECT_ID=myproject-id
+$ PROJECT_ID=myproject-id
 $ gcloud iam service-accounts create dns01-solver --display-name "dns01-solver"
 ```
-Replace both instances of `$PROJECT_ID` with the ID of your project.
+
+In the command above, replace `myproject-id` with the ID of your project.
+
 ```bash
 $ gcloud projects add-iam-policy-binding $PROJECT_ID \
    --member serviceAccount:dns01-solver@$PROJECT_ID.iam.gserviceaccount.com \
@@ -43,7 +45,13 @@ $ gcloud projects add-iam-policy-binding $PROJECT_ID \
 >  * `dns.changes.*`
 >  * `dns.managedZones.list`
 
-## Create a Service Account Secret
+## Use Static Credentials
+
+Follow the instructions in the following sections to deploy cert-manager using
+static credentials for the service account you created. You should rotate these
+credentials periodically.
+
+### Create a Service Account Secret
 
 To access this service account, cert-manager uses a key stored in a Kubernetes
 `Secret`. First, create a key for the service account and download it as a JSON
@@ -75,7 +83,7 @@ $ kubectl create secret generic clouddns-dns01-solver-svc-acct \
 > is `cert-manager` by default.  If you're configuring an `Issuer`, the `Secret`
 > should be stored in the same namespace as the `Issuer` resource.
 
-## Create an Issuer That Uses CloudDNS
+### Create an Issuer That Uses CloudDNS
 
 Next, create an `Issuer` (or `ClusterIssuer`) with a `cloudDNS` provider. An
 example `Issuer` manifest can be seen below with annotations.
@@ -97,6 +105,111 @@ spec:
           serviceAccountSecretRef:
             name: clouddns-dns01-solver-svc-acct
             key: key.json
+```
+
+For more information about `Issuers` and `ClusterIssuers`, see
+[Configuration](../../../).
+
+Once an `Issuer` (or `ClusterIssuer`) has been created successfully, a
+`Certificate` can then be added to verify that everything works.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example-com
+  namespace: default
+spec:
+  secretName: example-com-tls
+  issuerRef:
+    # The issuer created previously
+    name: example-issuer
+  dnsNames:
+  - example.com
+  - www.example.com
+```
+
+For more details about `Certificates`, see [Usage](../../../../usage/).
+
+## GKE Workload Identity
+
+If you are deploying cert-manager into a [Google Container Engine (GKE)
+cluster](https://cloud.google.com/kubernetes-engine/) with workload identity
+enabled, you can leverage workload identity to avoid creating and managing
+static service account credentials. The [workload identity
+how-to](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+provides more detail on how workload identity functions, but briefly workload
+identity allows you to link a Google service accounts (GSA) to Kubernetes
+service accounts (KSA). This GSA/KSA linking is two-way, i.e., you must
+establish the link in GCP _and_ Kubernetes. Once configured, workload identity
+allows Kubernetes pods running under a KSA to access the GCP APIs with the
+permissions of the linked GSA. The workload identity how-to also provides
+detailed instructions on how to enable workload identity in your GKE cluster.
+The instructions in the following sections assume you are deploying cert-manager
+to a GKE cluster with workload identity already enabled.
+
+### Link KSA to GSA in GCP
+
+The cert-manager component that needs to modify DNS records is the pod created
+as part of the cert-manager deployment. The [standard methods for deploying
+cert-manger to Kubernetes](../../../../installation/kubernetes/) create the
+cert-manager deployment in the cert-manager namespace and its pod spec specifies
+it runs under the cert-manager service account. To link the GSA you created
+above to the cert-manager KSA in the cert-manager namespace in your GKE cluster,
+run the following command.
+
+```bash
+$ gcloud iam service-accounts add-iam-policy-binding \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:$PROJECT_ID.svc.id.goog[cert-manager/cert-manager]" \
+    dns01-solver@$PROJECT_ID.iam.gserviceaccount.com
+```
+
+If your cert-manager pods are running under a different service account, replace
+`goog[cert-manager/cert-manager]` with `goog[NAMESPACE/SERVICE_ACCOUNT]`, where
+`NAMESPACE` is the namespace of the service account and `SERVICE_ACCOUNT` is the
+name of the service account.
+
+### Link KSA to GSA in Kubernetes
+
+After deploying cert-manager, add the proper workload identity annotation to the
+cert-manager service account.
+
+```bash
+$ kubectl annotate serviceaccount --namespace=cert-manager cert-manager \
+    "iam.gke.io/gcp-service-account=dns01-solver@$PROJECT_ID.iam.gserviceaccount.com"
+```
+
+Again, if your cert-manager pods are running under a different service account,
+replace `--namespace=cert-manager cert-manager` with `--namespace=NAMESPACE
+SERVICE_ACCOUNT`, where `NAMESPACE` is the namespace of the service account and
+`SERVICE_ACCOUNT` is the name of the service account.
+
+If you are deploying cert-manager using its helm chart, you can use the
+`serviceAccount.annotations` configuration parameter to add the above workload
+identity annotation to the cert-manager KSA.
+
+### Create an Issuer That Uses CloudDNS
+
+Next, create an `Issuer` (or `ClusterIssuer`) with a `clouddns` provider. An
+example `Issuer` manifest can be seen below with annotations. Note that the
+issuer does not include a `serviceAccountSecretRef` property. Excluding this
+instructs cert-manager to use the default credentials provided by GKE workload
+identity.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: example-issuer
+spec:
+  acme:
+    ...
+    solvers:
+    - dns01:
+        cloudDNS:
+          # The ID of the GCP project
+          project: $PROJECT_ID
 ```
 
 For more information about `Issuers` and `ClusterIssuers`, see

--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -27,4 +27,6 @@ get to a final goal. Below is the list of tutorials that you might find helpful:
 
 
 User How-To Blog Posts and Examples:
+
 - A full cert-manager installation demo on GKE Cluster. See [How-To: Automatic SSL Certificate Management for your Kubernetes Application Deployment](https://medium.com/contino-engineering/how-to-automatic-ssl-certificate-management-for-your-kubernetes-application-deployment-94b64dfc9114)
+- cert-manager installation on GKE Cluster using Workload Identity. See [Kubernetes, ingress-nginx, cert-manager & external-dns](https://blog.atomist.com/kubernetes-ingress-nginx-cert-manager-external-dns/)


### PR DESCRIPTION
Add documentation and link to blog post for using GKE workload
identity to authenticate against Google Cloud DNS.

Per request in jetstack/cert-manager#3009

Signed-off-by: David Dooling <dooling@gmail.com>