### PR TITLE
Add minimum supported Bazel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ To run all the verify checks, run:
 
 This will automatically run a number of checks against your changes.
 
-There is also a `./scripts/verify-release` command which will fetch all
-versions of the documentation content before running the regular `verify`
-script.
+If `./scripts/verify` fails with a number of `..target not found..` errors, you
+can run  `./scripts/verify-release` instead, which will fetch all versions of the
+documentation content before running the regular `verify` script.

--- a/content/en/docs/contributing/building.md
+++ b/content/en/docs/contributing/building.md
@@ -8,6 +8,7 @@ type: "docs"
 cert-manager makes use of [Bazel](https://bazel.build/) to build the project. 
 Bazel manages all developer dependencies, Helm chart building, Docker images and the code itself. 
 We try to use it as much as possible.
+We currently use Bazel `v3.7.2`. The minimum supported version is `v3.5.0`.
 
 > **TIP**: are you using GoLand? Make sure to exclude the `bazel-` folders! You can do this by right clicking on the folder -> Mark Directory As -> Excluded
 > This will save you a ton of CPU time!


### PR DESCRIPTION
I thought it could be useful for contributors to see what version of Bazel they should have.

Signed-off-by: irbekrm <irbekrm@gmail.com>