### PR TITLE
add SECURITY.md pointing at main cert-manager repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Vulnerability Reporting Process
+
+Security is the number one priority for cert-manager. If you think you've
+found a vulnerability in the cert-manager website, or in any cert-manager
+project, please follow the [vulnerability reporting process](https://github.com/jetstack/cert-manager/blob/master/SECURITY.md)
+documented in the main cert-manager repository.

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -16,8 +16,9 @@ external cert-manager components:
 - [DCO sign off](./sign-off/)
 - [Developing with kind](./kind/)
 - [Running end-to-end tests](./e2e/)
-- [Release process](release-process/)
-- [Feature policy](policy/)
+- [Release process](./release-process/)
+- [Feature policy](./policy/)
+- [Reporting security vulnerabilities](./security/)
 
 ## Welcome
 

--- a/content/en/docs/contributing/security.md
+++ b/content/en/docs/contributing/security.md
@@ -1,0 +1,15 @@
+---
+title: "Reporting Security Issues"
+linkTitle: "Reporting Security Issues"
+weight: 80
+type: "docs"
+---
+
+Security is the number one priority for cert-manager. If you think you've
+found a vulnerability in any cert-manager project, please follow the
+[vulnerability reporting process](https://github.com/jetstack/cert-manager/blob/master/SECURITY.md)
+documented in the main cert-manager repository.
+
+The reporting process is the same for all repositories under the
+cert-manager organization. The process is documented in one place to ensure
+a single source of truth and a single list of [security contacts](https://github.com/jetstack/cert-manager/blob/master/SECURITY_CONTACTS.md).


### PR DESCRIPTION
the intent is to preserve a single source of truth for the reporting
process, and as such the file in this repo just points to the main repo

also adds a page to the "contributing" section of the site, with
similar information.