### PR TITLE
Add deprecation notices for old k8s

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -19,15 +19,15 @@ configuring different `Issuer` types can be found in the [respective configurati
 guides](../../configuration/).
 
 
-> Note: From cert-manager `v0.14.0` onward, the minimum supported version of
-> Kubernetes is `v1.11.0`. Users still running Kubernetes `v1.10` or below should
-> upgrade to a supported version before installing cert-manager.
-
 > **Warning**: You should not install multiple instances of cert-manager on a single
 > cluster. This will lead to undefined behavior and you may be banned from
 > providers such as Let's Encrypt.
 
 ## Installing with regular manifests
+
+> Note: From cert-manager `v1.2.0` onward, the minimum supported version of
+> Kubernetes is `v1.16.0`. Users still running Kubernetes `v1.15` or below should
+> upgrade to a supported version before installing cert-manager or use cert-manager `v1.1`.
 
 All resources (the `CustomResourceDefinitions`, cert-manager, namespace, and the webhook component)
 are included in a single YAML manifest file:
@@ -39,23 +39,8 @@ are included in a single YAML manifest file:
 Install the `CustomResourceDefinitions` and cert-manager itself:
 
 ```bash
-# Kubernetes 1.16+
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
-
-# Kubernetes <1.16
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager-legacy.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
 ```
-
-> **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the manifests.
-> This version does not have API version conversion and only supports `cert-manager.io/v1` API resources.
-
-> **Note**: If you are running Kubernetes `v1.15.4` or below, you will need to add the
-> `--validate=false` flag to your `kubectl apply` command above else you will
-> receive a validation error relating to the
-> `x-kubernetes-preserve-unknown-fields` field in cert-manager's
-> `CustomResourceDefinition` resources.  This is a benign error and occurs due
-> to the way `kubectl` performs resource validation.
-
 
 > **Note**: When running on GKE (Google Kubernetes Engine), you may encounter a
 > 'permission denied' error when creating some of these resources. This is a
@@ -79,6 +64,10 @@ Once you have deployed cert-manager, you can verify the installation
 [here](./#verifying-the-installation).
 
 ## Installing with Helm
+
+> Note: From cert-manager `v1.2.0` onward, the minimum supported version of
+> Kubernetes is `v1.16.0`. Users still running Kubernetes `v1.15` or below should
+> upgrade to a supported version before installing cert-manager or use cert-manager `v1.1`.
 
 As an alternative to the YAML manifests referenced above, we also provide an
 official Helm chart for installing cert-manager.
@@ -129,15 +118,9 @@ option when installing the Helm chart.
 Install the `CustomResourceDefinition` resources using `kubectl`:
 
 ```bash
-# Kubernetes 1.15+
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml
-
-# Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager-legacy.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.crds.yaml
 ```
 
-> **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the CRDs.
-> This version does not have API version conversion and only supports `cert-manager.io/v1` API resources. 
 
 **Option 2: install CRDs as part of the Helm release**
 
@@ -154,7 +137,7 @@ To install the cert-manager Helm chart:
 $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.1.0 \
+  --version v1.2.0 \
   # --set installCRDs=true
 ```
 

--- a/content/en/docs/installation/openshift.md
+++ b/content/en/docs/installation/openshift.md
@@ -23,6 +23,11 @@ More information on configuring different Issuer types can be found in the
 > single cluster. This will lead to undefined behavior and you may be banned
 > from providers such as Let's Encrypt.
 
+> Note: From cert-manager `v1.2.0` onward, the minimum supported version of
+> OpenShift is `v3.2` (Kubernetes `v1.16.0`). Users still running versions below should
+> upgrade to a supported version before installing cert-manager or use cert-manager `v1.1`.
+
+
 ## Login to your OpenShift cluster
 
 Before you can install cert-manager, you must first ensure your local machine
@@ -61,11 +66,7 @@ are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
 ```bash
-# OpenShift 4+
-oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
-
-# OpenShift 3.11
-$ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager-legacy.yaml
+oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
 ```
 
 > **Note**: If you're using OpenShift 3 you will need to install the legacy version of the manifests.

--- a/content/en/docs/installation/upgrading/upgrading-1.1-1.2.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.1-1.2.md
@@ -1,0 +1,17 @@
+---
+title: "Upgrading from v1.1 to v1.2"
+linkTitle: "v1.1 to v1.2"
+weight: 810
+type: "docs"
+---
+
+> The upgrade process for upgrading to `v1.2` is very Kubernetes version specific. Please check the version of your cluster using `kubectl version` and follow the steps required for your version of Kubernetes.
+
+### Kubernetes `1.15.x` and below
+
+cert-manager `v1.2` will no longer support Kubernetes `v1.15` and below following the Kubernetes upstream version support. We advise you to consider upgrading to Kubernetes 1.16 or above. If this isn't possible we advise you to stay with the cert-manager `v1.1.x` releases.
+
+### Kubernetes `1.16.x` and above
+
+When upgrading from `v1.1` to `v1.2`, no special upgrade steps are required 🎉.
+From here on you can follow the [regular upgrade process](../).


### PR DESCRIPTION
The initial https://github.com/cert-manager/website/pull/396 description from Maartje:

> Adds upgrade and install notes for 1.2.0 not supporting old kubernetes

**Context:** this commit was initially (mistakenly) merged to master in commit 79a7a05b, then reverted in 4828078c. This commit re-introduces the change!

Signed-off-by: Maël Valais <mael@vls.dev>
Co-authored-by: Maartje Eyskens <maartje@eyskens.me>