### PR TITLE
Update _index.md

### DIFF
--- a/content/en/docs/configuration/acme/dns01/_index.md
+++ b/content/en/docs/configuration/acme/dns01/_index.md
@@ -173,6 +173,7 @@ Links to these supported providers along with their documentation are below:
 - [`cert-manager-webhook-selectel`](https://github.com/selectel/cert-manager-webhook-selectel)
 - [`cert-manager-webhook-softlayer`](https://github.com/cgroschupp/cert-manager-webhook-softlayer)
 - [`cert-manager-webhook-ibmcis`](https://github.com/jb-dk/cert-manager-webhook-ibmcis)
+- [`cert-manager-webhook-loopia`](https://github.com/Identitry/cert-manager-webhook-loopia)
 
 You can find more information on how to configure webhook providers
 [here](./webhook/).


### PR DESCRIPTION
Adding a link to cert-manager-webhook-loopia, a new Webhook for Loopia (https://loopia.com).
Signed-off-by: Henrik Nilsson <henrik.nilsson@identitry.com>