### PR TITLE
Added needed escape to second sed expression since

### DIFF
--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -136,7 +136,7 @@ ACME server
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 | sed -e 's/+/-/g' -e 's///_/g' -e 's/=//g'
+>     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
 > 
 > You can then create the Secret resource with: 
 > 

--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -125,7 +125,7 @@ most cert-manager users unless you know it is explicitly needed.
 External Account Bindings require three fields on an ACME `Issuer` which
 represents your ACME account. These fields are:
 
-- `keyID` - the key ID of which your external account binding is indexed by the
+- `keyID` - the key ID or account ID of which your external account binding is indexed by the
 external account manager
 - `keySecretRef` - the name and key of a secret containing a base 64 encoded 
 URL string of your external account symmetric MAC key
@@ -155,7 +155,7 @@ spec:
     email: user@example.com
     server: https://my-acme-server-with-eab.com/directory
     externalAccountBinding:
-      keyID: my-kid-1
+      keyID: my-keyID-1
       keySecretRef:
         name: eab-secret
         key: secret


### PR DESCRIPTION
slash is being used as the separator in the expression.

Added option to base64 to prevent output string
from being line wrapped.

Signed-off-by: Clay Cooper <claycooper@users.noreply.github.com>