### PR TITLE
Updates installation guide to use 1.2

### DIFF
--- a/content/en/docs/concepts/project-maturity.md
+++ b/content/en/docs/concepts/project-maturity.md
@@ -18,7 +18,7 @@ cert-manager has a hard guarantee of compatibly with the current stable upstream
 Kubernetes version. Beyond this, cert-manager also aims to be compatible with
 versions down to `N-4`, where `N` is the current upstream version release. This
 means that if the current version is `v1.19`, cert-manager aims to be compatible
-with versions down to `v1.15`. This is done by running periodic end-to-end test
+with versions down to `v1.16`. This is done by running periodic end-to-end test
 jobs against each version of Kubernetes.
 
 Versions lower than the current Kubernetes version down to `N-4` is *not
@@ -27,5 +27,5 @@ many versions as possible, it is sometimes required to lose compatibility in
 the interest of furthering the feature set of cert-manager and making use of
 newer features available in upstream Kubernetes.
 
-As of cert-manager version `v0.14`, the lowest Kubernetes version supported is
-`v1.11`.
+As of cert-manager version `v1.2`, the lowest Kubernetes version supported is
+`v1.16`.

--- a/content/en/docs/contributing/crds.md
+++ b/content/en/docs/contributing/crds.md
@@ -20,7 +20,7 @@ This will also update the version conversion code if needed.
 
 ## Versions
 
-cert-manager at time of writing has 4 (5 actually) CRD versions in use, distributed in 2 versions (mainline and legacy). The last 2 Bazel will take care of for you.
+cert-manager at time of writing has 4 CRD versions in use.
 
 These versions are defined in [`//pkg/apis/certmanager`](https://github.com/jetstack/cert-manager/tree/master/pkg/apis/certmanager). ACME related resources are in `//pkg/apis/acme`.
 

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -39,23 +39,8 @@ are included in a single YAML manifest file:
 Install the `CustomResourceDefinitions` and cert-manager itself:
 
 ```bash
-# Kubernetes 1.16+
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
-
-# Kubernetes <1.16
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager-legacy.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
 ```
-
-> **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the manifests.
-> This version does not have API version conversion and only supports `cert-manager.io/v1` API resources.
-
-> **Note**: If you are running Kubernetes `v1.15.4` or below, you will need to add the
-> `--validate=false` flag to your `kubectl apply` command above else you will
-> receive a validation error relating to the
-> `x-kubernetes-preserve-unknown-fields` field in cert-manager's
-> `CustomResourceDefinition` resources.  This is a benign error and occurs due
-> to the way `kubectl` performs resource validation.
-
 
 > **Note**: When running on GKE (Google Kubernetes Engine), you may encounter a
 > 'permission denied' error when creating some of these resources. This is a
@@ -129,15 +114,8 @@ option when installing the Helm chart.
 Install the `CustomResourceDefinition` resources using `kubectl`:
 
 ```bash
-# Kubernetes 1.15+
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml
-
-# Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager-legacy.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.crds.yaml
 ```
-
-> **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the CRDs.
-> This version does not have API version conversion and only supports `cert-manager.io/v1` API resources. 
 
 **Option 2: install CRDs as part of the Helm release**
 
@@ -154,7 +132,7 @@ To install the cert-manager Helm chart:
 $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.1.0 \
+  --version v1.2.0 \
   # --set installCRDs=true
 ```
 

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -19,8 +19,8 @@ configuring different `Issuer` types can be found in the [respective configurati
 guides](../../configuration/).
 
 
-> Note: From cert-manager `v0.14.0` onward, the minimum supported version of
-> Kubernetes is `v1.11.0`. Users still running Kubernetes `v1.10` or below should
+> Note: From cert-manager `v1.2.0` onward, the minimum supported version of
+> Kubernetes is `v1.16.0`. Users still running Kubernetes `v1.15` or below should
 > upgrade to a supported version before installing cert-manager.
 
 > **Warning**: You should not install multiple instances of cert-manager on a single

--- a/content/en/docs/installation/openshift.md
+++ b/content/en/docs/installation/openshift.md
@@ -61,15 +61,8 @@ are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
 ```bash
-# OpenShift 4+
-oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
-
-# OpenShift 3.11
-$ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager-legacy.yaml
+oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
 ```
-
-> **Note**: If you're using OpenShift 3 you will need to install the legacy version of the manifests.
-> This version does not have API version conversion and only supports `cert-manager.io/v1` API resources.
 
 > **Note**: The `--validate=false` flag is added to the `oc apply` command
 > above else you will receive a validation error relating to the `caBundle`

--- a/content/en/docs/installation/upgrading/_index.md
+++ b/content/en/docs/installation/upgrading/_index.md
@@ -33,11 +33,7 @@ option added to your Helm install command, you should upgrade your CRD resources
 before upgrading the Helm chart:
 
 ```bash
-# Kubernetes 1.15+
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml
-
-# Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager-legacy.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.crds.yaml
 ```
 
 Add the Jetstack Helm repository if you haven't already.
@@ -73,9 +69,5 @@ begin the upgrade process like so - replacing `<version>` with the version
 number you want to install:
 
 ```bash
-# Kubernetes 1.15+
 $ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
-
-# Kubernetes <1.15
-$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager-legacy.yaml
 ```

--- a/content/en/docs/installation/upgrading/upgrading-1.1-1.2.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.1-1.2.md
@@ -5,8 +5,14 @@ weight: 810
 type: "docs"
 ---
 
-Note: In this release some features have been deprecated.
-Please read the [version 1.2 release notes](../../../release-notes/release-notes-1.2/) for more details and
-consider whether you are using any of these deprecated features before you proceed with the upgrade.
+In an effort to introduce new features whilst keeping the project maintainable,
+cert-manager now only supports Kubernetes down to version `v1.16`. This means
+the `legacy` manifests have now been removed. You can read more
+[here](../../../concepts/project-maturity).
+
+In this release some features have been deprecated.  Please read the [version
+1.2 release notes](../../../release-notes/release-notes-1.2/) for more details
+and consider whether you are using any of these deprecated features before you
+proceed with the upgrade.
 
 From here on you can follow the [regular upgrade process](../).

--- a/content/en/docs/release-notes/release-notes-1.2.md
+++ b/content/en/docs/release-notes/release-notes-1.2.md
@@ -11,3 +11,8 @@ type: "docs"
 1. The `--renew-before-expiration-duration` flag of the cert-manager controller-manager has been deprecated. 
    Please set the `Certificate.Spec.RenewBefore` field instead.
    This flag will be removed in the next release.
+
+1. In an effort to introduce new features whilst keeping the project
+   maintainable, cert-manager now only supports Kubernetes down to version
+   `v1.16`. This means the `legacy` manifests have now been removed. You can
+   read more [here](../../../concepts/project-maturity).

--- a/content/en/docs/usage/kubectl-plugin.md
+++ b/content/en/docs/usage/kubectl-plugin.md
@@ -12,7 +12,7 @@ You need the `kubectl-cert-manager.tar.gz` file for the platform you're using, t
 In order to use the kubectl plugin you need its binary to be accessible under the name `kubectl-cert_manager` in your `$PATH`.
 Run the following commands to set up the plugin:
 ```console
-$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/download/v1.1.0/kubectl-cert_manager-linux-amd64.tar.gz
+$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/download/v1.2.0/kubectl-cert_manager-linux-amd64.tar.gz
 $ tar xzf kubectl-cert-manager.tar.gz
 $ sudo mv kubectl-cert_manager /usr/local/bin
 ```


### PR DESCRIPTION
Updates supported Kubernetes version to be 1.16
Removes all reference to the legacy manifests

Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>