### PR TITLE
Updating section for MatchLabels

### DIFF
--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -213,7 +213,7 @@ single solver.
 The `matchLabel` selector requires that all `Certificates` match all of
 the labels that are defined in the string map list of that stanza. For example,
 the following `Issuer` will only match on `Certificates` that have the labels
-`"user-cloudflare-solver": "true"`, or `"email": "user@example.com"`, or both.
+`"user-cloudflare-solver": "true"` and `"email": "user@example.com"`.
 
 ```yaml
 apiVersion: cert-manager.io/v1

--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -210,7 +210,7 @@ single solver.
 
 #### Match Labels
 
-The `matchLabel` selector requires that all `Certificates` match at least one of
+The `matchLabel` selector requires that all `Certificates` match all of
 the labels that are defined in the string map list of that stanza. For example,
 the following `Issuer` will only match on `Certificates` that have the labels
 `"user-cloudflare-solver": "true"`, or `"email": "user@example.com"`, or both.


### PR DESCRIPTION
At the moment documentation states that when using `MatchLabels` selector for `Issuers` at least on label should be matched in order for solver to be chosen, however it seems that all of the labels defined in `MatchLabels` stanza *must* also be applied on certificate.

Signed-off-by: Justinas B <12399634+justinas-b@users.noreply.github.com>