### PR TITLE
Update ingress.md

### DIFF
--- a/content/en/docs/usage/ingress.md
+++ b/content/en/docs/usage/ingress.md
@@ -33,10 +33,13 @@ spec:
   - host: example.com
     http:
       paths:
-      - backend:
-          serviceName: myservice
-          servicePort: 80
+      - pathType: Prefix
         path: /
+        backend:
+          service:
+            name: myservice
+            port: 
+              number: 80
   tls: # < placing a host in the TLS config will indicate a certificate should be created
   - hosts:
     - example.com


### PR DESCRIPTION
Correct the ingress example to correctly match the api version (v1), adding the mandatory spec.rules[*].http.paths[*].pathType key/value and rewriting the spec.rules[*].http.paths[*].backend to the new format.