### PR TITLE
Add security context to Route53 dns01 documentation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -209,3 +209,4 @@ ArtifactHub
 CryptoKey
 Encrypter
 cmrel
+filesystem

--- a/content/en/docs/configuration/acme/dns01/route53.md
+++ b/content/en/docs/configuration/acme/dns01/route53.md
@@ -232,12 +232,25 @@ metadata:
     eks.amazonaws.com/role-arn: arn:aws:iam::XXXXXXXXXXX:role/cert-manager
 ```
 
-The cert-manager Helm chart provides a variable for injecting annotations into cert-manager's `ServiceAccount` object like so:
+You will also need to modify the cert-manager deployment with the correct filesystem permissions, so the serviceaccount token can be read.
+
+```yaml
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1001
+```
+
+The cert-manager Helm chart provides a variable for injecting annotations into cert-manager's `ServiceAccount` and `Deployment` object like so:
 
 ```yaml
 serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::XXXXXXXXXXX:role/cert-manager
+securityContext:
+  enabled: true
+  fsGroup: 1001
 ```
 
 **Note:** If you're following the Cross Account example above, modify the `ClusterIssuer` in the same way as above with the role from Account Y.

--- a/content/en/docs/configuration/acme/dns01/route53.md
+++ b/content/en/docs/configuration/acme/dns01/route53.md
@@ -232,7 +232,7 @@ metadata:
     eks.amazonaws.com/role-arn: arn:aws:iam::XXXXXXXXXXX:role/cert-manager
 ```
 
-You will also need to modify the cert-manager deployment with the correct filesystem permissions, so the serviceaccount token can be read.
+You will also need to modify the cert-manager `Deployment` with the correct filesystem permissions, so the `ServiceAccount` token can be read.
 
 ```yaml
 spec:


### PR DESCRIPTION
Using a `ServiceAccount` without modifying the deployments `securityContext` will cause a permissions error as described in https://github.com/jetstack/cert-manager/issues/2147. This documents how to solve this problem per https://github.com/jetstack/cert-manager/issues/2147#issuecomment-540542406