### PR TITLE
add -w0 to base64 command to get a singel line

### DIFF
--- a/content/en/docs/configuration/ca.md
+++ b/content/en/docs/configuration/ca.md
@@ -28,7 +28,7 @@ being the `cert-manager` namespace, however can be configured using the
 Below is an example of a secret resource that will be used for signing. Take
 note of the index keys used for each field as these are required in order for
 cert-manager to find the certificate and key. Also note that, like all secrets,
-data must be base64 encoded. The command `$ cat crt.pem | base64` should help
+data must be base64 encoded. The command `$ cat crt.pem | base64 -w0` should help
 you here.
 
 ```yaml

--- a/content/en/docs/configuration/ca.md
+++ b/content/en/docs/configuration/ca.md
@@ -28,8 +28,9 @@ being the `cert-manager` namespace, however can be configured using the
 Below is an example of a secret resource that will be used for signing. Take
 note of the index keys used for each field as these are required in order for
 cert-manager to find the certificate and key. Also note that, like all secrets,
-data must be base64 encoded. The command `$ cat crt.pem | base64 -w0` should help
-you here.
+data must be base64 encoded. The command `$ cat crt.pem | base64 -w0` should help you
+on GNU-based systems (Debian, Ubuntu, etc.) and `$ cat crt.pem | base64 -b0` on BSD-based
+systems (most notably macOS).
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
I think it's easier to get a valid base64 string with the -w0 argument which makes a single line instead of a multiline output.