### PR TITLE
Note about what assignees on Github issues and PRs mean to us

### DIFF
--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -118,6 +118,19 @@ Sometimes `/triage` is also added which helps us when following up Issues.
 * Kind indicates if it is a `bug` or a `feature` but also can be `documentation` or `cleanup` (general maintenance)
 * Priority is the priority it has for the cert-manager team, PRs are still very welcome for those!
 
+### Assignees meaning in PRs and issues
+
+Sometimes, you might see someone commenting with the
+[`/assign` prow command](https://prow.build-infra.jetstack.net/command-help#assign):
+
+```plain
+/assign @meyskens
+```
+
+We don't have a strong definition yet of what being an assignee means. On issues, it
+means "working on it". On PRs, well... it is meaningless. This is something we want to
+improve with a Kanban board where we then can start defining states of PRs.
+
 ### Triage Party!
 
 Every few weeks we will plan a Triage Party meeting, where we use the (Triage Party)[https://triage.build-infra.jetstack.net/] tool to go recent/old issues to prioritise them so we can address them in a timely matter. These meetings are open to everyone and invites will be sent out using our mailing list (warning: despite the word party these meetings are sometimes boring).

--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -127,9 +127,13 @@ Sometimes, you might see someone commenting with the
 /assign @meyskens
 ```
 
-We don't have a strong definition yet of what being an assignee means. On issues, it
-means "working on it". On PRs, well... it is meaningless. This is something we want to
-improve with a Kanban board where we then can start defining states of PRs.
+Here is the meaning that we give to the Github assignees:
+
+- On issues, it means that the assignee is working on it.
+- On PRs, we use it as a way to know who should be taking a look at the PR at any time:
+  - When the author is assigned, it means the PR needs work to be done aka "changes requested";
+  - When nobody is assigned, it means this PR needs review;
+  - When someone different from the author is assigned, it means this person is reviewing this PR.
 
 ### Triage Party!
 

--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -127,7 +127,7 @@ Sometimes, you might see someone commenting with the
 /assign @meyskens
 ```
 
-Here is the meaning that we give to the Github assignees:
+Here is the meaning that we give to the GitHub assignees:
 
 - On issues, it means that the assignee is working on it.
 - On PRs, we use it as a way to know who should be taking a look at the PR at any time:


### PR DESCRIPTION
I created this PR after [this Slack convo](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1610564003454800):

- Mael [Jan 13th at 19:53](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1610564003454800)

  > Quick question: I noticed in [#3457](https://github.com/jetstack/cert-manager/pull/3457) that we seem to be using Github assignees:
  >
  >     JoshVanL commented 7 days ago
  >     /assign @meyskens
  >
  > How do we use Github assignees? I did a search in the jetstack org [with the term "assignee"](https://github.com/search?q=org%3Ajetstack+assignee&type=code) and I was able to find [triageparty_configmap.yaml](https://github.com/jetstack/testing/blob/f3a6f3cd857525f5382ae2f37001a8bac0e7c6e0/triage_party/triageparty_configmap.yaml) (in jetstack/testing).How does it work? Maybe we could put that information in [contributing.md](https://github.com/cert-manager/website/blob/master/content/en/docs/contributing/_index.md)?

- Jake Sanders [6 days ago](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1610564090455200?thread_ts=1610564003.454800&cid=CDEQJ0Q8M)

  > How do we use them or how does prow work? prow commands are here <https://prow.build-infra.jetstack.net/command-help>

- Mael [6 days ago](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1610564174455400?thread_ts=1610564003.454800&cid=CDEQJ0Q8M)

  > good point, i wasnt very specific :sweat_smile: How do we use the "Assignee" Github feature?E.g. in the above example, what is Maartje being assigned to?

- Jake Sanders [6 days ago](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1610564468455900?thread_ts=1610564003.454800&cid=CDEQJ0Q8M)

  > It just adds the issue to your github notifications as far as I know

- Maartje [5 days ago](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1610576359459100?thread_ts=1610564003.454800&cid=CDEQJ0Q8M)

  > We don't have a strong definition yet, on issues it means "working on it" on PRs it is well... meaningless something i want to improve with a kanban board where we then can start defining states of PRs


Signed-off-by: Maël Valais <mael@vls.dev>