### PR TITLE
Remove pathType from ingress examples so that other resources (i.e. css, js) can be accessed within kuard

### DIFF
--- a/content/en/docs/tutorials/acme/example/ingress-tls-final.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress-tls-final.yaml
@@ -16,7 +16,6 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Exact
         backend:
           service:
             name: kuard

--- a/content/en/docs/tutorials/acme/example/ingress-tls.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress-tls.yaml
@@ -16,7 +16,6 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Exact
         backend:
           service:
             name: kuard

--- a/content/en/docs/tutorials/acme/example/ingress.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress.yaml
@@ -16,7 +16,6 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Exact
         backend:
           service:
             name: kuard


### PR DESCRIPTION
Signed-off-by: Kevin Sullivan <kevin.sullivan5@gmail.com>
