### PR TITLE
Differentiate the types of releases: initial alpha, subsequent alpha, beta, final and patch releases

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -232,6 +232,7 @@ OmairK
 Makefile
 SelfSigned
 justinkillen
+Maartje
 
 # As per https://tools.ietf.org/html/rfc5280, the spelling "X.509" is the
 # correct spelling. The spelling "x509" and "X509" are incorrect.

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -90,9 +90,7 @@ release:
    go install github.com/cert-manager/release/cmd/cmrel@master
    ```
 
-3. Clone and `cd` into the `cert-manager/release` repo. ⚠️ All the commands
-   below have to be run from this cloned folder as it contains the necessary
-   `cloudbuild.yml` files.
+3. Clone the `cert-manager/release` repo:
 
    ```sh
    # Don't clone it from inside the cert-manager repo folder.

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -180,12 +180,7 @@ page if a step is missing or if it is outdated.
        git remote -v | grep origin
        ```
 
-       You should see:
-
-       ```text
-       origin  https://github.com/jetstack/cert-manager (fetch)
-       origin  https://github.com/jetstack/cert-manager (push)
-       ```
+       You should see `https://github.com/jetstack/cert-manager`.
 
     2. Push the release branch:
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -285,7 +285,7 @@ page if a step is missing or if it is outdated.
     2.  While the build is running, send a first Slack message to
         `#cert-manager-dev`:
 
-        <div class="pageinfo pageinfo-primary">
+        <div class="pageinfo pageinfo-primary"><p>
         Releasing <code>1.2.0-alpha.2</code> 🧵
         </p></div>
 
@@ -299,7 +299,7 @@ page if a step is missing or if it is outdated.
         Cloud Build job link that `cmrel` displayed in "View logs at". For
         example, the message would look like:
 
-        <div class="pageinfo pageinfo-primary">
+        <div class="pageinfo pageinfo-primary"><p>
         Follow the <code>cmrel stage</code> build: https://console.cloud.google.com/cloud-build/builds/7641734d-fc3c-42e7-9e4c-85bfc4d1d547?project=1021342095237
         </p></div>
 
@@ -334,7 +334,7 @@ page if a step is missing or if it is outdated.
     3.  While the build is running, send a third Slack message in reply to
         the first message:
 
-        <div class="pageinfo pageinfo-primary">
+        <div class="pageinfo pageinfo-primary"><p>
         Follow the `cmrel publish` dry-run build: https://console.cloud.google.com/cloud-build/builds16f6f875-0a23-4fff-b24d-3de0af207463?project=1021342095237
         </p></div>
 
@@ -361,7 +361,7 @@ page if a step is missing or if it is outdated.
     5.  While the build is running, send a fourth Slack message in reply to
         the first message:
 
-        <div class="pageinfo pageinfo-primary">
+        <div class="pageinfo pageinfo-primary"><p>
         Follow the <code>cmrel publish</code> build: https://console.cloud.google.com/cloud-build/builds/b6fef12b-2e81-4486-9f1f-d00592351789?project=1021342095237
         </p></div>
 
@@ -380,7 +380,7 @@ page if a step is missing or if it is outdated.
     check box "Also send to `#cert-manager-dev`" so that the message is well
     visible. Also cross-post the message on `#cert-manager`.
 
-    <div class="pageinfo pageinfo-primary">
+    <div class="pageinfo pageinfo-primary"><p>
     https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉
     </p></div>
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -23,10 +23,9 @@ following conditions:
    complete all the steps.
 2. You currently need to be at Jetstack to get the required GitHub and GCP
    permissions. (we'd like contributors outside Jetstack to be able to get
-   access; if that's of interest to you, please let us know)
+   access; if that's of interest to you, please let us know).
 3. You need to have the GitHub `write` permission on the cert-manager project.
-   To check that you have the `write` role, [get a personal access
-   token](https://github.com/settings/tokens) and run:
+   To check that you have the `write` role, run:
 
     ```sh
     go install github.com/cli/cli/cmd/gh@latest

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -243,7 +243,7 @@ page if a step is missing or if it is outdated.
         export RELEASE_VERSION="1.3.0-alpha.0"
         ```
 
-    2. Generate `release-note.md` at the root of your cert-manager repo folder
+    2. Generate `release-notes.md` at the root of your cert-manager repo folder
        with the following command:
 
         ```sh

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -145,13 +145,13 @@ page if a step is missing or if it is outdated.
     | patch release            | `v1.3.1`           |
     </br>
 
-1. **(final release only)** Make sure that a PR with the new upgrade document
-   is ready to be merged on
+2. **(final release only)** Make sure that a PR with the new upgrade
+   document is ready to be merged on
    [cert-manager/website](https://github.com/cert-manager/website). See for
    example, see
    [upgrading-1.0-1.1](https://cert-manager.io/docs/installation/upgrading/upgrading-1.0-1.1/).
 
-2. Create or update the release branch:
+3. Create or update the release branch:
 
     - **(initial alpha only)** Create the release branch:
 
@@ -161,9 +161,9 @@ page if a step is missing or if it is outdated.
        git checkout -b release-1.0 origin/master
        ```
 
-    - **(subsequent alpha, beta, final, and patch releases only)**
-      You need to update it with the latest commits from the master branch, as
-      follows:
+    - **(subsequent alpha, beta and final releases only)**; You need to
+      update the release branch with the latest commits from the master
+      branch, as follows:
 
        ```bash
        # Must be run from the cert-manager repo folder.
@@ -173,7 +173,11 @@ page if a step is missing or if it is outdated.
        git merge --ff-only origin/master
        ```
 
-3. Push the new or updated release branch:
+       Patch releases do not require this `git merge --ff-only` step, since
+       the merge is done by opening a PR using the `/cherry-pick
+       release-1.0` command.
+
+4. Push the new or updated release branch:
 
     1. Check that the `origin` remote is correct. To do that, run the following
         command and make sure it returns
@@ -195,7 +199,7 @@ page if a step is missing or if it is outdated.
         `write` or `admin` GitHub permission on the cert-manager repo to create
         or push to the branch, see [requirements](#requirements).
 
-4. Generate and edit the release notes:
+5. Generate and edit the release notes:
 
     1. Use the following two tables to understand how to fill in the four
        environment variables needed for the next step. These four environment
@@ -271,7 +275,7 @@ page if a step is missing or if it is outdated.
     4. **(final release only)** Check the release notes include all changes
        since the last final release.
 
-5. Run `cmrel stage`:
+6. Run `cmrel stage`:
 
     1. In this example we stage a release using the 'release-1.0' branch,
        setting the release version to `v1.0.0`:
@@ -310,7 +314,7 @@ page if a step is missing or if it is outdated.
         Follow the <code>cmrel stage</code> build: https://console.cloud.google.com/cloud-build/builds/7641734d-fc3c-42e7-9e4c-85bfc4d1d547?project=1021342095237
         </p></div>
 
-6. Run `cmrel publish`:
+7. Run `cmrel publish`:
 
     1. Set the `CMREL_RELEASE_NAME` variable in your shell. The value for the
        `CMREL_RELEASE_NAME` variable is found in the output of the previous command,
@@ -369,7 +373,7 @@ page if a step is missing or if it is outdated.
         Follow the <code>cmrel publish</code> build: https://console.cloud.google.com/cloud-build/builds/b6fef12b-2e81-4486-9f1f-d00592351789?project=1021342095237
         </p></div>
 
-7. Publish the GitHub release:
+8. Publish the GitHub release:
 
     1. Visit the draft GitHub release and paste in the release notes that you
        generated earlier. You will need to manually edit the content to match
@@ -382,7 +386,7 @@ page if a step is missing or if it is outdated.
     3. Click "Publish" to make the GitHub release live. This will create a Git
        tag automatically.
 
-8. Finally, post a Slack message as an answer to the first message. Toggle the
+9. Finally, post a Slack message as an answer to the first message. Toggle the
    check box "Also send to `#cert-manager-dev`" so that the message is well
    visible. Also cross-post the message on `#cert-manager`.
 
@@ -390,7 +394,7 @@ page if a step is missing or if it is outdated.
     https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉
     </p></div>
 
-9. Proceed to the post-release steps:
+10. Proceed to the post-release steps:
 
     1. **(final release only)** Open a PR to
        [`jetstack/testing`](https://github.com/jetstack/testing) and change Prow's

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -71,7 +71,6 @@ following conditions:
     [2]: https://console.cloud.google.com/?project=cert-manager-release
     ```
 
-
 {{% /pageinfo %}}
 
 First, ensure that you have all the tools required to perform a cert-manager
@@ -197,7 +196,7 @@ page if a step is missing or if it is outdated.
 
         **(initial alpha only)**: `git push` will only work if you have the
         `write` or `admin` GitHub permission on the cert-manager repo to create
-        or push to the branch, see [requirements](#requirements).
+        or push to the branch, see [prerequisites](#prerequisites).
 
 5. Generate and edit the release notes:
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -343,12 +343,12 @@ page if a step is missing or if it is outdated.
         Follow the `cmrel publish` dry-run build: https://console.cloud.google.com/cloud-build/builds16f6f875-0a23-4fff-b24d-3de0af207463?project=1021342095237
         </p></div>
 
-    4. Next publish the release artifacts for real.
+    4. Next publish the release artifacts for real:
 
-       If the last step succeeded, you can now re-run the `cmrel publish` with
-       the `--nomock` argument to actually publish the release artifacts to
-       GitHub, `Quay.io`, to our [ChartMuseum](https://charts.jetstack.io)
-       instance, etc.
+        If the last step succeeded, you can now re-run the `cmrel publish` with
+        the `--nomock` argument to actually publish the release artifacts to
+        GitHub, `Quay.io`, to our [ChartMuseum](https://charts.jetstack.io)
+        instance, etc.
 
         ```bash
         # Must be run from the "cert-manager/release" repo folder.
@@ -376,8 +376,10 @@ page if a step is missing or if it is outdated.
        generated earlier. You will need to manually edit the content to match
        the style of earlier releases. In particular, remember to remove
        package-related changes.
+
     2. **(initial alpha, subsequent alpha and beta only)** Tick the box "This is
        a pre-release".
+
     3. Click "Publish" to make the GitHub release live. This will create a Git
        tag automatically.
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -27,21 +27,27 @@ following conditions:
 3. You need to have the GitHub `write` permission on the cert-manager project.
    To check that you have the `write` role, [get a personal access
    token](https://github.com/settings/tokens) and run:
-     ```sh
-     GH_USER=maelvls
-     curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/jetstack/cert-manager/collaborators/$GH_USER/permission
-     ```
-     If your permission is `write` or `admin`, then you are good to go:
-     ```json
-     {
-      "permission": "write",
-      "user": {...}
-     }
-     ```
 
-    To request the `write` permission on the cert-manager project, [open a
+   ```sh
+   go install github.com/cli/cli/cmd/gh@latest
+   gh auth login
+   gh api /repos/jetstack/cert-manager/collaborators/$(gh api /user | jq -r .login)/permission
+   ```
+
+   You should see something like:
+
+   ```json
+   {
+    "permission": "write",
+    "user": {...}
+   }
+   ```
+
+   If your permission is `write` or `admin`, then you are good to go. To request
+   the `write` permission on the cert-manager project, [open a
    PR](https://github.com/jetstack/platform-board/pulls/new) with a link to
    here.
+
 4. You need to be added as an "Editor" to the GCP project
    [cert-manager-release](https://console.cloud.google.com/?project=cert-manager-release).
    To check if you do have access, try opening [the Cloud Build
@@ -49,6 +55,7 @@ following conditions:
    To get the "Editor" permission on the GCP project, open a [new
    PR](https://github.com/jetstack/platform-board/pulls/new) and copy-paste the
    below example template:
+
    ```markdown
    <!-- PR title: Access to the cert-manager-release GCP project -->
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -77,46 +77,54 @@ following conditions:
    [2]: https://console.cloud.google.com/?project=cert-manager-release
    ```
 
-{{% /pageinfo %}}
+</p></div>
 
 First, ensure that you have all the tools required to perform a cert-manager
 release:
 
 1. Install the [`release-notes`](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md) CLI:
+
    ```sh
    go install k8s.io/release/cmd/release-notes@v0.7.0
    ```
+
 2. Install our [`cmrel`](https://github.com/cert-manager/release) CLI:
+
    ```sh
    go install github.com/cert-manager/release/cmd/cmrel@master
    ```
+
 3. Clone and `cd` into the `cert-manager/release` repo. ⚠️ All the commands
-   below have to be run from this  cloned folder as it contains the
-   necessary `cloudbuild.yml` files.
-     ```sh
-     # Don't clone it from inside the cert-manager repo folder.
-     git clone https://github.com/cert-manager/release
-     cd release
-     ```
-6. Install the [`gcloud`](https://cloud.google.com/sdk/) CLI.
-7. [Login](https://cloud.google.com/sdk/docs/authorizing#running_gcloud_auth_login)
+   below have to be run from this cloned folder as it contains the necessary
+   `cloudbuild.yml` files.
+
+   ```sh
+   # Don't clone it from inside the cert-manager repo folder.
+   git clone https://github.com/cert-manager/release
+   cd release
+   ```
+
+4. Install the [`gcloud`](https://cloud.google.com/sdk/) CLI.
+5. [Login](https://cloud.google.com/sdk/docs/authorizing#running_gcloud_auth_login)
    to `gcloud`:
 
    ```sh
    gcloud auth application-default login
    ```
-8. Make sure `gcloud` points to the cert-manager-release project:
+
+6. Make sure `gcloud` points to the cert-manager-release project:
 
    ```sh
    gcloud config set project cert-manager-release
    ```
-9.  Get a GitHub access token [here](https://github.com/settings/tokens)
+
+7. Get a GitHub access token [here](https://github.com/settings/tokens)
    with no scope ticked. It is used only by the `release-notes` CLI to
    avoid API rate limiting since it will go through all the PRs one by one.
 
 ## Minor Releases
 
-A minor release is a backwards-compatible 'feature' release.  It can contain new
+A minor release is a backwards-compatible 'feature' release. It can contain new
 features and bug fixes.
 
 ### Release Schedule
@@ -128,16 +136,17 @@ some of these goals are missed, in order to keep up release velocity.
 ### Process for Releasing a Minor Version
 
 {{% pageinfo color="info" %}}
-🔰 Please click on the **Edit this page** button on the top-right corner of this page if a step is missing or if it is outdated.
-{{% /pageinfo %}}
+🔰 Please click on the **Edit this page** button on the top-right corner of this
+page if a step is missing or if it is outdated.
+</p></div>
 
 The process for cutting a minor release is as follows:
 
-1. Ensure upgrading document exists. See for example, see
-   [upgrading-1.0-1.1](https://cert-manager.io/docs/installation/upgrading/upgrading-1.0-1.1/)
-   (not necessary for alpha and patch releases)
+1.  Ensure upgrading document exists. See for example, see
+    [upgrading-1.0-1.1](https://cert-manager.io/docs/installation/upgrading/upgrading-1.0-1.1/)
+    (not necessary for alpha and patch releases)
 
-2. Create or update the release branch
+2.  Create or update the release branch
 
     If this is the first alpha release (`alpha.0`), then you will need to create
     the release branch:
@@ -160,55 +169,54 @@ The process for cutting a minor release is as follows:
     git merge --ff-only origin/master
     ```
 
-3. Push it to the `jetstack/cert-manager` repository
+3.  Push it to the `jetstack/cert-manager` repository
 
-     **Note 1**: run `git remote -v` to check that `origin` points to the
-     upstream <https://github.com/jetstack/cert-manager.git>.
+    **Note 1**: run `git remote -v` to check that `origin` points to the
+    upstream <https://github.com/jetstack/cert-manager.git>.
 
-     **Note 2:** if the branch doesn't already exist, you will need to have the
-     `write` role on the GitHub project to be able to push to the release
-     branch.
+    **Note 2:** if the branch doesn't already exist, you will need to have the
+    `write` role on the GitHub project to be able to push to the release
+    branch.
 
-     ```bash
-     # Must be run from the cert-manager repo folder.
-     git push --set-upstream origin release-1.0
-     ```
+    ```bash
+    # Must be run from the cert-manager repo folder.
+    git push --set-upstream origin release-1.0
+    ```
 
-4. Generate and edit the release notes:
+4.  Generate and edit the release notes:
 
-   1. Use the following two tables to understand how to fill in the four
-      environment variables needed for the next step. These four environment
-      variables are documented on the
-      [README](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md#options)
-      for the Kubernetes `release-notes` tool.
+    1.  Use the following two tables to understand how to fill in the four
+        environment variables needed for the next step. These four environment
+        variables are documented on the
+        [README](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md#options)
+        for the Kubernetes `release-notes` tool.
 
-      | Variable          | Description                           |
-      | ----------------- | ------------------------------------- |
-      | `START_REV`\*     | The git tag of the "previous"\* release |
-      | `END_REV`         | Name of your release branch           |
-      | `BRANCH`          | Name of your release branch           |
-      | `RELEASE_VERSION` | The git tag without the leading `v`   |
+        | Variable          | Description                             |
+        | ----------------- | --------------------------------------- |
+        | `START_REV`\*     | The git tag of the "previous"\* release |
+        | `END_REV`         | Name of your release branch             |
+        | `BRANCH`          | Name of your release branch             |
+        | `RELEASE_VERSION` | The git tag without the leading `v`     |
 
-      Examples for each release type (e.g., initial alpha release):
+        Examples for each release type (e.g., initial alpha release):
 
-      | Variable          | Example 1             | Example 2                | Example 3     | Example 4     |
-      | ----------------- | --------------------- | ------------------------ | ------------- | ------------- |
-      |                   |                       |                          |               |               |
-      |                   | initial alpha release | subsequent alpha release | final release | patch release |
-      |                   | `v1.3.0-alpha.0`      | `v1.3.0-alpha.1`         | `v1.3.0`      | `v1.3.1`      |
-      |                   |                       |                          |               |               |
-      | `START_REV`\*     | `v1.2.0`              | `v1.3.0-alpha.0`         | `v1.2.0`      | `v1.3.0`      |
-      | `END_REV`         | `release-1.3`         | `release-1.3`            | `release-1.3` | `release-1.3` |
-      | `BRANCH`          | `release-1.3`         | `release-1.3`            | `release-1.3` | `release-1.3` |
-      | `RELEASE_VERSION` | `1.3.0-alpha.0`       | `1.3.0-alpha.1`          | `1.3.0`       | `1.3.1`       |
+        | Variable          | Example 1             | Example 2                | Example 3     | Example 4     |
+        | ----------------- | --------------------- | ------------------------ | ------------- | ------------- |
+        |                   |                       |                          |               |               |
+        |                   | initial alpha release | subsequent alpha release | final release | patch release |
+        |                   | `v1.3.0-alpha.0`      | `v1.3.0-alpha.1`         | `v1.3.0`      | `v1.3.1`      |
+        |                   |                       |                          |               |               |
+        | `START_REV`\*     | `v1.2.0`              | `v1.3.0-alpha.0`         | `v1.2.0`      | `v1.3.0`      |
+        | `END_REV`         | `release-1.3`         | `release-1.3`            | `release-1.3` | `release-1.3` |
+        | `BRANCH`          | `release-1.3`         | `release-1.3`            | `release-1.3` | `release-1.3` |
+        | `RELEASE_VERSION` | `1.3.0-alpha.0`       | `1.3.0-alpha.1`          | `1.3.0`       | `1.3.1`       |
 
+        > \*The git tag of the "previous" release (`START_REV`) depends on which
+        > type of release you count on doing. Look at the above examples to
+        > understand a bit more what those are.
 
-      > \*The git tag of the "previous" release (`START_REV`) depends on which
-      > type of release you count on doing. Look at the above examples to
-      > understand a bit more what those are.
-
-      After finding out the value for each of the 4 environment variables, set
-      the variables in your shell (for example, following the example 1):
+        After finding out the value for each of the 4 environment variables, set
+        the variables in your shell (for example, following the example 1):
 
         ```sh
         export START_REV="v1.2.0"
@@ -217,8 +225,8 @@ The process for cutting a minor release is as follows:
         export RELEASE_VERSION="1.3.0-alpha.0"
         ```
 
-   2. Generate `release-note.md` at the root of your cert-manager repo folder
-      with the following command:
+    2.  Generate `release-note.md` at the root of your cert-manager repo folder
+        with the following command:
 
         ```sh
         # Must be run from the cert-manger folder.
@@ -230,14 +238,14 @@ The process for cutting a minor release is as follows:
           --output release-notes.md
         ```
 
-        {{% pageinfo color="info" %}}
-The GitHub token **does not need any scope**. The token is
-required only to avoid rate-limits imposed on anonymous API users.
-        {{% /pageinfo %}}
+        <div class="pageinfo pageinfo-info"><p>
+        The GitHub token **does not need any scope**. The token is required
+        only to avoid rate-limits imposed on anonymous API users.
+        </p></div>
 
-   3. Sanity check the notes, checking that the notes contain details of all
-      the features and bug fixes that you expect to be in the release. Add
-      additional blurb, notable items and characterize change log.
+    3.  Sanity check the notes, checking that the notes contain details of all
+        the features and bug fixes that you expect to be in the release. Add
+        additional blurb, notable items and characterize change log.
 
         You can see the commits that will go into this release by using the
         [GitHub compare](https://github.com/jetstack/cert-manager/compare). For
@@ -246,58 +254,55 @@ required only to avoid rate-limits imposed on anonymous API users.
 
         <https://github.com/jetstack/cert-manager/compare/v1.0.0-beta.1...master>
 
-5. Run `cmrel stage`
+5.  Run `cmrel stage`
 
-   1. In this example we stage a release using the 'release-1.0' branch,
-      setting  the release version to `v1.0.0`:
+    1.  In this example we stage a release using the 'release-1.0' branch,
+        setting the release version to `v1.0.0`:
 
         ```bash
         # Must be run from the "cert-manager/release" repo folder.
         cmrel stage --branch=release-1.0 --release-version=v1.0.0
         ```
 
-        This step takes ~10 minutes. It will build all Docker images and
-        create all the manifest files and upload them to a storage bucket on
-        Google Cloud. These artifacts will be published and released in the
-        next steps.
+        This step takes ~10 minutes. It will build all Docker images and create
+        all the manifest files and upload them to a storage bucket on Google
+        Cloud. These artifacts will be published and released in the next steps.
 
-        {{% pageinfo color="info" %}}
-🔰  Remember to keep open the terminal where you run `cmrel stage`. Its output
-will be used in the next step.
-        {{% /pageinfo %}}
+        <div class="pageinfo pageinfo-info"><p>
+        🔰 Remember to keep open the terminal where you run <code>cmrel stage</code>. Its output will be used in the next step.
+        </p></div>
 
-   2. While the build is running, send a first Slack message to
-      `#cert-manager-dev`:
+    2.  While the build is running, send a first Slack message to
+        `#cert-manager-dev`:
 
-         {{% pageinfo %}}
-Releasing `1.2.0-alpha.2` 🧵
-         {{% /pageinfo %}}
+        <div class="pageinfo pageinfo-primary">
+        Releasing <code>1.2.0-alpha.2</code> 🧵
+        </p></div>
 
+        <div class="pageinfo pageinfo-info"><p>
+        🔰 Please have a quick look at the build log as it might contain some unredacted
+        data that we forgot to redact. We try to make sure the sensitive data is
+        properly redacted but sometimes we forget to update this.
+        </p></div>
 
-         {{% pageinfo color="info" %}}
-🔰 Please have a quick look at the build log as it might contain some unredacted
-data that we forgot to redact. We try to make sure the sensitive data is
-properly redacted but sometimes we forget to update this.
-         {{% /pageinfo %}}
+    3.  Send a second Slack message in reply to this first message with the
+        Cloud Build job link that `cmrel` displayed in "View logs at". For
+        example, the message would look like:
 
-   3. Send a second Slack message in reply to this first message with the
-      Cloud Build job link that `cmrel` displayed in "View logs at". For
-      example, the message would look like:
+        <div class="pageinfo pageinfo-primary">
+        Follow the <code>cmrel stage</code> build: https://console.cloud.google.com/cloud-build/builds/7641734d-fc3c-42e7-9e4c-85bfc4d1d547?project=1021342095237
+        </p></div>
 
-        {{% pageinfo %}}
-Follow the `cmrel stage` build: <https://console.cloud.google.com/cloud-build/builds/7641734d-fc3c-42e7-9e4c-85bfc4d1d547?project=1021342095237>
-        {{% /pageinfo %}}
+6.  Run `cmrel publish`
 
-6. Run `cmrel publish`
-
-   1. Set the `CMREL_RELEASE_NAME` variable in your shell. The value for the
-      `CMREL_RELEASE_NAME` variable is found in the output of the previous
-      command, `cmrel stage`. Look for the line that contains the `gs://` link:
+    1.  Set the `CMREL_RELEASE_NAME` variable in your shell. The value for the
+        `CMREL_RELEASE_NAME` variable is found in the output of the previous command,
+        `cmrel stage`. Look for the line that contains the `gs://` link:
 
         ```sh
-         gs://cert-manager-release/stage/gcb/release/v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08
-                                                     <------------- CMREL_RELEASE_NAME -------------------->
-         ```
+        gs://cert-manager-release/stage/gcb/release/v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08
+        #                                            <------------- CMREL_RELEASE_NAME -------------------------->
+        ```
 
         Copy that part into a variable in your shell:
 
@@ -305,10 +310,10 @@ Follow the `cmrel stage` build: <https://console.cloud.google.com/cloud-build/bu
         export CMREL_RELEASE_NAME=v1.3.0-alpha.0-77b045d159bd20ce0ec454cd79a5edce9187bdd9
         ```
 
-   1. Do a `cmrel publish` dry-run to ensure that all the staged resources are
-      valid. Run the following command:
+    2.  Do a `cmrel publish` dry-run to ensure that all the staged resources are
+        valid. Run the following command:
 
-        ```bash
+        ```sh
         # Must be run from the "cert-manager/release" repo folder.
         cmrel publish --release-name "$CMREL_RELEASE_NAME"
         ```
@@ -316,15 +321,14 @@ Follow the `cmrel stage` build: <https://console.cloud.google.com/cloud-build/bu
         You can view the progress by clicking the Google Cloud Build URL in the
         output of this command.
 
-   2. While the build is running, send a third Slack message in reply to
-      the first message:
+    3.  While the build is running, send a third Slack message in reply to
+        the first message:
 
-        {{% pageinfo %}}
-Follow the `cmrel publish` dry-run build: <https://console.cloud.google.com/cloud-build/builds16f6f875-0a23-4fff-b24d-3de0af207463?project=1021342095237>
-        {{% /pageinfo %}}
+        <div class="pageinfo pageinfo-primary">
+        Follow the `cmrel publish` dry-run build: https://console.cloud.google.com/cloud-build/builds16f6f875-0a23-4fff-b24d-3de0af207463?project=1021342095237
+        </p></div>
 
-
-   3. Next publish the release artifacts for real.
+    4.  Next publish the release artifacts for real.
 
         If the last step succeeded, you can now re-run the `cmrel publish` with
         the `--nomock` argument to actually publish the release artifacts to
@@ -336,38 +340,40 @@ Follow the `cmrel publish` dry-run build: <https://console.cloud.google.com/clou
         cmrel publish --nomock --release-name "$RELEASE_NAME"
         ```
 
-       {{% pageinfo color="warning" %}}
-⏰ At this stage, there will be a draft release on GitHub and a live release on our [ChartMuseum](https://charts.jetstack.io) instance. So you must now complete the
-release process quickly; otherwise, users of the latest release on our ChartMuseum instance will encounter errors because the manual CRD install URL will not be available yet.
-      {{% /pageinfo %}}
+        <div class="pageinfo pageinfo-warning">
+        ⏰ At this stage, there will be a draft release on GitHub and a live
+        release on our ChartMuseum (https://charts.jetstack.io/index.yaml).
+        So you must now complete the release process quickly; otherwise, users
+        of the latest release on our ChartMuseum instance will encounter errors
+        because the manual CRD install URL will not be available yet.
+        </p></div>
 
-   4. While the build is running, send a fourth Slack message in reply to
-      the first message:
+    5.  While the build is running, send a fourth Slack message in reply to
+        the first message:
 
-        {{% pageinfo %}}
-Follow the `cmrel publish` build: <https://console.cloud.google.com/cloud-build/builds/b6fef12b-2e81-4486-9f1f-d00592351789?project=1021342095237>
-        {{% /pageinfo %}}
+        <div class="pageinfo pageinfo-primary">
+        Follow the <code>cmrel publish</code> build: https://console.cloud.google.com/cloud-build/builds/b6fef12b-2e81-4486-9f1f-d00592351789?project=1021342095237
+        </p></div>
 
-7. Publish the GitHub release
+7.  Publish the GitHub release:
 
-   1. Visit the draft GitHub release and paste in the release notes that you generated earlier.
-
-        You will need to manually edit the content to match the style of earlier releases.
-        In particular, remember to remove package-related changes.
-
-   2. Tick the box "This is a pre-release" if your release is an alpha.
-      (not necessary for final releases)
-
-   3. Click "publish" to make the GitHub release live.
-      This will create a Git tag automatically.
+    1. Visit the draft GitHub release and paste in the release notes that you
+       generated earlier. You will need to manually edit the content to match
+       the style of earlier releases. In particular, remember to remove
+       package-related changes.
+    2. Tick the box "This is a pre-release" if your release is an alpha.
+       (not necessary for final releases)
+    3. Click "publish" to make the GitHub release live.
+       This will create a Git tag automatically.
 
 8.  Finally, post a Slack message as an answer to the first message. Toggle
-   the check box "Also send to `#cert-manager-dev`" so that the message is
-   well visible. Also cross-post the message on `#cert-manager`.
+    the check box "Also send to `#cert-manager-dev`" so that the message is
+    well visible. Also cross-post the message on `#cert-manager`.
 
-      {{% pageinfo %}}
-https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉
-      {{% /pageinfo %}}
+    <div class="pageinfo pageinfo-primary">
+
+    https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉
+    </p></div>
 
 ### Final Release
 
@@ -386,7 +392,7 @@ so that it uses the latest release as `release-previous`,
 and you will need to create a new release branch in the cert-manager repository which will be treated as `release-next`,
 and both these branches will be tested periodically.
 
-For example see the PR  [Prepare testing for the cert-manager `v1.0` release](https://github.com/jetstack/testing/pull/397).
+For example see the PR [Prepare testing for the cert-manager `v1.0` release](https://github.com/jetstack/testing/pull/397).
 
 #### Rollover Documentation
 
@@ -396,7 +402,7 @@ For example see the PR [Configure website for the `v1.0` release](https://github
 
 ## Patch Releases
 
-A patch release contains critical bug fixes for the project.  They are managed on
+A patch release contains critical bug fixes for the project. They are managed on
 an ad-hoc basis, and should only be required when critical bugs/regressions are
 found in the release.
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -346,12 +346,9 @@ page if a step is missing or if it is outdated.
         Follow the `cmrel publish` dry-run build: https://console.cloud.google.com/cloud-build/builds16f6f875-0a23-4fff-b24d-3de0af207463?project=1021342095237
         </p></div>
 
-    4. Next publish the release artifacts for real:
-
-        If the last step succeeded, you can now re-run the `cmrel publish` with
-        the `--nomock` argument to actually publish the release artifacts to
-        GitHub, `Quay.io`, to our [ChartMuseum](https://charts.jetstack.io)
-        instance, etc.
+    4. Next publish the release artifacts for real. The following command will
+       publish "for real" the artifacts to GitHub, `Quay.io`, to our
+       [ChartMuseum](https://charts.jetstack.io) instance:
 
         ```bash
         # Must be run from the "cert-manager/release" repo folder.

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -68,7 +68,7 @@ following conditions:
    [2]: https://console.cloud.google.com/?project=cert-manager-release
    ```
 
-</p></div>
+{{% /pageinfo %}}
 
 First, ensure that you have all the tools required to perform a cert-manager
 release:
@@ -129,11 +129,10 @@ some of these goals are missed, in order to keep up release velocity.
 {{% pageinfo color="info" %}}
 🔰 Please click on the **Edit this page** button on the top-right corner of this
 page if a step is missing or if it is outdated.
+{{% /pageinfo %}}
 
-</p></div>
-
-1.  Make sure to note which type of release you are doing. That will be helpful
-    in the next steps.
+1. Make sure to note which type of release you are doing. That will be helpful
+   in the next steps.
 
     | Type of release          | Example of git tag |
     | ------------------------ | ------------------ |
@@ -142,14 +141,15 @@ page if a step is missing or if it is outdated.
     | beta release             | `v1.3.0-beta.0`    |
     | final release            | `v1.3.0`           |
     | patch release            | `v1.3.1`           |
+    </br>
 
-2.  **(final release only)** Make sure that a PR with the new upgrade document
-    is ready to be merged on
-    [cert-manager/website](https://github.com/cert-manager/website). See for
-    example, see
-    [upgrading-1.0-1.1](https://cert-manager.io/docs/installation/upgrading/upgrading-1.0-1.1/).
+1. **(final release only)** Make sure that a PR with the new upgrade document
+   is ready to be merged on
+   [cert-manager/website](https://github.com/cert-manager/website). See for
+   example, see
+   [upgrading-1.0-1.1](https://cert-manager.io/docs/installation/upgrading/upgrading-1.0-1.1/).
 
-3.  Create or update the release branch:
+2. Create or update the release branch:
 
     - **(initial alpha only)** Create the release branch:
 
@@ -171,7 +171,7 @@ page if a step is missing or if it is outdated.
       git merge --ff-only origin/master
       ```
 
-4.  Push the new or updated release branch:
+3. Push the new or updated release branch:
 
     1. Check that the `origin` remote is correct:
 
@@ -193,13 +193,13 @@ page if a step is missing or if it is outdated.
        `write` or `admin` GitHub permission on the cert-manager repo to create
        or push to the branch, see [requirements](#requirements).
 
-5.  Generate and edit the release notes:
+4. Generate and edit the release notes:
 
-    1.  Use the following two tables to understand how to fill in the four
-        environment variables needed for the next step. These four environment
-        variables are documented on the
-        [README](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md#options)
-        for the Kubernetes `release-notes` tool.
+    1. Use the following two tables to understand how to fill in the four
+       environment variables needed for the next step. These four environment
+       variables are documented on the
+       [README](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md#options)
+       for the Kubernetes `release-notes` tool.
 
         | Variable          | Description                             |
         | ----------------- | --------------------------------------- |
@@ -235,8 +235,8 @@ page if a step is missing or if it is outdated.
         export RELEASE_VERSION="1.3.0-alpha.0"
         ```
 
-    2.  Generate `release-note.md` at the root of your cert-manager repo folder
-        with the following command:
+    2. Generate `release-note.md` at the root of your cert-manager repo folder
+       with the following command:
 
         ```sh
         # Must be run from the cert-manger folder.
@@ -253,9 +253,9 @@ page if a step is missing or if it is outdated.
         only to avoid rate-limits imposed on anonymous API users.
         </p></div>
 
-    3.  Sanity check the notes, checking that the notes contain details of all
-        the features and bug fixes that you expect to be in the release. Add
-        additional blurb, notable items and characterize change log.
+    3. Sanity check the notes, checking that the notes contain details of all
+       the features and bug fixes that you expect to be in the release. Add
+       additional blurb, notable items and characterize change log.
 
         You can see the commits that will go into this release by using the
         [GitHub compare](https://github.com/jetstack/cert-manager/compare). For
@@ -264,10 +264,10 @@ page if a step is missing or if it is outdated.
 
         <https://github.com/jetstack/cert-manager/compare/v1.0.0-beta.1...master>
 
-6.  Run `cmrel stage`:
+5. Run `cmrel stage`:
 
-    1.  In this example we stage a release using the 'release-1.0' branch,
-        setting the release version to `v1.0.0`:
+    1. In this example we stage a release using the 'release-1.0' branch,
+       setting the release version to `v1.0.0`:
 
         ```bash
         # Must be run from the "cert-manager/release" repo folder.
@@ -282,8 +282,8 @@ page if a step is missing or if it is outdated.
         🔰 Remember to keep open the terminal where you run <code>cmrel stage</code>. Its output will be used in the next step.
         </p></div>
 
-    2.  While the build is running, send a first Slack message to
-        `#cert-manager-dev`:
+    2. While the build is running, send a first Slack message to
+       `#cert-manager-dev`:
 
         <div class="pageinfo pageinfo-primary"><p>
         Releasing <code>1.2.0-alpha.2</code> 🧵
@@ -295,19 +295,19 @@ page if a step is missing or if it is outdated.
         properly redacted but sometimes we forget to update this.
         </p></div>
 
-    3.  Send a second Slack message in reply to this first message with the
-        Cloud Build job link that `cmrel` displayed in "View logs at". For
-        example, the message would look like:
+    3. Send a second Slack message in reply to this first message with the
+       Cloud Build job link that `cmrel` displayed in "View logs at". For
+       example, the message would look like:
 
-        <div class="pageinfo pageinfo-primary"><p>
+        <div class="pageinfo pageinfo-info"><p>
         Follow the <code>cmrel stage</code> build: https://console.cloud.google.com/cloud-build/builds/7641734d-fc3c-42e7-9e4c-85bfc4d1d547?project=1021342095237
         </p></div>
 
-7.  Run `cmrel publish`:
+6. Run `cmrel publish`:
 
-    1.  Set the `CMREL_RELEASE_NAME` variable in your shell. The value for the
-        `CMREL_RELEASE_NAME` variable is found in the output of the previous command,
-        `cmrel stage`. Look for the line that contains the `gs://` link:
+    1. Set the `CMREL_RELEASE_NAME` variable in your shell. The value for the
+       `CMREL_RELEASE_NAME` variable is found in the output of the previous command,
+       `cmrel stage`. Look for the line that contains the `gs://` link:
 
         ```sh
         gs://cert-manager-release/stage/gcb/release/v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08
@@ -320,8 +320,8 @@ page if a step is missing or if it is outdated.
         CMREL_RELEASE_NAME=v1.3.0-alpha.0-77b045d159bd20ce0ec454cd79a5edce9187bdd9
         ```
 
-    2.  Do a `cmrel publish` dry-run to ensure that all the staged resources are
-        valid. Run the following command:
+    2. Do a `cmrel publish` dry-run to ensure that all the staged resources are
+       valid. Run the following command:
 
         ```sh
         # Must be run from the "cert-manager/release" repo folder.
@@ -331,26 +331,26 @@ page if a step is missing or if it is outdated.
         You can view the progress by clicking the Google Cloud Build URL in the
         output of this command.
 
-    3.  While the build is running, send a third Slack message in reply to
-        the first message:
+    3. While the build is running, send a third Slack message in reply to
+       the first message:
 
         <div class="pageinfo pageinfo-primary"><p>
         Follow the `cmrel publish` dry-run build: https://console.cloud.google.com/cloud-build/builds16f6f875-0a23-4fff-b24d-3de0af207463?project=1021342095237
         </p></div>
 
-    4.  Next publish the release artifacts for real.
+    4. Next publish the release artifacts for real.
 
-        If the last step succeeded, you can now re-run the `cmrel publish` with
-        the `--nomock` argument to actually publish the release artifacts to
-        GitHub, `Quay.io`, to our [ChartMuseum](https://charts.jetstack.io)
-        instance, etc.
+       If the last step succeeded, you can now re-run the `cmrel publish` with
+       the `--nomock` argument to actually publish the release artifacts to
+       GitHub, `Quay.io`, to our [ChartMuseum](https://charts.jetstack.io)
+       instance, etc.
 
         ```bash
         # Must be run from the "cert-manager/release" repo folder.
         cmrel publish --nomock --release-name "$RELEASE_NAME"
         ```
 
-        <div class="pageinfo pageinfo-warning">
+        <div class="pageinfo pageinfo-warning"><p>
         ⏰ At this stage, there will be a draft release on GitHub and a live
         release on our ChartMuseum (https://charts.jetstack.io/index.yaml).
         So you must now complete the release process quickly; otherwise, users
@@ -358,14 +358,14 @@ page if a step is missing or if it is outdated.
         because the manual CRD install URL will not be available yet.
         </p></div>
 
-    5.  While the build is running, send a fourth Slack message in reply to
-        the first message:
+    5. While the build is running, send a fourth Slack message in reply to
+       the first message:
 
         <div class="pageinfo pageinfo-primary"><p>
         Follow the <code>cmrel publish</code> build: https://console.cloud.google.com/cloud-build/builds/b6fef12b-2e81-4486-9f1f-d00592351789?project=1021342095237
         </p></div>
 
-8.  Publish the GitHub release:
+7. Publish the GitHub release:
 
     1. Visit the draft GitHub release and paste in the release notes that you
        generated earlier. You will need to manually edit the content to match
@@ -376,9 +376,9 @@ page if a step is missing or if it is outdated.
     3. Click "Publish" to make the GitHub release live. This will create a Git
        tag automatically.
 
-9.  Finally, post a Slack message as an answer to the first message. Toggle the
-    check box "Also send to `#cert-manager-dev`" so that the message is well
-    visible. Also cross-post the message on `#cert-manager`.
+8. Finally, post a Slack message as an answer to the first message. Toggle the
+   check box "Also send to `#cert-manager-dev`" so that the message is well
+   visible. Also cross-post the message on `#cert-manager`.
 
     <div class="pageinfo pageinfo-primary"><p>
     https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -436,6 +436,6 @@ The process for cutting a patch release is as follows:
 
 1. Ensure that all PRs have been cherry-picked into the release branch, e.g. `release-1.0`
 
-   Bugs that need to be fixed in a patch release should be [cherry picked into the appropriate release branch](../contributing-flow/#cherry-picking).
+    Bugs that need to be fixed in a patch release should be [cherry picked into the appropriate release branch](../contributing-flow/#cherry-picking).
 
-2. Then, continue with the instructions in [process for releasing a minor version](#process-for-releasing-a-minor-version).
+2. Then, continue with the instructions in [process for releasing a version](#process-for-releasing-a-version).

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -28,7 +28,7 @@ following conditions:
    To check that you have the `write` role, run:
 
     ```sh
-    go install github.com/cli/cli/cmd/gh@master
+    brew install gh
     gh auth login
     gh api /repos/jetstack/cert-manager/collaborators/$(gh api /user | jq -r .login)/permission | jq .permission
     ```

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -210,7 +210,7 @@ page if a step is missing or if it is outdated.
         | Variable          | Description                             |
         | ----------------- | --------------------------------------- |
         | `START_REV`\*     | The git tag of the "previous"\* release |
-        | `END_REV`         | Name of your release branch             |
+        | `END_REV`         | Name of your release branch (inclusive) |
         | `BRANCH`          | Name of your release branch             |
         | `RELEASE_VERSION` | The git tag without the leading `v`     |
         </br>
@@ -261,9 +261,13 @@ page if a step is missing or if it is outdated.
         only to avoid rate-limits imposed on anonymous API users.
         </p></div>
 
-    3. Sanity check the notes, checking that the notes contain details of all
-       the features and bug fixes that you expect to be in the release. Add
-       additional blurb, notable items and characterize change log.
+    3. Sanity check the notes:
+
+        - Make sure you haven't duplicated the final release note from the
+          previous release (`START_REV` and `END_REV` are inclusive)
+        - Make sure the notes contain details of all the features and bug
+          fixes that you expect to be in the release.
+        - Add additional blurb, notable items and characterize change log.
 
         You can see the commits that will go into this release by using the
         [GitHub compare](https://github.com/jetstack/cert-manager/compare). For
@@ -386,7 +390,7 @@ page if a step is missing or if it is outdated.
     3. Click "Publish" to make the GitHub release live. This will create a Git
        tag automatically.
 
-9. Finally, post a Slack message as an answer to the first message. Toggle the
+9.  Finally, post a Slack message as an answer to the first message. Toggle the
    check box "Also send to `#cert-manager-dev`" so that the message is well
    visible. Also cross-post the message on `#cert-manager`.
 
@@ -394,7 +398,7 @@ page if a step is missing or if it is outdated.
     https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉
     </p></div>
 
-10. Proceed to the post-release steps:
+11. Proceed to the post-release steps:
 
     1. **(final release only)** Open a PR to
        [`jetstack/testing`](https://github.com/jetstack/testing) and change Prow's

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -28,7 +28,7 @@ following conditions:
    To check that you have the `write` role, run:
 
     ```sh
-    go install github.com/cli/cli/cmd/gh@latest
+    go install github.com/cli/cli/cmd/gh@master
     gh auth login
     gh api /repos/jetstack/cert-manager/collaborators/$(gh api /user | jq -r .login)/permission | jq .permission
     ```

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -28,45 +28,50 @@ following conditions:
    To check that you have the `write` role, [get a personal access
    token](https://github.com/settings/tokens) and run:
 
-   ```sh
-   go install github.com/cli/cli/cmd/gh@latest
-   gh auth login
-   gh api /repos/jetstack/cert-manager/collaborators/$(gh api /user | jq -r .login)/permission | jq .permission
-   ```
+    ```sh
+    go install github.com/cli/cli/cmd/gh@latest
+    gh auth login
+    gh api /repos/jetstack/cert-manager/collaborators/$(gh api /user | jq -r .login)/permission | jq .permission
+    ```
 
-   If your permission is `write` or `admin`, then you are good to go. To request
-   the `write` permission on the cert-manager project, [open a
-   PR](https://github.com/jetstack/platform-board/pulls/new) with a link to
-   here.
+    If your permission is `write` or `admin`, then you are good to go. To request
+    the `write` permission on the cert-manager project, [open a
+    PR](https://github.com/jetstack/platform-board/pulls/new) with a link to
+    here.
 
 4. You need to be added as an "Editor" to the GCP project
    [cert-manager-release](https://console.cloud.google.com/?project=cert-manager-release).
    To check if you do have access, try opening [the Cloud Build
    page](https://console.cloud.google.com/cloud-build?project=cert-manager-release).
-   To get the "Editor" permission on the GCP project, open a [new
-   PR](https://github.com/jetstack/platform-board/pulls/new) and copy-paste the
-   below example template:
+   To get the "Editor" permission on the GCP project, open a PR with your name
+   added to the maintainers list in
+   [cert_manager_release.tf](https://github.com/jetstack/terraform-jetstack/blob/master/cert_manager_release.tf)
 
-   ```markdown
-   <!-- PR title: Access to the cert-manager-release GCP project -->
+    ```diff
+    --- a/cert_manager_release.tf
+    +++ b/cert_manager_release.tf
+    @@ -17,6 +17,7 @@ locals {
+         var.personal_email["..."],
+         var.personal_email["..."],
+         var.personal_email["..."],
+    +    var.personal_email["mael-valais"],
+       ])
+     }
+    ```
 
-   Hi,
+    You may use the following PR description:
 
-   As stated in step 4 under "Prerequisites" on the [release-process][1] page,
-   I need access to the [cert-manager-release][2] project on GCP.
+    ```markdown
+    Title: Access to the cert-manager-release GCP project
 
-   I need to be an "Editor" on this project. More specifically, the roles
-   I need are:
+    Hi. As stated in "Prerequisites" on the [release-process][1] page,
+    I need access to the [cert-manager-release][2] project on GCP in
+    order to perform the release process. Thanks!
 
-   - Cloud Build Editor (`roles/cloudbuild.builds.builder`),
-   - Storage Object Viewer (`roles/storage.objectViewer`), and
-   - Cloud KMS CryptoKey Encrypter (`roles/cloudkms.cryptoKeyEncrypter`)
+    [1]: https://cert-manager.io/docs/contributing/release-process/#prerequisites
+    [2]: https://console.cloud.google.com/?project=cert-manager-release
+    ```
 
-   Thanks!
-
-   [1]: https://cert-manager.io/docs/contributing/release-process/#prerequisites
-   [2]: https://console.cloud.google.com/?project=cert-manager-release
-   ```
 
 {{% /pageinfo %}}
 
@@ -153,45 +158,45 @@ page if a step is missing or if it is outdated.
 
     - **(initial alpha only)** Create the release branch:
 
-      ```bash
-      # Must be run from the cert-manager repo folder.
-      git fetch --all
-      git checkout -b release-1.0 origin/master
-      ```
+       ```bash
+       # Must be run from the cert-manager repo folder.
+       git fetch --all
+       git checkout -b release-1.0 origin/master
+       ```
 
     - **(subsequent alpha, beta, final, and patch releases only)**
       You need to update it with the latest commits from the master branch, as
       follows:
 
-      ```bash
-      # Must be run from the cert-manager repo folder.
-      git fetch --all
-      git branch --force release-1.0 origin/release-1.0
-      git checkout release-1.0
-      git merge --ff-only origin/master
-      ```
+       ```bash
+       # Must be run from the cert-manager repo folder.
+       git fetch --all
+       git branch --force release-1.0 origin/release-1.0
+       git checkout release-1.0
+       git merge --ff-only origin/master
+       ```
 
 3. Push the new or updated release branch:
 
-    1. Check that the `origin` remote is correct:
+    1. Check that the `origin` remote is correct. To do that, run the following
+        command and make sure it returns
+        the upstream `https://github.com/jetstack/cert-manager.git`:
 
-       ```sh
-       # Must be run from the cert-manager repo folder.
-       git remote -v | grep origin
-       ```
-
-       You should see `https://github.com/jetstack/cert-manager`.
+        ```sh
+        # Must be run from the cert-manager repo folder.
+        git remote -v | grep origin
+        ```
 
     2. Push the release branch:
 
-       ```bash
-       # Must be run from the cert-manager repo folder.
-       git push --set-upstream origin release-1.0
-       ```
+        ```bash
+        # Must be run from the cert-manager repo folder.
+        git push --set-upstream origin release-1.0
+        ```
 
-       **(initial alpha only)**: `git push` will only work if you have the
-       `write` or `admin` GitHub permission on the cert-manager repo to create
-       or push to the branch, see [requirements](#requirements).
+        **(initial alpha only)**: `git push` will only work if you have the
+        `write` or `admin` GitHub permission on the cert-manager repo to create
+        or push to the branch, see [requirements](#requirements).
 
 4. Generate and edit the release notes:
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -359,7 +359,7 @@ page if a step is missing or if it is outdated.
 
         ```bash
         # Must be run from the "cert-manager/release" repo folder.
-        cmrel publish --nomock --release-name "$RELEASE_NAME"
+        cmrel publish --nomock --release-name "$CMREL_RELEASE_NAME"
         ```
 
         <div class="pageinfo pageinfo-warning"><p>

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -269,6 +269,9 @@ page if a step is missing or if it is outdated.
 
         <https://github.com/jetstack/cert-manager/compare/v1.0.0-beta.1...master>
 
+    4. **(final release only)** Check the release notes include all changes
+       since the last final release.
+
 5. Run `cmrel stage`:
 
     1. In this example we stage a release using the 'release-1.0' branch,
@@ -391,30 +394,30 @@ page if a step is missing or if it is outdated.
     https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉
     </p></div>
 
-### Final Release
+9. Proceed to the post-release steps:
 
-After releasing one or more alpha and beta releases,
-you will release the final version.
-For the final release, you should follow the process described above with the following changes and additional steps:
+    1. **(final release only)** Open a PR to
+       [jetstack/testing](https://github.com/jetstack/testing) and change Prow's
+       config. To do this, take inspiration from [Maartje's PR
+       example](https://github.com/jetstack/testing/pull/397/files).
 
-#### Full Release Notes
+    2. **(final release only)** Push a new release branch to
+       [jetstack/cert-manager](https://github.com/jetstack/cert-manager).
 
-The release notes for the final release should include all changes since the last minor release.
+        If the final release is `v1.0.0`, then push the new branch
+        `release-1.1`:
 
-#### Rollover Testing Infrastructure
+        ```bash
+        # Must be run from the cert-manager repo folder.
+        git checkout -b release-1.1 v1.0.0
+        git push origin release-1.1
+        ```
 
-After releasing the final release you will need to update the testing infrastructure,
-so that it uses the latest release as `release-previous`,
-and you will need to create a new release branch in the cert-manager repository which will be treated as `release-next`,
-and both these branches will be tested periodically.
-
-For example see the PR [Prepare testing for the cert-manager `v1.0` release](https://github.com/jetstack/testing/pull/397).
-
-#### Rollover Documentation
-
-You will also need to update the versions and branches in the cert-manager website configuration.
-
-For example see the PR [Configure website for the `v1.0` release](https://github.com/cert-manager/website/pull/309).
+    3. Open a PR to
+       [cert-manager/website](https://github.com/cert-manager/website) with
+       updates to the website configuration. To do this, take inspiration from
+       [Maartje's PR
+       example](ttps://github.com/cert-manager/website/pull/309/files).
 
 ## Patch Releases
 

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -397,15 +397,13 @@ page if a step is missing or if it is outdated.
 9. Proceed to the post-release steps:
 
     1. **(final release only)** Open a PR to
-       [jetstack/testing](https://github.com/jetstack/testing) and change Prow's
+       [`jetstack/testing`](https://github.com/jetstack/testing) and change Prow's
        config. To do this, take inspiration from [Maartje's PR
        example](https://github.com/jetstack/testing/pull/397/files).
 
     2. **(final release only)** Push a new release branch to
-       [jetstack/cert-manager](https://github.com/jetstack/cert-manager).
-
-        If the final release is `v1.0.0`, then push the new branch
-        `release-1.1`:
+       [`jetstack/cert-manager`](https://github.com/jetstack/cert-manager). If the
+       final release is `v1.0.0`, then push the new branch `release-1.1`:
 
         ```bash
         # Must be run from the cert-manager repo folder.
@@ -413,8 +411,8 @@ page if a step is missing or if it is outdated.
         git push origin release-1.1
         ```
 
-    3. Open a PR to
-       [cert-manager/website](https://github.com/cert-manager/website) with
+    3. **(final release only)** Open a PR to
+       [`cert-manager/website`](https://github.com/cert-manager/website) with
        updates to the website configuration. To do this, take inspiration from
        [Maartje's PR
        example](ttps://github.com/cert-manager/website/pull/309/files).

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -45,7 +45,7 @@ following conditions:
    page](https://console.cloud.google.com/cloud-build?project=cert-manager-release).
    To get the "Editor" permission on the GCP project, open a PR with your name
    added to the maintainers list in
-   [cert_manager_release.tf](https://github.com/jetstack/terraform-jetstack/blob/master/cert_manager_release.tf)
+   [`cert_manager_release.tf`](https://github.com/jetstack/terraform-jetstack/blob/master/cert_manager_release.tf)
 
     ```diff
     --- a/cert_manager_release.tf
@@ -210,6 +210,7 @@ page if a step is missing or if it is outdated.
         | `END_REV`         | Name of your release branch             |
         | `BRANCH`          | Name of your release branch             |
         | `RELEASE_VERSION` | The git tag without the leading `v`     |
+        </br>
 
         Examples for each release type (e.g., initial alpha release):
 
@@ -223,6 +224,7 @@ page if a step is missing or if it is outdated.
         | `END_REV`         | `release-1.3`    | `release-1.3`    | `release-1.3`    | `release-1.3` | `release-1.3` |
         | `BRANCH`          | `release-1.3`    | `release-1.3`    | `release-1.3`    | `release-1.3` | `release-1.3` |
         | `RELEASE_VERSION` | `1.3.0-alpha.0`  | `1.3.0-alpha.1`  | `1.3.0-beta.0`   | `1.3.0`       | `1.3.1`       |
+        </br>
 
         > \*The git tag of the "previous" release (`START_REV`) depends on which
         > type of release you count on doing. Look at the above examples to


### PR DESCRIPTION
| Preview: https://deploy-preview-522--cert-manager.netlify.app/docs/contributing/release-process/ |
|-|

I find it confusing not to have a clear naming around our releases. Sometimes we talk about "minor release", then we talk about "final release"... In this PR, I propose to harmonize the naming and have a clear definition for each:

| Type of release          | Example of git tag |
| ------------------------ | ------------------ |
| initial alpha release    | `v1.3.0-alpha.0`   |
| subsequent alpha release | `v1.3.0-alpha.1`   |
| beta release             | `v1.3.0-beta.0`    |
| final release            | `v1.3.0`           |
| patch release            | `v1.3.1`           |

~~I also decided to run `prettier` to refmt the Markdown file, it was becoming hard to maintain otherwise~~ nope, prettier breaks Hugo in nested lists