### PR TITLE
Improve language on which DNS solvers are called

### DIFF
--- a/content/en/docs/configuration/acme/dns01/_index.md
+++ b/content/en/docs/configuration/acme/dns01/_index.md
@@ -52,8 +52,8 @@ read the multiple-solver-types section.
 
 cert-manager will check the correct DNS records exist before attempting a DNS01
 challenge.  By default cert-manager will use the recursive nameservers taken
-from `/etc/resolv.conf` to query for the authoritative nameserver to verify the
-DNS records exist.
+from `/etc/resolv.conf` to query for the authoritative nameservers, which it will
+then query directly to verify the DNS records exist.
 
 If this is not desired (for example with multiple authoritative nameservers or
 split-horizon DNS), the cert-manager controller exposes two flags that allows


### PR DESCRIPTION
Improve language on which DNS solvers are called, see https://github.com/jetstack/cert-manager/issues/3272