### PR TITLE
Fix ingress examples for the new API

### DIFF
--- a/content/en/docs/tutorials/acme/example/ingress-tls-final.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress-tls-final.yaml
@@ -16,6 +16,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Exact
         backend:
-          serviceName: kuard
-          servicePort: 80
+          service:
+            name: kuard
+            port:
+              number: 80

--- a/content/en/docs/tutorials/acme/example/ingress-tls.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress-tls.yaml
@@ -16,6 +16,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Exact
         backend:
-          serviceName: kuard
-          servicePort: 80
+          service:
+            name: kuard
+            port:
+              number: 80

--- a/content/en/docs/tutorials/acme/example/ingress.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress.yaml
@@ -16,6 +16,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Exact
         backend:
-          serviceName: kuard
-          servicePort: 80
+          service:
+            name: kuard
+            port:
+              number: 80

--- a/content/en/docs/tutorials/venafi/venafi.md
+++ b/content/en/docs/tutorials/venafi/venafi.md
@@ -567,9 +567,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Exact
         backend:
-          serviceName: hello-kubernetes
-          servicePort: 80
+          service:
+            name: kuard
+            port:
+              number: 80
 ```
 
 You can then apply this resource with:


### PR DESCRIPTION
The Ingress resource structure is a little bit different between `extensions/v1beta1` and `networking.k8s.io/v1`, so a few of our examples are now invalid since changing to `networking.k8s.io/v1`.

Signed-off-by: irbekrm <irbekrm@gmail.com>