### PR TITLE
Remove Helm 2 instructions

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -88,25 +88,7 @@ official Helm chart for installing cert-manager.
 
 ### Prerequisites
 
-- Helm v2 or v3 installed
-
-### Note: Helm v2
-
-Before deploying cert-manager with Helm v2, you must ensure
-[Tiller](https://github.com/helm/helm) is up and running in your cluster. Tiller
-is the server side component to Helm.
-
-Your cluster administrator may have already setup and configured Helm for you,
-in which case you can skip this step.
-
-Full documentation on installing Helm can be found in the [installing helm
-docs](https://v2.helm.sh/docs/install/#installing-helm).
-
-If your cluster has RBAC (Role Based Access Control) enabled (default in GKE
-`v1.7`+), you will need to take special care when deploying Tiller, to ensure
-Tiller has permission to create resources as a cluster administrator. More
-information on deploying Helm with RBAC can be found in the [Helm RBAC
-docs](https://github.com/helm/helm/blob/240e539cec44e2b746b3541529d41f4ba01e77df/docs/rbac.md#Example-Service-account-with-cluster-admin-role).
+- Helm v3 installed
 
 ### Steps
 
@@ -169,19 +151,10 @@ Uncomment the relevant line in the next steps to enable this.
 To install the cert-manager Helm chart:
 
 ```bash
-# Helm v3+
 $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --version v1.1.0 \
-  # --set installCRDs=true
-
-# Helm v2
-$ helm install \
-  --name cert-manager \
-  --namespace cert-manager \
-  --version v1.1.0 \
-  jetstack/cert-manager \
   # --set installCRDs=true
 ```
 

--- a/content/en/docs/installation/uninstall/kubernetes.md
+++ b/content/en/docs/installation/uninstall/kubernetes.md
@@ -44,15 +44,9 @@ Uninstalling cert-manager from a `helm` installation is a case of running the
 installation process, *in reverse*, using the delete command on both `kubectl`
 and `helm`.
 
-Firstly, delete the cert-manager installation using `helm`. Ensure the
-`--purge` flag is applied if you are using Helm 2.
 
 ```bash
-# Helm 3
 $ helm --namespace cert-manager delete cert-manager
-
-# Helm 2.x
-$ helm delete cert-manager --purge
 ```
 
 Next, delete the cert-manager namespace:


### PR DESCRIPTION
As per https://helm.sh/blog/helm-2-becomes-unsupported/ Helm 2 is no longer supported, so we should remove it from our instructions.