### PR TITLE
Update backup instructions

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -139,6 +139,7 @@ propagations
 publicised
 RBAC
 rebase
+reissuance
 remediate
 repo
 reStructuredText

--- a/content/en/docs/tutorials/backup.md
+++ b/content/en/docs/tutorials/backup.md
@@ -13,8 +13,8 @@ re-install.
 
 The following commands will back up the configuration of `cert-manager`
 resources. Doing that might be useful before upgrading `cert-manager`. As
-this backup does not include the Secrets containing the X.509 certificates,
-restoring to a cluster that does not already have those Secrets will result in
+this backup does not include the `Secrets` containing the X.509 certificates,
+restoring to a cluster that does not already have those `Secret`s will result in
 the certificates being reissued.
 
 ### Backup
@@ -28,24 +28,24 @@ $ kubectl get -o yaml \
 ```
 
 If you are transferring data to a new cluster, you may also need to copy across
-additional Secret resources that are referenced by your configured Issuers, such
+additional `Secret` resources that are referenced by your configured Issuers, such
 as:
 
 #### CA Issuers
 
-- The root CA Secret referenced by `issuer.spec.ca.secretName`
+- The root CA `Secret` referenced by `issuer.spec.ca.secretName`
 
 #### Vault Issuers
 
-- The token authentication Secret referenced by
+- The token authentication `Secret` referenced by
   `issuer.spec.vault.auth.tokenSecretRef`
-- The AppRole configuration Secret referenced by
+- The AppRole configuration `Secret` referenced by
   `issuer.spec.vault.auth.appRole.secretRef`
 
 #### ACME Issuers
 
-- The ACME account private key Secret referenced by `issuer.acme.privateKeySecretRef`
-- Any Secrets referenced by DNS providers configured under the
+- The ACME account private key `Secret` referenced by `issuer.acme.privateKeySecretRef`
+- Any `Secret`s referenced by DNS providers configured under the
   `issuer.acme.dns01.providers` and `issuer.acme.solvers.dns01` fields.
 
 ### Restore
@@ -77,12 +77,12 @@ are using [`ingress-shim`](../../usage/ingress/).
 
 #### Excluding some cert-manager resources from backup
 
-`cert-manager` has a number of resources- `Order`s, `Challenge`s and
-`CertificateRequest`s -that are designed to represent a point-in-time operation
-such as a request for a certificate. As such, their status often depends on other
-ephemeral resources (i.e a temporary Secret holding a private key), so
-`cert-manager` cannot always correctly re-create the status of these resources
-by just looking at the cluster state at some later time.
+`cert-manager` has a number of custom resources that are designed to represent a
+point-in-time operation. An example would be a `CertificateRequest` that
+represents a one-time request for an X.509 certificate. The status of these
+resources can depend on other ephemeral resources (such as a temporary `Secret`
+holding a private key) so `cert-manager` might not be able to correctly recreate
+the state of these resources at a later point.
 
 In most cases backup and restore tools will not restore the statuses of custom resources,
 so including such one-time resources in a backup can result in an unnecessary reissuance
@@ -104,10 +104,10 @@ to a situation where updates to the `Ingress` (i.e a new DNS name) are not
 applied to the `Certificate`.
 
 To avoid this issue, in most cases `Certificate`s created via `ingress-shim`
-can be excluded from the backup- given that the restore happens
-in the correct order- Secret with the X.509 certificate restored before
-the `Ingress`- `cert-manager` will be able to create a new `Certificate`
-for the `Ingress` and determine that the existing Secret is for that `Certificate`.
+can be excluded from the backup. Given that the restore happens
+in the correct order (`Secret` with the X.509 certificate restored before
+the `Ingress`) `cert-manager` will be able to create a new `Certificate`
+for the `Ingress` and determine that the existing `Secret` is for that `Certificate`.
 
 ### Velero
 
@@ -127,7 +127,7 @@ We have briefly tested backup and restore with `velero` `v1.5.3` and
    exclude `Order`s, `Challenge`s and `CertificateRequest`s from the backup, see
    [Excluding some cert-manager resources from backup](#excluding-some-cert-manager-resources-from-backup).
 
-- Velero's [default restore order](https://github.com/vmware-tanzu/velero/blob/main/pkg/cmd/server/server.go#L470)(Secrets before `Ingress`es, Custom Resources
+- Velero's [default restore order](https://github.com/vmware-tanzu/velero/blob/main/pkg/cmd/server/server.go#L470)(`Secrets` before `Ingress`es, Custom Resources
   restored last), should ensure that there is no unnecessary certificate reissuance
   due to the order of restore operation, see [Order of restore](#order-of-restore).
 
@@ -148,7 +148,7 @@ We have briefly tested backup and restore with `velero` `v1.5.3` and
  We no longer recommend including `CertificateRequest` resources in a backup
  for most scenarios.
  `CertificateRequest`s are designed to represent a one-time
- request for an X.509 certificate- once the request has been fulfilled,
+ request for an X.509 certificate. Once the request has been fulfilled,
  `CertificateRequest` can usually be safely deleted. In most cases (such as when
  a `CertificateRequest` has been created for a `Certificate`) a new
  `CertificateRequest` will be created when needed (i.e at a time of a renewal

--- a/content/en/docs/tutorials/backup.md
+++ b/content/en/docs/tutorials/backup.md
@@ -9,38 +9,46 @@ If you need to uninstall cert-manager, or transfer your installation to a new
 cluster, you can backup all of cert-manager's configuration in order to later
 re-install.
 
-## Backing up
+## Backing up cert-manager resource configuration
+
+The following commands will back up the configuration of `cert-manager`
+resources. This might be useful to back up before upgrading `cert-manager`. As
+this backup does not include the secrets containing the X.509 certificates,
+restoring to a cluster that does not already have those secrets will result in
+the certificates being re-issued.
+
+### Backup
 
 To backup all of your cert-manager configuration resources, run:
 
 ```bash
 $ kubectl get -o yaml \
      --all-namespaces \
-     issuer,clusterissuer,certificates,certificaterequests > cert-manager-backup.yaml
+     issuer,clusterissuer,certificates > cert-manager-backup.yaml
 ```
 
 If you are transferring data to a new cluster, you may also need to copy across
 additional Secret resources that are referenced by your configured Issuers, such
 as:
 
-### CA Issuers
+#### CA Issuers
 
 - The root CA Secret referenced by `issuer.spec.ca.secretName`
 
-### Vault Issuers
+#### Vault Issuers
 
 - The token authentication Secret referenced by
   `issuer.spec.vault.auth.tokenSecretRef`
 - The AppRole configuration Secret referenced by
   `issuer.spec.vault.auth.appRole.secretRef`
 
-### ACME Issuers
+#### ACME Issuers
 
 - The ACME account private key Secret referenced by `issuer.acme.privateKeySecretRef`
 - Any Secrets referenced by DNS providers configured under the
   `issuer.acme.dns01.providers` and `issuer.acme.solvers.dns01` fields.
 
-## Restoring Resources
+### Restore
 
 In order to restore your configuration, you can simply `kubectl apply` the files
 created above after installing cert-manager.
@@ -49,5 +57,23 @@ created above after installing cert-manager.
 $ kubectl apply -f cert-manager-backup.yaml
 ```
 
-If you have migrated from an old cluster, you will need to make sure to run a
-similar `kubectl apply` command to restore your Secret resources too.
+## Backing up and Restoring CertificateRequests 
+
+ We no longer recommend including `CertificateRequest` resources in a backup
+ for most scenarios.
+ `CertificateRequest`s are designed to represent a one-time
+ request for an X.509 certificate- once the request has been fulfilled,
+ `CertificateRequest` can usually be safely deleted as in most cases (such as when
+ a `CertificateRequest` has been created for a `Certificate`) a new
+ `CertificateRequest` will be created when needed (i.e at a time of a renewal
+ of a `Certificate`).
+ In `v1.3.0` , as part of our work towards [policy
+ implementation](https://github.com/jetstack/cert-manager/pull/3727) we
+ introduced identity fields for `CertificateRequest` resources where, at a time
+ of creation, `cert-mananager`'s webhook updates `CertificateRequest`'s spec
+ with immutable identity fields, representing the identity of the creator of
+ the `CertificateRequest`.
+ This introduces some extra complexity for backing up
+ and restoring `CertificateRequest`s as the identity of the restorer might
+ differ from that of the original creator and we have seen some edge cases
+ where this causes issues at restore time.

--- a/content/en/docs/tutorials/backup.md
+++ b/content/en/docs/tutorials/backup.md
@@ -57,6 +57,95 @@ created above after installing cert-manager.
 $ kubectl apply -f cert-manager-backup.yaml
 ```
 
+## Full cluster backup and restore
+
+This section refers to backing up and restoring 'all' Kubernetes resources in a
+cluster- including some `cert-manager` ones- for scenarios such as disaster
+recovery, cluster migration etc.
+
+Note that we have not done any extensive testing, only a few common scenarios-
+it is recommended that to test the backup and restore strategy before relying
+on it as there are likely to be some other edge cases.
+We would like to ensure that users can reliably backup and restore `cert-manager`
+resources using common tools- if you encounter any errors, please do open a
+GitHub issue or PR an update to this document.
+
+### Avoiding unnecessary certificate reissuance
+
+#### Order of restore
+
+If `cert-manager` does not find a Kubernetes secret with an X.509 certificate
+for a `Certificate`, reissuance will be triggered. To avoid unnecessary
+reissuance after a restore, ensure that secrets are restored before
+`Certificate`s. Similarly secrets should be restored before `Ingress`es if you
+are using ingress-shim.
+
+#### Excluding one-time `cert-manager` resources from backup
+
+`cert-manager` has a number of resources- `Order`s, `Challenge`s and
+`CertificateRequest`s -that are designed to represent a point-in-time operation
+such as a request for a certificate. As such their status often depends on other
+ephemeral resources (i.e a temporary Secret holding a private key), so
+`cert-manager` cannot always correctly re-create the status of these resources
+by just looking at the cluster state. In most cases backup tools will not
+restore the statuses of custom resources so including such one-time resource in a
+backup can result in an unnecessary reissuance after a restore. For example, a
+restored `Order` often ends up in a 'pending' state which results in new
+`Challenge`s being created and reissuance. To avoid reissuance, we recommend
+that `Order`s and `Challenge`s are excluded from the backup. We also don't
+recommend backing up `CertificateRequest`s, see below.
+
+### Restoring ingress-shim Certificates
+
+A `Certificate` created for an `Ingress` via `ingress-shim` will have an [owner
+reference](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents)
+pointing to the owning `Ingress`. `cert-manager` uses the owner reference to
+verify that the `Certificate` 'belongs' to an `Ingress` and will not attempt to
+create/correct it for an existing `Certificate`. After a full
+cluster recreation, a restored owner reference would probably be incorrect
+(`Ingress` UUID will have changed). The owner reference not matching could lead
+to a situation where updates to the `Ingress` (i.e a new DNS name) are not
+applied to the `Certificate`.
+In most cases it would make sense to exclude the `Certificate`s created for
+`Ingresses` by `ingress-shim` from the backup- given that the restore happens
+in the correct order- Secret with the X.509 certificate restored before
+the `Ingress`- `cert-manager` will be able to create a new `Certificate`
+for the `Ingress` and determine that the existing secret is for that `Certificate`.
+
+### Velero
+
+We have briefly tested backup and restore with `velero` `v1.5.3` and
+`cert-manager` `v1.3.1` and `v1.3.0` as well as `velero` `v1.3.1` and
+`cert-manager` `v1.1.0` `velero` `v1.3.1`.
+
+ A few potential edge cases:
+
+- Ensure that the backups include `cert-manager` CRDs. We have seen that if
+  `--exclude-namespaces` flag is passed to `velero backup create`, CRDs for
+  which there are no actual custom resources included in the backup might not be
+  included in backup unless `--include-cluster-resources=true` flag is also passed.
+
+-  Velero does not restore statuses of custom resources, so you should probably
+   exclude `Order`s, `Challenge`s and `CertificateRequest`s from the backup, see
+   the section on excluding one-time resources from backup.
+
+- Velero by default restores Secrets before `Ingress`es and Custom Resources
+  are restored last, so there should be no unnecessary certificate reissuance
+  due to `Certificate`s whose `Secret`s have not yet been restored.
+
+- When restoring the deployment of `cert-manager` itself, it may be necessary to
+  restore `cert-manager`'s RBAC resources before the rest of the deployment.
+  This is because `cert-manager`'s controller needs to be able to create
+  `Certificate`'s for the `cert-manager`'s webhook before the webhook can become
+  ready. In order to do this, the controller needs the right permissions. Since
+  Velero by default restores pods before RBAC resources, the restore might get
+  stuck waiting for the webhook pod to become ready.
+
+- Velero does not restore owner references, so it may be necessary to exclude
+  `Certificate`s created for `Ingress`es from the backup even when not
+  re-creating the `Ingress` itself. See the section on restoring `ingress-shim`
+  `Certificate`s.
+
 ## Backing up and Restoring CertificateRequests 
 
  We no longer recommend including `CertificateRequest` resources in a backup

--- a/content/en/docs/tutorials/backup.md
+++ b/content/en/docs/tutorials/backup.md
@@ -15,7 +15,7 @@ The following commands will back up the configuration of `cert-manager`
 resources. Doing that might be useful before upgrading `cert-manager`. As
 this backup does not include the Secrets containing the X.509 certificates,
 restoring to a cluster that does not already have those Secrets will result in
-the certificates being re-issued.
+the certificates being reissued.
 
 ### Backup
 
@@ -60,24 +60,19 @@ $ kubectl apply -f cert-manager-backup.yaml
 ## Full cluster backup and restore
 
 This section refers to backing up and restoring 'all' Kubernetes resources in a
-cluster- including some `cert-manager` ones- for scenarios such as disaster
+cluster — including some `cert-manager` ones — for scenarios such as disaster
 recovery, cluster migration etc.
 
-Note that we have not done any extensive testing, only a few common scenarios-
-it is recommended to test the backup and restore strategy before putting it in place
-as there are likely to be some other edge cases.
-We would like to ensure that users can reliably backup and restore `cert-manager`
-resources using common tools- if you encounter any errors, please do open a
-GitHub issue or PR an update to this document.
+*Note*: We have tested this process on simple Kubernetes test clusters with a limited set of Kubernetes releases. To avoid data loss, please test both the backup and the restore strategy on your own cluster before depending upon it in production. If you encounter any errors, please open a GitHub issue or a PR to document variations on this process for different Kubernetes environments. 
 
 ### Avoiding unnecessary certificate reissuance
 
 #### Order of restore
 
-If `cert-manager` does not find a Kubernetes Secret with an X.509 certificate
+If `cert-manager` does not find a Kubernetes `Secret` with an X.509 certificate
 for a `Certificate`, reissuance will be triggered. To avoid unnecessary
-reissuance after a restore, ensure that Secrets are restored before
-`Certificate`s. Similarly, Secrets should be restored before `Ingress`es if you
+reissuance after a restore, ensure that `Secret`s are restored before
+`Certificate`s. Similarly, `Secret`s should be restored before `Ingress`es if you
 are using [`ingress-shim`](../../usage/ingress/).
 
 #### Excluding some cert-manager resources from backup


### PR DESCRIPTION
I did some manual backup and restore testing (mostly with Velero on GKE) and added a few more notes to the backup doc.

The fact that the `Certificate`s for `Ingress` lose the correct owner reference during a restore and `cert-manager` cannot recreate it, seems problematic from backup and restore perspective, as there is no straightforward way to exclude the `Ingress` `Certificate`s only from a Velero backup. 

I added a recommendation to not restore `CertificateRequest`s.
I don't think that restoring them would necessarily cause failures as such, but with the new identity fields it seems like we should not restore them since the restorer's identity is likely going to be different than creator's and it might just cause confusion.
Also `cert-manager` cannot recreate their status after a restore correctly, so they end up having Ready condition set to False, which I think would also be confusing for users.
In all cases I could think of there should be no need to restore completed `CertificateRequest`s, but perhaps there are some edge cases where they are needed?

Some issues related to `cert-manager` backup and restore:

- [#2318](https://github.com/jetstack/cert-manager/issues/2318)
- [#2112](https://github.com/jetstack/cert-manager/issues/2112)
- #234
- #397 
- [#3612](https://github.com/jetstack/cert-manager/issues/3612)

Some of the issues above refer to the currently documented backup strategy via `kubectl get.. kubectl apply`- I have not looked into that much as a part of this PR.
I have not yet properly tested restoring from an etcd snapshot which I was planning- that might be a separate PR.


Fixes #479 

/kind cleanup