### PR TITLE
Document the transition to Venafi Cloud OutagePREDICT

### DIFF
--- a/content/en/docs/configuration/venafi.md
+++ b/content/en/docs/configuration/venafi.md
@@ -32,6 +32,13 @@ resources, read the [Namespaces](../../concepts/issuer/#namespaces) section.
 
 ### Creating a Venafi Cloud Issuer
 
+⚠ From cert-manager `v1.3` you will need to update your Venafi Cloud configuration to use `OutagePREDICT` instead of `DevOpsACCELERATE`.
+With this update, the zone format changes from a UUID to a string of the form `<Application Name>\<Issuing Template Alias>`.
+Please read [cert-manager 1.2 to 1.3 upgrade notes][] and [Venafi Cloud Prerequisites][] for further information.
+
+[cert-manager 1.2 to 1.3 upgrade notes]: ../../installation/upgrading/upgrading-1.2-1.3/
+[Venafi Cloud Prerequisites]: https://github.com/Venafi/vcert/blob/v4.13.1/README-CLI-CLOUD.md#prerequisites
+
 In order to set up a Venafi Cloud `Issuer`, you must first create a Kubernetes
 `Secret` resource containing your Venafi Cloud API credentials:
 
@@ -68,7 +75,7 @@ metadata:
   namespace: <NAMESPACE YOU WANT TO ISSUE CERTIFICATES IN>
 spec:
   venafi:
-    zone: "801bdbd0-8587-11ea-b487-4d978b4efe3d" # Set this to the GUID of the Venafi policy zone you want to use
+    zone: "My Application\My CIT" # Set this to <Application Name>\<Issuing Template Alias>
     cloud:
       apiTokenSecretRef:
         name: cloud-secret

--- a/content/en/docs/installation/upgrading/upgrading-1.2-1.3.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.2-1.3.md
@@ -1,0 +1,34 @@
+---
+title: "Upgrading from v1.2 to v1.3"
+linkTitle: "v1.2 to v1.3"
+weight: 800
+type: "docs"
+---
+
+## Upgrade notes for users of the Venafi Cloud Issuer
+
+This release updates the [Venafi Cloud Issuer][] to use `OutagePREDICT` instead of `DevOpsACCELERATE`.
+
+The only impact to Venafi Cloud users is the change in zone syntax.
+The zone is now `<Application Name>\<Issuing Template Alias>`
+(e.g. `My Application\My CIT`).
+
+### Background
+
+Venafi are currently transitioning Venafi Cloud users to the `OutagePREDICT` ("OP") product,
+from `DevOpsACCELERATE` ("DA"), which will be sunset later in 2021.
+
+The [Venafi Cloud Issuer][] in cert-manager relies upon the `VCert` library,
+and the [`VCert` `v4.13.0`][] release marks this "DA2OP" transition.
+The `VCert` module dependencies in cert-manager have been updated in order for cert-manager to complete the transition as well.
+
+With this update, cert-manager users with Venafi Cloud issuers will need to be aware that the zone format changes from a UUID (DA Zone ID) to a string of the form `<Application Name>\<Issuing Template Alias>`.
+This means users will need to create an Application in `OutagePREDICT` and associate an _Issuing Template_ with it
+(the same _Issuing Templates_ assigned to DA Projects Zones can be used since _Issuing Templates_ are shared between Venafi Cloud products).
+
+[Venafi Cloud Issuer]: https://cert-manager.io/docs/configuration/venafi/
+[`VCert` `v4.13.0`]: https://github.com/Venafi/vcert/releases/tag/v4.13.0
+
+## Next Steps
+
+You should now follow the [regular upgrade process](../).

--- a/content/en/docs/release-notes/_index.md
+++ b/content/en/docs/release-notes/_index.md
@@ -9,6 +9,7 @@ no_list: true
 Here you will find a link to all release notes for each version release of
 cert-manager:
 
+- [`v1.3`](./release-notes-1.3/)
 - [`v1.2`](./release-notes-1.2/)
 - [`v1.1`](./release-notes-1.1/)
 - [`v1.0`](./release-notes-1.0/)

--- a/content/en/docs/release-notes/release-notes-1.3.md
+++ b/content/en/docs/release-notes/release-notes-1.3.md
@@ -1,0 +1,27 @@
+---
+title: "Release Notes"
+linkTitle: "v1.3"
+weight: 800
+type: "docs"
+---
+
+Please read the [upgrade notes](/docs/installation/upgrading/upgrading-1.2-1.3/) before upgrading.
+
+Aside from that, there have been numerous bug fixes and features summarized below.
+
+# Breaking Changes
+
+## Venafi Cloud Issuer
+
+This release updates the [Venafi Cloud Issuer][] to use `OutagePREDICT` instead of `DevOpsACCELERATE`.
+
+The only impact to Venafi Cloud users is the change in zone syntax.
+The zone is now `<Application Name>\<Issuing Template Alias>`
+(e.g. `My Application\My CIT`).
+
+[Venafi Cloud Issuer]: https://cert-manager.io/docs/configuration/venafi/
+
+# New Features
+
+
+# Bug Fixes


### PR DESCRIPTION
Added some release notes, upgrade notes and Venafi Issuer documentation updates based on the words by @tr1ck3r in #3642 and in https://github.com/Venafi/vcert/blob/v4.13.1/README-CLI-CLOUD.md

Fixes: https://github.com/jetstack/cert-manager/issues/3642