### PR TITLE
A "supported-releases" page to give a support timeline

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -233,6 +233,14 @@ Makefile
 SelfSigned
 justinkillen
 Maartje
+pre-releases
+versioning
+cert-manager-dev
+backport
+kubernetes-supported-versions
+prepended
+retweets
+JetstackHQ
 
 # As per https://tools.ietf.org/html/rfc5280, the spelling "X.509" is the
 # correct spelling. The spelling "x509" and "X509" are incorrect.

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,25 @@
+// The ASCII diagrams aren't nicely formatted by the default .highlight
+// class. For ASCII diagrams we want no border and a miniman line height so
+// that the characters "fit". To use this hack:
+//
+//    ```diagram
+//    +-----------------------+
+//    |                       |
+//    |  This is a lovely     |
+//    |  diagram drawn using  |
+//    |  the excellent        |
+//    |                       |
+//    |  https://textik.com   |
+//    |                       |
+//    +-----------------------+
+//    ```
+
+.highlight .language-diagram {
+  font-size: 0.9em;
+  line-height: 1rem;
+  font-family: monospace;
+
+  // Using display: block; was the only way I found to force the
+  // line-height to be 1. See: https://stackoverflow.com/questions/12851792
+  display: block;
+}

--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -79,7 +79,7 @@ To let people know that your PR is still a work in progress, we usually add a
 ### Cherry Picking
 
 If the pull request contains a critical bug fix then this should be cherry picked in to the current stable cert-manager branch 
-and [released as a patch release](../release-process/#patch-releases).
+and [released as a patch release](/docs/installation/supported-releases/#support-policy).
 
 To trigger the cherry-pick process, add a comment to the GitHub PR.
 For example:
@@ -101,7 +101,7 @@ Most of cert-manager's project management is done on GitHub, with the help of Pr
 
 ### When will something be released?
 
-Our team works in milestones, you can follow them (inside GitHub)[https://github.com/jetstack/cert-manager/milestones].
+Our team works using [GitHub milestones](https://github.com/jetstack/cert-manager/milestones).
 When a milestone is set on an Issue it is generally an indication of when we plan to address this.
 Prow will apply milestones on merged PRs, this will tell you in which version that PR will land.
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -5,8 +5,10 @@ weight: 70
 type: "docs"
 ---
 
-This document aims to outline the process that should be followed for cutting a
-new release of cert-manager.
+This document aims to outline the process that should be followed for
+cutting a new release of cert-manager. If you would like to know more about
+current releases and the timeline for future releases, take a look at the
+[Supported Releases](/docs/installation/supported-releases/) page.
 
 ## Prerequisites
 
@@ -389,22 +391,39 @@ page if a step is missing or if it is outdated.
     3. Click "Publish" to make the GitHub release live. This will create a Git
        tag automatically.
 
-9.  Finally, post a Slack message as an answer to the first message. Toggle the
-   check box "Also send to `#cert-manager-dev`" so that the message is well
+9. **(final release only)** Add the new final release to the
+    [supported-releases](/docs/installation/supported-releases/) page.
+
+10. Post a Slack message as an answer to the first message. Toggle the check
+   box "Also send to `#cert-manager-dev`" so that the message is well
    visible. Also cross-post the message on `#cert-manager`.
 
     <div class="pageinfo pageinfo-primary"><p>
     https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉
     </p></div>
 
-11. Proceed to the post-release steps:
+11. **(final release only)** Show the release to the world:
 
-    1. **(final release only)** Open a PR to
+    1. Send an email to
+       [`cert-manager-dev@googlegroups.com`](https://groups.google.com/g/cert-manager-dev)
+       with the `release` label
+       ([examples](https://groups.google.com/g/cert-manager-dev?label=release)).
+
+    2. Send a tweet
+       ([example](https://twitter.com/MaartjeME/status/1286327362121084928))
+       and make sure [@JetstackHQ](https://twitter.com/JetstackHQ) retweets it.
+
+12. Proceed to the post-release steps:
+
+    1. **(final release only)** Add the new final release to the
+       [supported-releases](/docs/installation/supported-releases/) page.
+
+    2. **(final release only)** Open a PR to
        [`jetstack/testing`](https://github.com/jetstack/testing) and change Prow's
        config. To do this, take inspiration from [Maartje's PR
        example](https://github.com/jetstack/testing/pull/397/files).
 
-    2. **(final release only)** Push a new release branch to
+    3. **(final release only)** Push a new release branch to
        [`jetstack/cert-manager`](https://github.com/jetstack/cert-manager). If the
        final release is `v1.0.0`, then push the new branch `release-1.1`:
 
@@ -414,34 +433,8 @@ page if a step is missing or if it is outdated.
         git push origin release-1.1
         ```
 
-    3. **(final release only)** Open a PR to
+    4. **(final release only)** Open a PR to
        [`cert-manager/website`](https://github.com/cert-manager/website) with
        updates to the website configuration. To do this, take inspiration from
        [Maartje's PR
        example](ttps://github.com/cert-manager/website/pull/309/files).
-
-## Patch Releases
-
-A patch release contains critical bug fixes for the project. They are managed on
-an ad-hoc basis, and should only be required when critical bugs/regressions are
-found in the release.
-
-We will only perform patch release for the **current** version of cert-manager.
-
-Once a new minor release has been cut, we will stop providing patches for the
-version before it.
-
-### Release Schedule
-
-Patch releases are cut on an ad-hoc basis, depending on recent activity on the
-release branch.
-
-### Process for Releasing a Patch Version
-
-The process for cutting a patch release is as follows:
-
-1. Ensure that all PRs have been cherry-picked into the release branch, e.g. `release-1.0`
-
-    Bugs that need to be fixed in a patch release should be [cherry picked into the appropriate release branch](../contributing-flow/#cherry-picking).
-
-2. Then, continue with the instructions in [process for releasing a version](#process-for-releasing-a-version).

--- a/content/en/docs/installation/supported-releases.md
+++ b/content/en/docs/installation/supported-releases.md
@@ -1,0 +1,262 @@
+---
+title: "Supported Releases"
+linkTitle: "Supported Releases"
+weight: 5
+type: "docs"
+---
+
+<!--
+Inspired by https://istio.io/latest/about/supported-releases/
+-->
+
+This page lists the status, timeline and policy for currently supported
+releases.
+
+Each release is supported for a period of four months, and we create a new
+release every two months.
+
+## Supported releases {#supported-releases}
+
+| Release | Release Date |        EOL        | [Supported Kubernetes versions][s] |
+| ------- | :----------: | :---------------: | :--------------------------------: |
+| [1.3][] | Apr 08, 2021 |   [~][]Aug 2021   | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
+| [1.2][] | Feb 10, 2021 | [~][]Jun 11, 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
+
+## Upcoming releases
+
+| Release |   Release Date    |      EOL      | [Supported Kubernetes versions][s] |
+| ------- | :---------------: | :-----------: | :--------------------------------: |
+| [1.4][] | [~][]Jun 11, 2021 | [~][]Oct 2021 |                TBC                 |
+
+> The `~` sign is used when the date is uncertain and might change; the
+> "EOL" abbreviation stands for End Of Life.
+
+## Old releases
+
+| Release  | Release Date |     EOL      | Compatible Kubernetes versions |
+| -------- | :----------: | :----------: | :----------------------------: |
+| [1.1][]  | Nov 24, 2021 | Apr 08, 2021 |          1.11 → 1.21           |
+| [1.0][]  | Sep 02, 2020 | Feb 10, 2021 |          1.11 → 1.21           |
+| [0.16][] | Jul 23, 2020 | Nov 24, 2020 |          1.11 → 1.21           |
+| [0.15][] | May 06, 2020 | Sep 02, 2020 |          1.11 → 1.21           |
+| [0.14][] | Mar 11, 2020 | Jul 23, 2020 |          1.11 → 1.21           |
+| [0.13][] | Jan 21, 2020 | May 06, 2020 |          1.11 → 1.21           |
+| [0.12][] | Nov 27, 2019 | Mar 11, 2020 |          1.11 → 1.21           |
+| [0.11][] | Oct 10, 2019 | Jan 21, 2020 |           1.9 → 1.21           |
+
+[s]: #kubernetes-supported-versions
+[~]: https://docs.google.com/document/d/1Tc5t6ylY9dhXAan1OjOoldeaoys1Yh4Ir710ATfBa5U/edit?pli=1#bookmark=id.jzi02xg0ngn "Project timeline"
+[1.4]: https://github.com/jetstack/cert-manager/milestone/25
+[1.3]: https://cert-manager.io/docs/release-notes/release-notes-1.3
+[1.2]: https://cert-manager.io/docs/release-notes/release-notes-1.2
+[1.1]: https://cert-manager.io/docs/release-notes/release-notes-1.1
+[1.0]: https://cert-manager.io/docs/release-notes/release-notes-1.0
+[0.16]: https://cert-manager.io/docs/release-notes/release-notes-0.16
+[0.15]: https://cert-manager.io/docs/release-notes/release-notes-0.15
+[0.14]: https://cert-manager.io/docs/release-notes/release-notes-0.14
+[0.13]: https://cert-manager.io/docs/release-notes/release-notes-0.13
+[0.12]: https://cert-manager.io/docs/release-notes/release-notes-0.12
+[0.11]: https://cert-manager.io/docs/release-notes/release-notes-0.11
+
+You can find available releases on the [releases
+page](https://github.com/cert-manager/cert-manager/releases). You can find
+the release notes for each minor release
+[here](https://cert-manager.io/docs/release-notes/), and the upgrade
+instructions are
+[here](https://cert-manager.io/docs/installation/upgrading/). The
+cert-manager release process is documented on the [release-process
+page](https://cert-manager.io/docs/contributing/release-process/).
+
+## Support policy
+
+### What we mean by support
+
+Our support window is four months for each release branch. In the below
+diagram, `release-1.2` is an example of a release branch. The support
+window corresponds to the two latest releases, given that we produce a new
+final release every two months. We offer two types of support:
+
+- [Technical support](#technical-support),
+- [Security and bug fixes](#bug-fixes-support).
+
+For example, imagining that the latest release is `v1.2.0`, you can expect
+support for both `v1.2.0` and `v1.1.0`. Only the last patch release of each
+branch is actually supported.
+
+```diagram
+   v1.0.0                                                          ^
+ Sep 2, 2020                                                       | UNSUPPORTED
+------+---------------------------------------------> release-1.0  | RELEASES
+       \                                                           v
+        \
+         \       v1.1.0
+          \    Nov 24, 2021                                        ^
+           ---------+-------------------------------> release-1.1  |
+                     \                                             | SUPPORTED
+                      \                                            | RELEASES
+                       \         v1.2.0                            | = the two
+                        \      Feb 10, 2021                        |   last
+                         ------------+--------------> release-1.2  |   releases
+                                      \                            v
+                                       \
+                                        \
+                                         \
+                                          -----------> master branch
+                                                       April 1, 2021
+```
+
+### Technical support {#technical-support}
+
+Technical assistance is offered on a best-effort basis for supported
+releases only. You can request support from the community on [Kubernetes
+Slack](https://slack.k8s.io/) (in the `#cert-manager` channel), using
+[GitHub Discussions][discussions] or using the [cert-manager-dev][group]
+Google group.
+
+[discussions]: https://github.com/jetstack/cert-manager/discussions
+[group]: https://groups.google.com/g/cert-manager-dev
+
+### Security and bug fixes {#bug-fixes-support}
+
+We back-port important bug fixes — including security fixes — to all
+currently supported releases.
+
+- [Security issues](#security-issues),
+- [Critical bugs](#critical-bugs),
+- [Long-standing bugs](#long-standing-bugs).
+
+#### Security issues {#security-issues}
+
+**Security issues** are fixed as soon as possible. They get back-ported to
+the last two releases, and a new patch release is immediately created for
+them.
+
+#### Critical bugs {#critical-bugs}
+
+**Critical bugs** include both regression bugs as well as upgrade bugs.
+
+Regressions are functionalities that worked in a previous release but no
+longer work. [#3393][] and [#2857][] are two examples of regressions.
+
+Upgrade bugs are issues (often Helm-related) preventing users from
+upgrading to currently supported releases from earlier releases of
+cert-manager. [#3882][] and [#3644][] are examples of upgrade bugs.
+
+Note that [intentional breaking changes](#breaking-changes) do not belong
+to this category.
+
+Once merged to the master branch, fixes for critical bugs are not
+immediately back-ported. Instead, we wait until the next final release for
+triggering a patch release. The patch release will be made for all
+supported release, but note that since we do only support the two last
+releases, a single patch release is made for the last release.
+
+In the example below, the release branches `release-1.2` and `release-1.3`
+are the two supported releases at the time of the release of 1.3.0, which
+means that critical bug fixes 1 and 2 will only be back-ported to
+`release-1.2` and not to `release-1.1`:
+
+```diagram
+   v1.2.1                                v1.2.2
+------+-------------------------------------+-----------> release-1.2
+       \      backport ^  backport ^        ^
+        \     commit  /   commit  /         | v1.2.2 is created
+         \           /           /          | along with v1.3.0
+          \         /           /
+           \       /           /
+            \     /           /          v1.3.0
+             --------master-----------------+-----------> release-1.3
+                 ^           ^               \
+                 |           |                \
+                 |           |                 \
+           critical      critical               \
+           bug fix 1     bug fix 2               \
+           merged to     merged to                \
+           master        master                    ------> master
+```
+
+<!-- Diagram source: https://textik.com/#7c4096204b3c0ad3 -->
+
+#### Long-standing bugs {#long-standing-bugs}
+
+**Long-standing bug**: sometimes a bug exists for a long time, and may have
+known workarounds. [#3444][] is an example of a long-standing bug.
+
+Where we feel that back-porting would be difficult or might be a stability
+risk to clusters running cert-manager, we'll make the fix in a major
+release but avoid back-porting the fix.
+
+#### Breaking changes {#breaking-changes}
+
+Breaking changes are changes that intentionally break the cert-manager
+Kubernetes API or the command line flags. We avoid making breaking changes
+where possible, and where they're required we'll give as much notice as
+possible.
+
+[#3393]: https://github.com/jetstack/cert-manager/issues/3393 "Broken CloudFlare DNS01 challenge"
+[#2857]: https://github.com/jetstack/cert-manager/issues/2857 "CloudDNS DNS01 challenge crashes cert-manager"
+[#3444]: https://github.com/jetstack/cert-manager/issues/3444 "Certificates do not get immediately updated after updating them"
+[#3882]: https://github.com/jetstack/cert-manager/pull/3882: "Helm upgrade from v1.2 to v1.2 impossible due to a Helm bug"
+[#3644]: https://github.com/jetstack/cert-manager/issues/3644 "Helm upgrade from v1.2 to v1.2 impossible due to a Helm bug"
+
+## How we determine supported Kubernetes versions {#kubernetes-supported-versions}
+
+The list of supported Kubernetes versions displayed in the [Supported
+Releases](#supported-releases) section depends on what the cert-manager
+maintainers think is reasonable to support and to test.
+
+Our testing coverage is:
+
+| Release branch | Prow configuration            | Dashboard                 | Kubernetes versions tested   |  Periodicity  |
+| :------------: | :---------------------------- | :------------------------ | :--------------------------- | :-----------: |
+|      PRs       | [`presubmits.yaml`][]         | [`presubmits-blocking`][] | 1.20                         |  On each PR   |
+|     master     | [`periodics.yaml`][]          | [`master`][]              | 1.16, 1.17, 1.18, 1.19, 1.20 | Every 2 hours |
+|  release-1.4   | [`next-periodics.yaml`][]     | [`next`][]                | 1.16, 1.17, 1.18, 1.19, 1.20 | Every 2 hours |
+|  release-1.3   | [`previous-periodics.yaml`][] | [`previous`][]            | 1.16, 1.17, 1.18, 1.19, 1.20 | Every 2 hours |
+|  release-1.2   | N/A                           |                           | N/A                          |      N/A      |
+
+[`presubmits.yaml`]: https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/cert-manager-presubmits.yaml
+[`periodics.yaml`]: https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/cert-manager-periodics.yaml
+[`next-periodics.yaml`]: https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+[`previous-periodics.yaml`]: https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+[`presubmits-blocking`]: https://testgrid.k8s.io/jetstack-cert-manager-presubmits-blocking
+[`master`]: https://testgrid.k8s.io/jetstack-cert-manager-master
+[`next`]: https://testgrid.k8s.io/jetstack-cert-manager-next
+[`previous`]: https://testgrid.k8s.io/jetstack-cert-manager-previous
+
+## Terminology
+
+The term "release" (or "minor release") refers to one minor version of
+cert-manager. For example, 1.2 and 1.3 are two releases. Note that we do
+not use the prefix `v` for releases (just "1.2"). This is because releases
+are not used as git tags.
+
+Patch releases use the `v` prefix (e.g., `v1.2.0`, `v1.3.1`...) since one
+patch release = one git tag. The initial patch release is called "final
+release":
+
+| Type of release | Example of git tag | Corresponding release | Corresponding release branch\* |
+| --------------- | ------------------ | --------------------- | ------------------------------ |
+| Final release   | `v1.3.0`           | 1.3                   | `release-1.3`                  |
+| Patch release   | `v1.3.1`           | 1.3                   | `release-1.3`                  |
+| Pre-release     | `v1.4.0-alpha.0`   | N/A\*\*               | `release-1.4`                  |
+
+\*For maintainers: each release has an associated long-lived branch that we
+call the “release branch”. For example, `release-1.2` is the release branch
+for release 1.2.
+
+\*\*Pre-releases (e.g., `v1.3.0-alpha.0`) don't have a corresponding
+release (e.g., 1.3) since a release only exists after a final release
+(e.g., `v1.3.0`) has been created.
+
+Our naming scheme mostly follows [Semantic Versioning
+2.0.0](https://semver.org/) with `v` prepended to git tags and docker
+images:
+
+```plain
+v<major>.<minor>.<patch>
+```
+
+where `<minor>` is increased for each release, and `<patch>` counts the
+number of patches for the current `<minor>` release. A patch is usually a
+small change relative to the `<minor>` release.


### PR DESCRIPTION
As discussed in this morning's standup, here is a proposition for a new page that would live at `https://cert-manager.io/docs/installation/supported-releases`

| 🔰 https://deploy-preview-452--cert-manager.netlify.app/docs/installation/supported-releases/ 🔰 |
|:---:|


The page is inspired by Istio's https://istio.io/latest/about/supported-releases.

I also propose to have a "live" timeline where we can quickly edit the dates at the top of the [biweekly dev meeting notes](https://docs.google.com/document/d/1Tc5t6ylY9dhXAan1OjOoldeaoys1Yh4Ir710ATfBa5U/edit#).

<img alt="Project timeline in the biweekly dev meeting notes" src="https://user-images.githubusercontent.com/2195781/113007095-32d63680-9176-11eb-98ae-d0bfcbded99f.png" width="300">

I also added links to this timeline table inside the "Supported releases" page:

<img alt="link-to-the-live-timeline" src="https://user-images.githubusercontent.com/2195781/113007516-9496a080-9176-11eb-9bfb-d9796857e4dc.png" width="300">

Related:
- https://kubernetes.io/docs/reference/using-api/deprecation-guide/