### PR TITLE
Add link to AWS KmsIssuer external issuer

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -172,3 +172,4 @@ WIP
 x509
 YAML
 YAMLs
+awskms-issuer

--- a/content/en/docs/configuration/external.md
+++ b/content/en/docs/configuration/external.md
@@ -30,5 +30,9 @@ authors are as follows:
   (https://aws.amazon.com/certificate-manager/private-certificate-authority/)
   for cloud native/hybrid environments.
 
+- [awskms-issuer](https://github.com/Skyscanner/kms-issuer): Used to request
+  certificates signed using an [AWS KMS](https://aws.amazon.com/kms/) asymetric key.
+ 
+
 To create your own external issuer type, please follow the guidance in the
 [development documentation](../../contributing/external-issuers/).

--- a/content/en/docs/configuration/external.md
+++ b/content/en/docs/configuration/external.md
@@ -31,7 +31,7 @@ authors are as follows:
   for cloud native/hybrid environments.
 
 - [awskms-issuer](https://github.com/Skyscanner/kms-issuer): Used to request
-  certificates signed using an [AWS KMS](https://aws.amazon.com/kms/) asymetric key.
+  certificates signed using an [AWS KMS](https://aws.amazon.com/kms/) asymmetric key.
  
 
 To create your own external issuer type, please follow the guidance in the


### PR DESCRIPTION
KMS issuer is a [cert-manager](https://cert-manager.io/) Certificate Request controller that uses [AWS KMS](https://aws.amazon.com/kms/) to sign the certificate request.