### PR TITLE
Update "Setting Nameservers for DNS01 Self Check" example

### DIFF
--- a/content/en/docs/configuration/acme/dns01/_index.md
+++ b/content/en/docs/configuration/acme/dns01/_index.md
@@ -59,8 +59,8 @@ If this is not desired (for example with multiple authoritative nameservers or
 split-horizon DNS), the cert-manager controller exposes two flags that allows
 you alter this behavior:
 
-`--dns01-recursive-nameservers` Comma separated string with host and port of the
-recursive nameservers cert-manager should query.
+`--dns01-recursive-nameservers` String with host and port of the
+recursive nameservers cert-manager should query. This parameter can be supplied multiple times.
 
 `--dns01-recursive-nameservers-only` Forces cert-manager to only use the
 recursive nameservers for verification. Enabling this option could cause the DNS01
@@ -69,7 +69,7 @@ self check to take longer due to caching performed by the recursive nameservers.
 
 Example usage:
 ```bash
---dns01-recursive-nameservers-only --dns01-recursive-nameservers="8.8.8.8:53,1.1.1.1:53"
+--dns01-recursive-nameservers-only --dns01-recursive-nameservers="8.8.8.8:53" --dns01-recursive-nameservers="1.1.1.1:53"
 ```
 
 If you're using the `cert-manager` helm chart, you can set recursive nameservers
@@ -77,7 +77,7 @@ through `.Values.extraArgs` or at the command at helm install/upgrade time
 with `--set`:
 
 ```bash
---set 'extraArgs={--dns01-recursive-nameservers-only,--dns01-recursive-nameservers=8.8.8.8:53\,1.1.1.1:53}'
+--set 'extraArgs={--dns01-recursive-nameservers-only,--dns01-recursive-nameservers=8.8.8.8:53,--dns01-recursive-nameservers=1.1.1.1:53}'
 ```
 
 ## Delegated Domains for DNS01


### PR DESCRIPTION
I tried to apply the example for configuration alternative servers used for the DNS01 self check, since I'm having trouble with that on my DigitalOcean managed cluster.

Here are the commands I ran:
```
kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.0/cert-manager.yaml
kubectl --namespace cert-manager patch --type json deployment cert-manager -p "$(cat cert-manager.patch.json)"
```
cert-manager.patch.json:
```json
[
  {
    "op": "add",
    "path": "/spec/template/spec/containers/0/args/-",
    "value": "--dns01-recursive-nameservers-only"
  },
  {
    "op": "add",
    "path": "/spec/template/spec/containers/0/args/-",
    "value": "--dns01-recursive-nameservers=\"8.8.8.8:53,1.1.1.1:53\""
  }
]
```

I get a Crashloopbackoff from the cert-manager pod however: `Error: error validating options: invalid DNS server (address 8.8.8.8:53,1.1.1.1:53: too many colons in address): 8.8.8.8:53,1.1.1.1:53`

After changing my patch to like the following it worked as expected:
```
[
  {
    "op": "add",
    "path": "/spec/template/spec/containers/0/args/-",
    "value": "--dns01-recursive-nameservers-only"
  },
  {
    "op": "add",
    "path": "/spec/template/spec/containers/0/args/-",
    "value": "--dns01-recursive-nameservers=\"8.8.8.8:53\""
  },
  {
    "op": "add",
    "path": "/spec/template/spec/containers/0/args/-",
    "value": "--dns01-recursive-nameservers=\"1.1.1.1:53\""
  }
]
```

I guess the "Comma separated string" part isn't valid anymore.