### PR TITLE
Do not specify namespace for DO DNS01 secret

### DIFF
--- a/content/en/docs/configuration/acme/dns01/digitalocean.md
+++ b/content/en/docs/configuration/acme/dns01/digitalocean.md
@@ -14,7 +14,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: digitalocean-dns
-  namespace: cert-manager
 data:
   # insert your DO access token here
   access-token: "base64 encoded access-token here"


### PR DESCRIPTION
The examples for `Issuer` do not specify a namespace, so when we copy/paste the examples they go into the current namespace. Specifying that this secret goes in the `cert-manager` namespace potentially puts it into a _different_ namespace than the `Issuer`, creating confusion when it doesn't work.

This PR suggests implying placement of the secret in the same namespace as other resources being created.