### PR TITLE
Broken Create a Personal access token URL

### DIFF
--- a/content/en/docs/configuration/acme/dns01/digitalocean.md
+++ b/content/en/docs/configuration/acme/dns01/digitalocean.md
@@ -21,7 +21,7 @@ data:
 
 The access token must have write access.
 
-To create a Personal Access Token, see [DigitalOcean documentation](https://www.digitalocean.com/docs/api/create-personal-access-token).
+To create a Personal Access Token, see [DigitalOcean documentation](https://docs.digitalocean.com/reference/api/create-personal-access-token/).
 
 Handy direct link: https://cloud.digitalocean.com/account/api/tokens/new
 


### PR DESCRIPTION
The url to Create a personal access token is broken. 
This PR is a fix to the broken URL, pointing to the new URL.