### PR TITLE
Use the X.509 typography instead of "x509"

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -180,7 +180,6 @@ whitespace
 wildcard
 wildcards
 WIP
-x509
 YAML
 YAMLs
 awskms-issuer
@@ -209,3 +208,136 @@ ArtifactHub
 CryptoKey
 Encrypter
 cmrel
+
+# As per the RFCs, X.509 is the right spelling. x509 and X509 are
+# misspellings.
+
+X.509
+
+# Since the Markdown files in content/en/*-docs are copied over from the
+# cert-manager repository using fixed tags, we can't expect these files to
+# contain the right X.509 spelling. The following is a series of exceptions
+# so that the x509 spelling is accepted in those files.
+
+ - content/en/next-docs/concepts/certificate.md
+x509
+ - content/en/next-docs/concepts/certificaterequest.md
+x509
+ - content/en/next-docs/concepts/webhook.md
+x509
+ - content/en/next-docs/release-notes/release-notes-0.13.md
+x509
+ - content/en/next-docs/release-notes/release-notes-0.15.md
+x509
+ - content/en/next-docs/release-notes/release-notes-0.16.md
+x509
+ - content/en/next-docs/release-notes/release-notes-0.5.md
+x509
+ - content/en/next-docs/release-notes/release-notes-0.6.md
+x509
+ - content/en/next-docs/release-notes/release-notes-0.7.md
+x509
+ - content/en/next-docs/release-notes/release-notes-0.9.md
+x509
+ - content/en/next-docs/tutorials/venafi/venafi.md
+x509
+ - content/en/next-docs/usage/certificate.md
+x509
+ - content/en/next-docs/usage/kubectl-plugin.md
+x509
+ - content/en/v0.12-docs/concepts/certificate.md
+x509
+ - content/en/v0.12-docs/concepts/certificaterequest.md
+x509
+ - content/en/v0.12-docs/release-notes/release-notes-0.5.md
+x509
+ - content/en/v0.12-docs/release-notes/release-notes-0.6.md
+x509
+ - content/en/v0.12-docs/release-notes/release-notes-0.7.md
+x509
+ - content/en/v0.12-docs/release-notes/release-notes-0.9.md
+x509
+ - content/en/v0.12-docs/tutorials/venafi/venafi.md
+x509
+ - content/en/v0.12-docs/usage/certificate.md
+x509
+ - content/en/v0.13-docs/concepts/certificate.md
+x509
+ - content/en/v0.13-docs/concepts/certificaterequest.md
+x509
+ - content/en/v0.13-docs/release-notes/release-notes-0.13.md
+x509
+ - content/en/v0.13-docs/release-notes/release-notes-0.5.md
+x509
+ - content/en/v0.13-docs/release-notes/release-notes-0.6.md
+x509
+ - content/en/v0.13-docs/release-notes/release-notes-0.7.md
+x509
+ - content/en/v0.13-docs/release-notes/release-notes-0.9.md
+x509
+ - content/en/v0.13-docs/tutorials/venafi/venafi.md
+x509
+ - content/en/v0.13-docs/usage/certificate.md
+x509
+ - content/en/v0.14-docs/concepts/certificate.md
+x509
+ - content/en/v0.14-docs/concepts/certificaterequest.md
+x509
+ - content/en/v0.14-docs/release-notes/release-notes-0.13.md
+x509
+ - content/en/v0.14-docs/release-notes/release-notes-0.5.md
+x509
+ - content/en/v0.14-docs/release-notes/release-notes-0.6.md
+x509
+ - content/en/v0.14-docs/release-notes/release-notes-0.7.md
+x509
+ - content/en/v0.14-docs/release-notes/release-notes-0.9.md
+x509
+ - content/en/v0.14-docs/tutorials/venafi/venafi.md
+x509
+ - content/en/v0.14-docs/usage/certificate.md
+x509
+ - content/en/v0.15-docs/concepts/certificate.md
+x509
+ - content/en/v0.15-docs/concepts/certificaterequest.md
+x509
+ - content/en/v0.15-docs/release-notes/release-notes-0.13.md
+x509
+ - content/en/v0.15-docs/release-notes/release-notes-0.15.md
+x509
+ - content/en/v0.15-docs/release-notes/release-notes-0.5.md
+x509
+ - content/en/v0.15-docs/release-notes/release-notes-0.6.md
+x509
+ - content/en/v0.15-docs/release-notes/release-notes-0.7.md
+x509
+ - content/en/v0.15-docs/release-notes/release-notes-0.9.md
+x509
+ - content/en/v0.15-docs/tutorials/venafi/venafi.md
+x509
+ - content/en/v0.15-docs/usage/certificate.md
+x509
+ - content/en/v0.16-docs/concepts/certificate.md
+x509
+ - content/en/v0.16-docs/concepts/certificaterequest.md
+x509
+ - content/en/v0.16-docs/release-notes/release-notes-0.13.md
+x509
+ - content/en/v0.16-docs/release-notes/release-notes-0.15.md
+x509
+ - content/en/v0.16-docs/release-notes/release-notes-0.16.md
+x509
+ - content/en/v0.16-docs/release-notes/release-notes-0.5.md
+x509
+ - content/en/v0.16-docs/release-notes/release-notes-0.6.md
+x509
+ - content/en/v0.16-docs/release-notes/release-notes-0.7.md
+x509
+ - content/en/v0.16-docs/release-notes/release-notes-0.9.md
+x509
+ - content/en/v0.16-docs/tutorials/venafi/venafi.md
+x509
+ - content/en/v0.16-docs/usage/certificate.md
+x509
+ - content/en/v0.16-docs/usage/kubectl-plugin.md
+x509

--- a/.spelling
+++ b/.spelling
@@ -209,8 +209,8 @@ CryptoKey
 Encrypter
 cmrel
 
-# As per the RFCs, X.509 is the right spelling. x509 and X509 are
-# misspellings.
+# As per https://tools.ietf.org/html/rfc5280, the spelling "X.509" is the
+# correct spelling. The spelling "x509" and "X509" are incorrect.
 
 X.509
 

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -11,7 +11,7 @@ title = "cert-manager"
 	</div>
 	<div class="col-md-7 col-lg-8 order-xs-2 order-sm-2 order-md-2">
 		<h1>cert-manager</h1>
-		<p class="lead mt-2">x509 certificate management for Kubernetes</p>
+		<p class="lead mt-2">X.509 certificate management for Kubernetes</p>
 		<div class="mx-auto mt-5">
 			<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "docs" >}}">
 				Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>

--- a/content/en/docs/concepts/certificate.md
+++ b/content/en/docs/concepts/certificate.md
@@ -5,13 +5,13 @@ weight: 200
 type: "docs"
 ---
 
-cert-manager has the concept of `Certificates` that define a desired x509
+cert-manager has the concept of `Certificates` that define a desired X.509
 certificate which will be renewed and kept up to date. A `Certificate` is a
 namespaced resource that references an `Issuer` or `ClusterIssuer` that
 determine what will be honoring the certificate request.
 
 When a `Certificate` is created, a corresponding `CertificateRequest` resource
-is created by cert-manager containing the encoded x509 certificate request,
+is created by cert-manager containing the encoded X.509 certificate request,
 `Issuer` reference, and other options based upon the specification of the
 `Certificate` resource.
 

--- a/content/en/docs/concepts/certificaterequest.md
+++ b/content/en/docs/concepts/certificaterequest.md
@@ -6,7 +6,7 @@ type: "docs"
 ---
 
 The `CertificateRequest` is a namespaced resource in cert-manager that is used
-to request x509 certificates from an [`Issuer`](../issuer/). The resource
+to request X.509 certificates from an [`Issuer`](../issuer/). The resource
 contains a base64 encoded string of a PEM encoded certificate request which is
 sent to the referenced issuer. A successful issuance will return a signed
 certificate, based on the certificate signing request. `CertificateRequests` are
@@ -61,8 +61,8 @@ actions to take next on the resource. Each condition consists of the pair
 `Ready` - a boolean value, and `Reason` - a string. The set of values and
 meanings are as follows:
 
-| Ready | Reason  | Condition Meaning                                                                                                                                                                                                                             |
-|-------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| False | Pending | The `CertificateRequest` is currently pending, waiting for some other operation to take place. This could be that the `Issuer` does not exist yet or the `Issuer` is in the process of issuing a certificate.                                       |
+| Ready | Reason  | Condition Meaning                                                                                                                                                                                                                               |
+| ----- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| False | Pending | The `CertificateRequest` is currently pending, waiting for some other operation to take place. This could be that the `Issuer` does not exist yet or the `Issuer` is in the process of issuing a certificate.                                   |
 | False | Failed  | The certificate has failed to be issued - either the returned certificate failed to be decoded or an instance of the referenced issuer used for signing failed. No further action will be taken on the `CertificateRequest` by it's controller. |
-| True  | Issued  | A signed certificate has been successfully issued by the referenced `Issuer`.                                                                                                                                                                 |
+| True  | Issued  | A signed certificate has been successfully issued by the referenced `Issuer`.                                                                                                                                                                   |

--- a/content/en/docs/concepts/webhook.md
+++ b/content/en/docs/concepts/webhook.md
@@ -104,7 +104,7 @@ Then compare that with the certificates that are being used by the webhook serve
 kubectl -n cert-manager get secrets cert-manager-webhook-ca  -o yaml
 ```
 
-You should be able to decode the `ca.crt` x509 content from that secret and see that the CA matches that which we saw in the webhook configuration.
+You should be able to decode the `ca.crt` X.509 content from that secret and see that the CA matches that which we saw in the webhook configuration.
 
 You should also find that the `tls.crt` content has a certificate signed by that same CA.
 

--- a/content/en/docs/release-notes/release-notes-0.13.md
+++ b/content/en/docs/release-notes/release-notes-0.13.md
@@ -17,11 +17,11 @@ that a user is somehow associated with some other entity, like an account in the
 With EAB support, it's now possible to specify additional parameters (`spec.acme.externalAccountBinding`) on your ACME
 Issuer resource and utilize cert-manager with your preferred ACME provider.
 
-## Support for full set of x509 'subject' parameters
+## Support for full set of X.509 'subject' parameters
 
-In this release, support for the full range of 'subject' parameters as per the x509 specification has been added.
+In this release, support for the full range of 'subject' parameters as per the X.509 specification has been added.
 This means you can set fields like `organizationalUnit`, `provinces`, `serialNumber`, `country`, and all other standard
-x509 subject fields.
+X.509 subject fields.
 
 A big thanks to [`@mathianasj`](https://github.com/mathianasj) for this addition!
 
@@ -29,7 +29,7 @@ A big thanks to [`@mathianasj`](https://github.com/mathianasj) for this addition
 
 For the growing ecosystem of developers creating their own 'external issuer types' for cert-manager, we have added
 support for a new 'status condition' type `InvalidRequest` - this can be used to signal from your signer/issuer to
-cert-manager that the parameters that the user has requested on the x509 CSR are 'invalid' and the CSR should **not**
+cert-manager that the parameters that the user has requested on the X.509 CSR are 'invalid' and the CSR should **not**
 be retried.
 
 This prevents users expending API quotas and making requests that will never succeed.
@@ -49,11 +49,11 @@ This prevents users expending API quotas and making requests that will never suc
 
 - Adds `InvalidRequest` condition type to `CertificateRequest`, signaling to not retry the request. ([#2508](https://github.com/jetstack/cert-manager/pull/2508), [`@JoshVanL`](https://github.com/JoshVanL))
 - Add volume and volume mounts field to cert-manager helm chart ([#2504](https://github.com/jetstack/cert-manager/pull/2504), [`@joshuastern`](https://github.com/joshuastern))
-- Add support for additional x509 'subject' fields ([#2518](https://github.com/jetstack/cert-manager/pull/2518), [`@mathianasj`](https://github.com/mathianasj))
+- Add support for additional X.509 'subject' fields ([#2518](https://github.com/jetstack/cert-manager/pull/2518), [`@mathianasj`](https://github.com/mathianasj))
 - Bump `k8s.io/*` dependencies to Kubernetes 1.17.0 ([#2452](https://github.com/jetstack/cert-manager/pull/2452), [`@munnerz`](https://github.com/munnerz))
 - It is now possible to disable `AppArmor` when Pod Security Policies are used. ([#2489](https://github.com/jetstack/cert-manager/pull/2489), [`@czunker`](https://github.com/czunker))
 - Support for arbitrary `securityContext` parameters ([#2455](https://github.com/jetstack/cert-manager/pull/2455), [`@nefischer`](https://github.com/nefischer))
-- Remove misleading 'error decoding x509 certificate' message ([#2470](https://github.com/jetstack/cert-manager/pull/2470), [`@munnerz`](https://github.com/munnerz))
+- Remove misleading 'error decoding X.509 certificate' message ([#2470](https://github.com/jetstack/cert-manager/pull/2470), [`@munnerz`](https://github.com/munnerz))
 - Remove IP address validation on `dns01-recursive-nameservers` to allow domain names ([#2428](https://github.com/jetstack/cert-manager/pull/2428), [`@haines`](https://github.com/haines))
 - Optional `webhook.securityContext` and `cainjector.securityContext` chart parameters to specify pods security context. ([#2449](https://github.com/jetstack/cert-manager/pull/2449), [`@nefischer`](https://github.com/nefischer))
 - webhook: register HTTP handlers for `pprof` debug endpoints ([#2450](https://github.com/jetstack/cert-manager/pull/2450), [`@munnerz`](https://github.com/munnerz))

--- a/content/en/docs/release-notes/release-notes-0.15.md
+++ b/content/en/docs/release-notes/release-notes-0.15.md
@@ -19,7 +19,7 @@ As usual, please read the [upgrade notes](/docs/installation/upgrading/upgrading
 ## Experimental controllers
 
 The Certificate controller is one of the most commonly used controllers in the project.
-It represents the 'full lifecycle' of an x509 private key and certificate, including
+It represents the 'full lifecycle' of an X.509 private key and certificate, including
 private key management and renewal.
 
 As the project is maturing, more requirements around this controller are starting to become

--- a/content/en/docs/release-notes/release-notes-0.16.md
+++ b/content/en/docs/release-notes/release-notes-0.16.md
@@ -17,7 +17,7 @@ As usual, please read the [upgrade notes](/docs/installation/upgrading/upgrading
 ## New certificate controller
 
 The Certificate controller is one of the most commonly used controllers in the project.
-It represents the 'full lifecycle' of an x509 private key and certificate, including
+It represents the 'full lifecycle' of an X.509 private key and certificate, including
 private key management and renewal.
 
 In `v0.15` we added the new certificate controllers under a feature gate to allow users to test these and gather feedback.
@@ -37,7 +37,7 @@ The `kubectl cert-manager create certificaterequest` command creates a new Certi
 resource based on the YAML manifest of a Certificate resource as specified by `--from-certificate-file` flag.
  
 For example this will create a CertificateRequest resource with the name "my-cr" based on the Certificate described in `my-certificate.yaml` while storing the
-private key and x509 certificate in `my-cr.key` and `my-cr.crt` respectively.
+private key and X.509 certificate in `my-cr.key` and `my-cr.crt` respectively.
 ```console
 $ kubectl cert-manager create certificaterequest my-cr --from-certificate-file my-certificate.yaml --fetch-certificate --timeout 20m
 ```

--- a/content/en/docs/release-notes/release-notes-0.5.md
+++ b/content/en/docs/release-notes/release-notes-0.5.md
@@ -21,7 +21,7 @@ A number of new fields have been added to the Certificate resource type:
 - `isCA` - allows generating certificates with the 'signing' usage set
 - `organization` - allows specifying values for the 'O' field of Certificates (for supported providers)
 
-New fields like this make cert-manager more useful for applications beyond just securing Ingress, as well as allowing users to continue meeting their security requirements for x509 certificates.
+New fields like this make cert-manager more useful for applications beyond just securing Ingress, as well as allowing users to continue meeting their security requirements for X.509 certificates.
 
 ## New ACME DNS providers
 This release includes two new DNS provides for the ACME Issuer:

--- a/content/en/docs/release-notes/release-notes-0.6.md
+++ b/content/en/docs/release-notes/release-notes-0.6.md
@@ -9,7 +9,7 @@ The long-awaited `v0.6` release is here! This release includes a huge number of 
 
 We've made a big focus on the ACME implementation, as well as improving the general user-experience when requesting certificates.
 
-We've exposed new x509 certificate fields via the Certificate resource type, as well as improving support for these options across all Issuer types.
+We've exposed new X.509 certificate fields via the Certificate resource type, as well as improving support for these options across all Issuer types.
 
 As of the `v0.6` release being cut, we've also reached a huge 99 code contributors! This is incredible to see, and we're thankful to all those who have contributed in all forms over the last couple of years!
 

--- a/content/en/docs/release-notes/release-notes-0.7.md
+++ b/content/en/docs/release-notes/release-notes-0.7.md
@@ -82,7 +82,7 @@ reason, this information will be displayed when running `kubectl get` and
 - Allow to use PKCS#8 encoded private keys in CA issuers. (#1191, `@chr-fritz`)
 - Add webhook troubleshooting guide (#1288, `@munnerz`)
 - Overhaul documentation and add additional content (#1279, `@munnerz`)
-- Increase x509 certificate duration from 90 days to 1 year for webhook component certificates (#1276, `@munnerz`)
+- Increase X.509 certificate duration from 90 days to 1 year for webhook component certificates (#1276, `@munnerz`)
 - Fix bug where `--dns01-recursive-nameservers` flag was not respected when looking up the zone to update for a DNS01 challenge (#1266, `@munnerz`)
 - Reuse acme clients to limit use of nonce/directory/accounts endpoints (#1265, `@DanielMorsing`)
 - Surface self-check errors in challenge resource (#1244, `@DanielMorsing`)

--- a/content/en/docs/release-notes/release-notes-0.9.md
+++ b/content/en/docs/release-notes/release-notes-0.9.md
@@ -49,7 +49,7 @@ This release includes changes from:
 ### New `CertificateRequest` Resource
 
 A new resource has been introduced - `CertificateRequest` - that is used to
-request certificates using a raw x509 certificate signing request. This resource
+request certificates using a raw X.509 certificate signing request. This resource
 is not typically used by humans but rather by other controllers or services. For
 example, the `Certificate` controller will now create a `CertificateRequest`
 resource to resolve its own Spec.

--- a/content/en/docs/tutorials/venafi/venafi.md
+++ b/content/en/docs/tutorials/venafi/venafi.md
@@ -389,7 +389,7 @@ applications.
 Full information on how to specify and request Certificate resources can be
 found in the [Issuing certificates](../../../usage/certificate/) guide.
 
-For now, we will create a basic x509 Certificate that is valid for our domain,
+For now, we will create a basic X.509 Certificate that is valid for our domain,
 `example.com`:
 
 ```yaml

--- a/content/en/docs/usage/certificate.md
+++ b/content/en/docs/usage/certificate.md
@@ -94,7 +94,7 @@ The `Certificate` will be issued using the issuer named `ca-issuer` in the
 > Note: Take care when setting the `renewBefore` field to be very close to the
 > `duration` as this can lead to a renewal loop, where the `Certificate` is always
 > in the renewal period. Some `Issuers` set the `notBefore` field on their
-> issued x509 certificates before the issue time to fix clock-skew issues,
+> issued X.509 certificates before the issue time to fix clock-skew issues,
 > leading to the working duration of a certificate to be less than the full
 > duration of the certificate. For example, Let's Encrypt sets it to be one hour
 > before issue time, so the actual *working duration* of the certificate is 89

--- a/content/en/docs/usage/kubectl-plugin.md
+++ b/content/en/docs/usage/kubectl-plugin.md
@@ -112,15 +112,15 @@ To create a cert-manager CertificateRequest, use `kubectl cert-manager create ce
 and creates a new CertificateRequest resource based on the YAML manifest of a Certificate resource as specified by `--from-certificate-file` flag, by generating a private key locally and creating a 'certificate signing request' 
 to be submitted to a cert-manager Issuer. The private key will be written to a local file, where the default is `<name_of_cr>.key`, or it can be specified using the `--output-key-file` flag.
 
-If you wish to wait for the CertificateRequest to be signed and store the x509 certificate in a file, you can set
+If you wish to wait for the CertificateRequest to be signed and store the X.509 certificate in a file, you can set
 the `--fetch-certificate` flag. The default timeout when waiting for the issuance of the certificate is 5 minutes,
-but can be specified with the `--timeout` flag. The default name of the file storing the x509 certificate
+but can be specified with the `--timeout` flag. The default name of the file storing the X.509 certificate
 is `<name_of_cr>.crt`, you can use the ` --output-certificate-file` flag to specify otherwise.
 
-Note that the private key and the x509 certificate are both written to file, and are **not** stored inside Kubernetes.
+Note that the private key and the X.509 certificate are both written to file, and are **not** stored inside Kubernetes.
 
 For example this will create a CertificateRequest resource with the name "my-cr" based on the cert-manager Certificate described in `my-certificate.yaml` while storing the
-private key and x509 certificate in `my-cr.key` and `my-cr.crt` respectively.
+private key and X.509 certificate in `my-cr.key` and `my-cr.crt` respectively.
 ```console
 kubectl cert-manager create certificaterequest my-cr --from-certificate-file my-certificate.yaml --fetch-certificate --timeout 20m
 ```


### PR DESCRIPTION
Looks like we started using the "x509" typography everywhere, but shouldn't we use "X.509" instead as started in [RFC 5280](https://tools.ietf.org/html/rfc5280) 😅

At first, I went with a quick PCRE which replaces all occurrences of `x509` except when it is used in the context of `openssl x509`:

```sh
perl -pi~ -n -e 's/(?<!openssl )x509/X.509/g' content/en/**/*.md && rm content/en/**/*.md~
```

But then I released that this change only fixes the spelling for the current documentation (i.e., master), not for all the other release branches from which we generate some parts of the website:


| branch       | spelling is fixed? | PR fixing the spelling |
| ------------ | :----------------: | ---------------------- |
| master       |         ✅          | #453                   |
| release-next |         ❌          |                        |
| release-1.2  |         ❌          |                        |
| release-1.1  |         ❌          |                        |
| release-0.12 |         ❌          |                        |
| release-0.13 |         ❌          |                        |
| release-0.14 |         ❌          |                        |
| release-0.15 |         ❌          |                        |
| release-0.16 |         ❌          |                        |


So I ignored all the above non-fixed branches with the following in `.spelling`:

```sh
# As per https://tools.ietf.org/html/rfc5280, "X.509" is the correct spelling.
# The spellings "x509" and "X509" are misspellings.
X.509

# Since the Markdown files in content/en/*-docs are copied over from the
# cert-manager repository using fixed tags, we can't expect these files to
# contain the right X.509 spelling. The following is a series of exceptions
# so that the x509 spelling is accepted in those files.
 - content/en/next-docs/concepts/certificate.md
x509
 - content/en/next-docs/concepts/certificaterequest.md
x509
 - content/en/next-docs/concepts/webhook.md
x509
 - content/en/next-docs/release-notes/release-notes-0.13.md
x509
 - content/en/next-docs/release-notes/release-notes-0.15.md
x509
 - content/en/next-docs/release-notes/release-notes-0.16.md
x509
 - content/en/next-docs/release-notes/release-notes-0.5.md
x509
 - content/en/next-docs/release-notes/release-notes-0.6.md
x509
 - content/en/next-docs/release-notes/release-notes-0.7.md
x509
 - content/en/next-docs/release-notes/release-notes-0.9.md
x509
 - content/en/next-docs/tutorials/venafi/venafi.md
x509
 - content/en/next-docs/usage/certificate.md
x509
 - content/en/next-docs/usage/kubectl-plugin.md
x509
 - content/en/v0.12-docs/concepts/certificate.md
x509
 - content/en/v0.12-docs/concepts/certificaterequest.md
x509
 - content/en/v0.12-docs/release-notes/release-notes-0.5.md
x509
 - content/en/v0.12-docs/release-notes/release-notes-0.6.md
x509
 - content/en/v0.12-docs/release-notes/release-notes-0.7.md
x509
 - content/en/v0.12-docs/release-notes/release-notes-0.9.md
x509
 - content/en/v0.12-docs/tutorials/venafi/venafi.md
x509
 - content/en/v0.12-docs/usage/certificate.md
x509
 - content/en/v0.13-docs/concepts/certificate.md
x509
 - content/en/v0.13-docs/concepts/certificaterequest.md
x509
 - content/en/v0.13-docs/release-notes/release-notes-0.13.md
x509
 - content/en/v0.13-docs/release-notes/release-notes-0.5.md
x509
 - content/en/v0.13-docs/release-notes/release-notes-0.6.md
x509
 - content/en/v0.13-docs/release-notes/release-notes-0.7.md
x509
 - content/en/v0.13-docs/release-notes/release-notes-0.9.md
x509
 - content/en/v0.13-docs/tutorials/venafi/venafi.md
x509
 - content/en/v0.13-docs/usage/certificate.md
x509
 - content/en/v0.14-docs/concepts/certificate.md
x509
 - content/en/v0.14-docs/concepts/certificaterequest.md
x509
 - content/en/v0.14-docs/release-notes/release-notes-0.13.md
x509
 - content/en/v0.14-docs/release-notes/release-notes-0.5.md
x509
 - content/en/v0.14-docs/release-notes/release-notes-0.6.md
x509
 - content/en/v0.14-docs/release-notes/release-notes-0.7.md
x509
 - content/en/v0.14-docs/release-notes/release-notes-0.9.md
x509
 - content/en/v0.14-docs/tutorials/venafi/venafi.md
x509
 - content/en/v0.14-docs/usage/certificate.md
x509
 - content/en/v0.15-docs/concepts/certificate.md
x509
 - content/en/v0.15-docs/concepts/certificaterequest.md
x509
 - content/en/v0.15-docs/release-notes/release-notes-0.13.md
x509
 - content/en/v0.15-docs/release-notes/release-notes-0.15.md
x509
 - content/en/v0.15-docs/release-notes/release-notes-0.5.md
x509
 - content/en/v0.15-docs/release-notes/release-notes-0.6.md
x509
 - content/en/v0.15-docs/release-notes/release-notes-0.7.md
x509
 - content/en/v0.15-docs/release-notes/release-notes-0.9.md
x509
 - content/en/v0.15-docs/tutorials/venafi/venafi.md
x509
 - content/en/v0.15-docs/usage/certificate.md
x509
 - content/en/v0.16-docs/concepts/certificate.md
x509
 - content/en/v0.16-docs/concepts/certificaterequest.md
x509
 - content/en/v0.16-docs/release-notes/release-notes-0.13.md
x509
 - content/en/v0.16-docs/release-notes/release-notes-0.15.md
x509
 - content/en/v0.16-docs/release-notes/release-notes-0.16.md
x509
 - content/en/v0.16-docs/release-notes/release-notes-0.5.md
x509
 - content/en/v0.16-docs/release-notes/release-notes-0.6.md
x509
 - content/en/v0.16-docs/release-notes/release-notes-0.7.md
x509
 - content/en/v0.16-docs/release-notes/release-notes-0.9.md
x509
 - content/en/v0.16-docs/tutorials/venafi/venafi.md
x509
 - content/en/v0.16-docs/usage/certificate.md
x509
 - content/en/v0.16-docs/usage/kubectl-plugin.md
x509
```

In order to be able to remove all the above exceptions, we have to fix the spelling in the individual branches. The current PR only focus on master.
