### PR TITLE
Mention how to let people know that a PR in in progress

### DIFF
--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -71,6 +71,11 @@ If the pull request is a critical bug fix then this will probably
 also be cherry picked to the current stable version of cert-manager as a patch
 release.
 
+To let people know that your PR is still a work in progress, we usually add a
+`WIP:` prefix to the title of the PR. Prow will then automatically set the label
+`do-not-merge/work-in-progress`.
+
+
 ### Cherry Picking
 
 If the pull request contains a critical bug fix then this should be cherry picked in to the current stable cert-manager branch 


### PR DESCRIPTION
This morning during the [daily standup](https://github.com/jetstack/cert-manager#daily-standups) I was told that the usual way of letting people know that my PR isn't ready for review yet was to set the `WIP:`  prefix.

Maybe I should also mention if the Github draft feature could also be used?

Here is a PR to document that! 👍