### PR TITLE
Detail why we are still supporting Kubernetes 1.16 & document GKE Autopilot incompatibility

### DIFF
--- a/content/en/docs/installation/compatibility.md
+++ b/content/en/docs/installation/compatibility.md
@@ -17,8 +17,7 @@ Google managed project.
 In order to restrict what Google are able to access within your cluster, the
 firewall rules configured restrict access to your Kubernetes pods. This will
 mean that you will experience the webhook to not work and experience errors such
-as `Internal error occurred: failed calling admission webhook ... the server is
-currently unable to handle the request`.
+as `Internal error occurred: failed calling admission webhook ... the server is currently unable to handle the request`.
 
 In order to use the webhook component with a GKE private cluster, you must
 configure an additional firewall rule to allow the GKE control plane access to
@@ -28,6 +27,17 @@ You can read more information on how to add firewall rules for the GKE control
 plane nodes in the [GKE
 docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules).
 
+## GKE Autopilot
+
+As of May 2021, GKE Autopilot has no support for 3rd party webhooks.
+Without webhooks, many Kubernetes plugins such as cert-manager cannot
+operate correctly.
+
+As per [this
+tweet](https://twitter.com/BagadeVivek/status/1365701217469534220), GKE
+Autopilot is meant to support webhooks in a coming release. We will keep
+you updated on the progress on [this
+issue](https://github.com/jetstack/cert-manager/issues/3717).
 
 ## AWS EKS
 
@@ -43,6 +53,6 @@ deployment, or, if using Helm, configuring it in your `values.yaml` file.
 Note that since kubelet uses port `10250` by default on the host network, the
 `webhook.securePort` value must be changed to a different, free port.
 
-
 ## Webhook
+
 Disabling the webhook is not supported anymore since `v0.14`.

--- a/content/en/docs/installation/supported-releases.md
+++ b/content/en/docs/installation/supported-releases.md
@@ -26,7 +26,7 @@ release every two months.
 
 | Release |   Release Date    |      EOL      | [Supported Kubernetes versions][s] |
 | ------- | :---------------: | :-----------: | :--------------------------------: |
-| [1.4][] | [~][]Jun 11, 2021 | [~][]Oct 2021 |                TBC                 |
+| [1.4][] | [~][]Jun 11, 2021 | [~][]Oct 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
 
 > The `~` sign is used when the date is uncertain and might change; the
 > "EOL" abbreviation stands for End Of Life.
@@ -223,6 +223,19 @@ Our testing coverage is:
 [`master`]: https://testgrid.k8s.io/jetstack-cert-manager-master
 [`next`]: https://testgrid.k8s.io/jetstack-cert-manager-next
 [`previous`]: https://testgrid.k8s.io/jetstack-cert-manager-previous
+
+The oldest Kubernetes release supported by cert-manager is 1.16, as we want
+to be supporting most commercial Kubernetes offerings.
+
+|   Vendor   | Oldest Kubernetes release | End of Life |
+| :--------: | :-----------------------: | :---------: |
+| [EKS][eks] |           1.16            | 25 Jul 2021 |
+| [GKE][gke] |           1.17            |  Nov 2021   |
+| [AKS][aks] |           1.18            |  Jun 2021   |
+
+[eks]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+[gke]: https://cloud.google.com/kubernetes-engine/docs/release-schedule
+[aks]: https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions#aks-kubernetes-release-calendar
 
 ## Terminology
 

--- a/content/en/docs/installation/supported-releases.md
+++ b/content/en/docs/installation/supported-releases.md
@@ -227,11 +227,13 @@ Our testing coverage is:
 The oldest Kubernetes release supported by cert-manager is 1.16, as we want
 to be supporting most commercial Kubernetes offerings.
 
-|   Vendor   | Oldest Kubernetes release | End of Life |
-| :--------: | :-----------------------: | :---------: |
-| [EKS][eks] |           1.16            | 25 Jul 2021 |
-| [GKE][gke] |           1.17            |  Nov 2021   |
-| [AKS][aks] |           1.18            |  Jun 2021   |
+|   Vendor   | Oldest Kubernetes Release\* | End of Life |
+| :--------: | :-------------------------: | :---------: |
+| [EKS][eks] |            1.16             | 25 Jul 2021 |
+| [GKE][gke] |            1.17             |  Nov 2021   |
+| [AKS][aks] |            1.18             |  Jun 2021   |
+
+\*As of 2021-05-25.
 
 [eks]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
 [gke]: https://cloud.google.com/kubernetes-engine/docs/release-schedule


### PR DESCRIPTION
| Preview: https://deploy-preview-564--cert-manager.netlify.app/docs/installation/supported-releases/#kubernetes-supported-versions |
|--|

Yesterday in the weekly backlog grooming we wondered: why are we supporting Kubernetes 1.16 again? This PR adds this information to the supported-releases page (see preview).

I also added a paragraph on GKE autopilot; the incompatibility with GKE Autopilot is tracked in https://github.com/jetstack/cert-manager/issues/3717.

cc @wallrj 