### PR TITLE
Moves the small step external issuer as an approval honoured issuer

### DIFF
--- a/content/en/docs/configuration/external.md
+++ b/content/en/docs/configuration/external.md
@@ -23,6 +23,10 @@ authors are as follows:
 
 # Issuers that Honour Approval
 
+- [step-issuer](https://github.com/smallstep/step-issuer): Used to request
+  certificates from the [Smallstep](https://smallstep.com) [Certificate
+  Authority server](https://github.com/smallstep/certificates).
+
 - [google-cas-issuer](https://github.com/jetstack/google-cas-issuer): Used
   to request certificates signed by private CAs managed by the
   [Google Cloud Certificate Authority Service](https://cloud.google.com/certificate-authority-service/).
@@ -31,10 +35,6 @@ authors are as follows:
 A list of known external issuer projects that are maintained by their authors
 are as follows. These issuers do _not_ honour
 [approval](../../concepts/certificaterequest/#approval).
-
-- [step-issuer](https://github.com/smallstep/step-issuer): Used to request
-  certificates from the [Smallstep](https://smallstep.com) [Certificate
-  Authority server](https://github.com/smallstep/certificates).
 
 - [aws-pca-issuer](https://github.com/jniebuhr/aws-pca-issuer): Used to
   request certificates from [AWS Private Certificate Authority]


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

/assign @jakexks 
/cc @maraino 