### PR TITLE
Adding spacing to render bulleted list correctly

### DIFF
--- a/content/en/docs/contributing/building.md
+++ b/content/en/docs/contributing/building.md
@@ -24,6 +24,7 @@ Bazel has 3 main commands which we use:
 
 After any Bazel command you will see something that looks like a path.
 Let's take `bazel run //hack/bin:helm` as an example:
+
 * `//` is the cert-manager project root, no matter in which directory under cert-manager you are it will find it
 * `hack/bin` is the path where the code is to execute/build/test you will for example see `pkg/acme/` to run ACME tests
 * `:helm` is the part of the Bazel file to execute, these are defined in the Bazel config themselves.
@@ -54,6 +55,7 @@ This will update everything you need without having to care about what needs cha
 ### I need granular control 
 
 You can also pick and mix the individual bash helper scripts:
+
 * `update-bazel.sh`: updates the all `*.bazel` files including formatting them
 * `update-codegen.sh`: runs all code generation
 * `update-crds.sh`: updates all CRD files to the latest scheme


### PR DESCRIPTION
Small change! Just noticed that content modified in this PR was structured as a bulleted list but didn't appear as one in the rendered version of the documentation (It does render correctly in VSCode's markdown preview, though).

Where is this happening today: 
- https://cert-manager.io/docs/contributing/building/#package-format
- https://cert-manager.io/docs/contributing/building/#i-need-granular-control

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>