### PR TITLE
Mention test-grid and the alert google group

### DIFF
--- a/content/en/docs/contributing/e2e.md
+++ b/content/en/docs/contributing/e2e.md
@@ -11,9 +11,11 @@ real Kubernetes cluster.
 This test takes around 30 minutes, it will be run on every PR in our cluster.
 
 > Note: you can see the status of each commit on the master branch at
-> [testgrid.k8s.io](jetstack-cert-manager-master). Anyone who joined the
-> Google group [cert-manager-dev-alerts](https://groups.google.com/u/2/g/cert-manager-dev-alerts)
-> will receive an email whenever a commit on master fails (see [testing-trusted.yaml](https://github.com/jetstack/testing/blob/f3a6f3cd857525f5382ae2f37001a8bac0e7c6e0/config/jobs/testing/testing-trusted.yaml#L74)).
+> [`testgrid.k8s.io`](https://testgrid.k8s.io/jetstack-cert-manager-master).
+> You can join the Google group
+> [`cert-manager-dev-alerts`](https://groups.google.com/g/cert-manager-dev-alerts)
+> in order to receive a notification by email whenever a commit on master
+> fails.
 
 It is only advised to run this locally when you made big changes to the
 codebase. This document explains how you can run the end-to-end tests yourself.

--- a/content/en/docs/contributing/e2e.md
+++ b/content/en/docs/contributing/e2e.md
@@ -9,9 +9,14 @@ cert-manager has an end-to-end test suite that verifies functionality against a
 real Kubernetes cluster.
 
 This test takes around 30 minutes, it will be run on every PR in our cluster.
-It is only advised to run this locally when you made big changes to the codebase.
 
-This document explains how you can run the end-to-end tests yourself.
+> Note: you can see the status of each commit on the master branch at
+> [testgrid.k8s.io](jetstack-cert-manager-master). Anyone who joined the
+> Google group [cert-manager-dev-alerts](https://groups.google.com/u/2/g/cert-manager-dev-alerts)
+> will receive an email whenever a commit on master fails (see [testing-trusted.yaml](https://github.com/jetstack/testing/blob/f3a6f3cd857525f5382ae2f37001a8bac0e7c6e0/config/jobs/testing/testing-trusted.yaml#L74)).
+
+It is only advised to run this locally when you made big changes to the
+codebase. This document explains how you can run the end-to-end tests yourself.
 
 ## Requirements
 
@@ -84,3 +89,5 @@ This suite tests certificate functionality against all issuers.
 #### Feature sets
 This exists to only test a certain feature (e.g. Email SAN) against issuers that support this feature.
 Each test specifies a used feature using `s.checkFeatures(feature)`, this is then checked against the issuer's `UnsupportedFeatures` list to check if it can be ran against the issuer.
+
+


### PR DESCRIPTION
This PR adds some documentation about test-grid and this new alert group that we (will use?), see discussion in https://github.com/jetstack/testing/pull/425.

@meyskens what do you think?
