### PR TITLE
Fix link to 0.16 to 1.0 upgrade guide

### DIFF
--- a/content/en/docs/installation/upgrading/upgrading-0.16-1.0.md
+++ b/content/en/docs/installation/upgrading/upgrading-0.16-1.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading from v0.16 to v1.0"
-linkTitle: "v0.15 to v0.16"
+linkTitle: "v0.16 to v1.0"
 weight: 830
 type: "docs"
 ---


### PR DESCRIPTION
This PR fixes a little bit of copy-pasta that makes it difficult to find the 1.0 upgrade guide.

<img width="134" alt="Screenshot 2020-09-02 at 12 03 57" src="https://user-images.githubusercontent.com/785641/91973782-b7fa8980-ed14-11ea-9df7-c7e791400e09.png">
