### PR TITLE
Non-honoring external issuers: explain their impact

### DIFF
--- a/content/en/docs/concepts/certificaterequest.md
+++ b/content/en/docs/concepts/certificaterequest.md
@@ -88,6 +88,7 @@ the case that the `CertificateRequest` was created by a
 
 
 ### Approval
+
 CertificateRequests can be `Approved` or `Denied`. These mutually exclusive
 conditions gate a CertificateRequest from being signed by its managed signer.
 

--- a/content/en/docs/configuration/external.md
+++ b/content/en/docs/configuration/external.md
@@ -21,13 +21,15 @@ external issuer types can be found in the documentation of that external issuer
 project. A list of known external issuer projects that are maintained by their
 authors are as follows:
 
-# Issuers that Honour Approval
+# Issuers compatible with the CertificateRequest Approval
+
 There are currently no external issuers that honour
 [approval](../../concepts/certificaterequest/#approval).
 
-# Issuers that do NOT Honour Approval
+# Issuers ignoring the CertificateRequest Approval
+
 A list of known external issuer projects that are maintained by their authors
-are as follows. These issuers do _not_ honour
+are as follows. These issuers do **not** honour
 [approval](../../concepts/certificaterequest/#approval).
 
 - [step-issuer](https://github.com/smallstep/step-issuer): Used to request


### PR DESCRIPTION
This is a follow-up to https://github.com/cert-manager/website/pull/502 and https://github.com/cert-manager/website/pull/515. A person reading this page might be interested to know what this sentence entails:

> A list of known external issuer projects that are maintained by their authors are as follows. These issuers do not honour approval.

In this ~PR~ empty PR, I propose to find out ways of giving more context around the use of non-honoring issuers.

- [ ] Am I decreasing the security on my cluster when using an issuer that does not honor the Approval API?
- [ ] I still want to be running a non-honoring issuer, is it still going to work, and is it supported?
- [ ] I want to use one issuer that is non-honoring along with another issuer that honors the Approved API. Is it supported?
- [ ] I use an external issuer maintained by vendor X, and this issuer belongs to the list of "non-honoring" issuers. What should I do to have this issuer gain this ability?

Another thought: could we use the words "compatible with the Approval API" and "ignoring the Approval API" instead of honoring/not honoring?