### PR TITLE
Bump version 1.3.1

### DIFF
--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -39,7 +39,7 @@ are included in a single YAML manifest file:
 Install the `CustomResourceDefinitions` and cert-manager itself:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
 ```
 
 > **Note**: When running on GKE (Google Kubernetes Engine), you may encounter a
@@ -114,7 +114,7 @@ option when installing the Helm chart.
 Install the `CustomResourceDefinition` resources using `kubectl`:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.0/cert-manager.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.crds.yaml
 ```
 
 #### Option 2: install CRDs as part of the Helm release
@@ -133,7 +133,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.3.0 \
+  --version v1.3.1 \
   # --set installCRDs=true
 ```
 

--- a/content/en/docs/installation/openshift.md
+++ b/content/en/docs/installation/openshift.md
@@ -61,7 +61,7 @@ are included in a single YAML manifest file:
 
 Install the `CustomResourceDefinitions` and cert-manager itself
 ```bash
-oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.0/cert-manager.yaml
+oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
 ```
 
 ## Installing with cert-manager operator

--- a/content/en/docs/installation/upgrading/_index.md
+++ b/content/en/docs/installation/upgrading/_index.md
@@ -33,7 +33,7 @@ option added to your Helm install command, you should upgrade your CRD resources
 before upgrading the Helm chart:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.0/cert-manager.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/<version>/cert-manager.crds.yaml
 ```
 
 Add the Jetstack Helm repository if you haven't already.
@@ -69,5 +69,5 @@ begin the upgrade process like so - replacing `<version>` with the version
 number you want to install:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/<version>/cert-manager.yaml
 ```

--- a/content/en/docs/usage/kubectl-plugin.md
+++ b/content/en/docs/usage/kubectl-plugin.md
@@ -12,7 +12,7 @@ You need the `kubectl-cert-manager.tar.gz` file for the platform you're using, t
 In order to use the kubectl plugin you need its binary to be accessible under the name `kubectl-cert_manager` in your `$PATH`.
 Run the following commands to set up the plugin:
 ```console
-$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/download/v1.3.0/kubectl-cert_manager-linux-amd64.tar.gz
+$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/download/v1.3.1/kubectl-cert_manager-linux-amd64.tar.gz
 $ tar xzf kubectl-cert-manager.tar.gz
 $ sudo mv kubectl-cert_manager /usr/local/bin
 ```


### PR DESCRIPTION
I have bumped versions in installation instructions `v1.3.0` -> `v1.3.1` as I guess we now want to recommend that people install the latest patch?
I have also updated the upgrade instructions to not include specific version number.

/kind cleanup