### PR TITLE
[release-1.2] Fix link check lint

### DIFF
--- a/content/en/docs/installation/upgrading/upgrading-1.1-1.2.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.1-1.2.md
@@ -8,7 +8,7 @@ type: "docs"
 In an effort to introduce new features whilst keeping the project maintainable,
 cert-manager now only supports Kubernetes down to version `v1.16`. This means
 the `legacy` manifests have now been removed. You can read more
-[here](../../../concepts/project-maturity).
+[here](../../../concepts/project-maturity/).
 
 In this release some features have been deprecated.  Please read the [version
 1.2 release notes](../../../release-notes/release-notes-1.2/) for more details


### PR DESCRIPTION
A missed trailing slash caused the link checker lint to fail