### PR TITLE
Mention that the acme-dns implementation can only do one challenge per subdomain

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -241,6 +241,7 @@ kubernetes-supported-versions
 prepended
 retweets
 JetstackHQ
+acme-dns
 
 # As per https://tools.ietf.org/html/rfc5280, the spelling "X.509" is the
 # correct spelling. The spelling "x509" and "X509" are incorrect.

--- a/content/en/docs/configuration/acme/dns01/acme-dns.md
+++ b/content/en/docs/configuration/acme/dns01/acme-dns.md
@@ -215,7 +215,7 @@ With this setup, we have:
 
 - `example.com` and `*.example.com` are registered in the acme-dns
   "subdomain" `d420c923-bbd7-4056-ab64-c3ca54c9b3cf`.
-- `foo.example.com` is registered with solved in the acme-dns "subdomain"
+- `foo.example.com` is registered in the acme-dns "subdomain"
   `d420c923-bbd7-4056-ab64-c3ca54c9b3cf`.
 
 Another workaround is to use `--max-concurrent-challenges 2` when running

--- a/content/en/docs/configuration/acme/dns01/acme-dns.md
+++ b/content/en/docs/configuration/acme/dns01/acme-dns.md
@@ -96,15 +96,17 @@ _acme-challenge.example.com CNAME d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.exam
 _acme-challenge.example.org CNAME d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com
 ```
 
-> Note: that the "name" of the record always has the `_acme-challenge`
-> subdomain, and the "value" of the record matches exactly the `fulldomain`
-> field from registration.
+{{% alert title="Note" color="primary" %}}
+The "name" of the record always has the `_acme-challenge` subdomain, and
+the "value" of the record matches exactly the `fulldomain` field from
+registration.
+{{% /alert %}}
 
 At verification time, the domain name `d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com` will be a TXT
 record that is set to your validation token. When the verifier queries `_acme-challenge.example.com`, it will
 be directed to the correct location by this CNAME record. This proves that you control `example.com`
 
-4. Create a secret from the credentials JSON that was saved in step 2, this secret is referenced
+1. Create a secret from the credentials JSON that was saved in step 2, this secret is referenced
    in the `accountSecretRef` field of your DNS01 issuer settings.
    When creating an `Issuer` both this `Issuer` and `Secret` must be in the same namespace.
    However for a `ClusterIssuer` (which does not have a namespace) the `Secret` must be placed in

--- a/content/en/docs/configuration/acme/dns01/acme-dns.md
+++ b/content/en/docs/configuration/acme/dns01/acme-dns.md
@@ -183,7 +183,7 @@ cert-manager will only be able to solve 2 challenges out of 3 in a non
 deterministic way. This limitation comes from a "feature" mentioned [this
 acme-dns issue](https://github.com/joohoi/acme-dns/issues/76).
 
-One workaround is to issue one set of `acme-dns` credentials for each
+One workaround is to issue one set of acme-dns credentials for each
 domain that we want to be challenged, keeping in mind that each acme-dns
 "subdomain" can only accept at most 2 challenged domains. For example, the
 above secret would become:

--- a/content/en/docs/configuration/acme/dns01/acme-dns.md
+++ b/content/en/docs/configuration/acme/dns01/acme-dns.md
@@ -12,7 +12,6 @@ metadata:
   name: example-issuer
 spec:
   acme:
-    ...
     solvers:
     - dns01:
         acmeDNS:
@@ -31,92 +30,100 @@ Information about setting up and configuring ACMEDNS is available on the
 [ACMEDNS project page](https://github.com/joohoi/acme-dns).
 
 1. First, register with the ACMEDNS server, in this example, there is one
-   running at `auth.example.com`
+   running at `auth.example.com`. The command:
 
-`curl -X POST http://auth.example.com/register` will return a JSON with
-credentials for your registration:
+    ```sh
+    curl -X POST http://auth.example.com/register
+    ```
 
-```json
-{
-  "username":"eabcdb41-d89f-4580-826f-3e62e9755ef2",
-  "password":"pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
-  "fulldomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com",
-  "subdomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
-  "allowfrom":[]
-}
-```
+    will return a JSON with credentials for your registration:
 
-It is strongly recommended to restrict the update endpoint to the IP range of your pods.
-This is done at registration time as follows:
+    ```json
+    {
+      "username": "eabcdb41-d89f-4580-826f-3e62e9755ef2",
+      "password": "pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
+      "fulldomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com",
+      "subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
+      "allowfrom": []
+    }
+    ```
 
-`curl -X POST http://auth.example.com/register -H "Content-Type: application/json" --data '{"allowfrom": ["10.244.0.0/16"]}'`
+    It is strongly recommended to restrict the update endpoint to the IP
+    range of your pods. This is done at registration time as follows:
 
-Make sure to update the `allowfrom` field to match your cluster configuration. The JSON will now look like
+    ```sh
+    curl -X POST http://auth.example.com/register \
+        -H "Content-Type: application/json" \
+        --data '{"allowfrom": ["10.244.0.0/16"]}'
+    ```
 
-```json
-{
-  "username":"eabcdb41-d89f-4580-826f-3e62e9755ef2",
-  "password":"pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
-  "fulldomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com",
-  "subdomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
-  "allowfrom":["10.244.0.0/16"]
-}
-```
+    Make sure to update the `allowfrom` field to match your cluster
+    configuration. The JSON will now look like:
+
+    ```json
+    {
+      "username": "eabcdb41-d89f-4580-826f-3e62e9755ef2",
+      "password": "pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
+      "fulldomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com",
+      "subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
+      "allowfrom": ["10.244.0.0/16"]
+    }
+    ```
 
 2. Save this JSON to a file with the key as your domain. You can specify
-   multiple domains with the same credentials if you like. In our example, the
-  returned credentials can be used to verify ownership of `example.com` and and
-  `example.org`.
+   multiple domains with the same credentials if you like. In our example,
+   the returned credentials can be used to verify ownership of
+   `example.com` and and `example.org`.
 
-```json
-{
-  "example.com": {
-    "username":"eabcdb41-d89f-4580-826f-3e62e9755ef2",
-    "password":"pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
-    "fulldomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com",
-    "subdomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
-    "allowfrom":["10.244.0.0/16"]
-  },
-  "example.org": {
-    "username":"eabcdb41-d89f-4580-826f-3e62e9755ef2",
-    "password":"pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
-    "fulldomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com",
-    "subdomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
-    "allowfrom":["10.244.0.0/16"]
-  }
-}
-```
+    ```json
+    {
+      "example.com": {
+        "username": "eabcdb41-d89f-4580-826f-3e62e9755ef2",
+        "password": "pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
+        "fulldomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com",
+        "subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
+        "allowfrom": ["10.244.0.0/16"]
+      },
+      "example.org": {
+        "username": "eabcdb41-d89f-4580-826f-3e62e9755ef2",
+        "password": "pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
+        "fulldomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com",
+        "subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
+        "allowfrom": ["10.244.0.0/16"]
+      }
+    }
+    ```
 
 3. Next, update your primary DNS server with the CNAME record that will tell the
    verifier how to locate the challenge TXT record. This is obtained from the
-  `fulldomain` field in the registration:
+   `fulldomain` field in the registration:
 
-```
-_acme-challenge.example.com CNAME d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com
-_acme-challenge.example.org CNAME d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com
-```
+    ```
+    _acme-challenge.example.com CNAME d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com
+    _acme-challenge.example.org CNAME d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com
+    ```
 
-{{% alert title="Note" color="primary" %}}
-The "name" of the record always has the `_acme-challenge` subdomain, and
-the "value" of the record matches exactly the `fulldomain` field from
-registration.
-{{% /alert %}}
+    The "name" of the record always has the _acme-challenge subdomain, and
+    the "value" of the record matches exactly the fulldomain field from
+    registration.
 
-At verification time, the domain name `d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com` will be a TXT
-record that is set to your validation token. When the verifier queries `_acme-challenge.example.com`, it will
-be directed to the correct location by this CNAME record. This proves that you control `example.com`
+    At verification time, the domain name `d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.com` will be a TXT
+    record that is set to your validation token. When the verifier queries `_acme-challenge.example.com`, it will
+    be directed to the correct location by this CNAME record. This proves that you control `example.com`
 
-1. Create a secret from the credentials JSON that was saved in step 2, this secret is referenced
-   in the `accountSecretRef` field of your DNS01 issuer settings.
-   When creating an `Issuer` both this `Issuer` and `Secret` must be in the same namespace.
-   However for a `ClusterIssuer` (which does not have a namespace) the `Secret` must be placed in
-   the same namespace as where the cert-manager pod is running in (in the default setup `cert-manager`).
+4. Create a secret from the credentials JSON that was saved in step 2, this
+   secret is referenced in the `accountSecretRef` field of your DNS01
+   issuer settings. When creating an `Issuer` both this `Issuer` and
+   `Secret` must be in the same namespace. However for a `ClusterIssuer`
+   (which does not have a namespace) the `Secret` must be placed in the
+   same namespace as where the cert-manager pod is running in (in the
+   default setup `cert-manager`).
 
-```bash
-$ kubectl create secret generic acme-dns --from-file acmedns.json
-```
+   ```sh
+   kubectl create secret generic acme-dns --from-file acmedns.json
+   ```
 
-## Limitation of ACMEDNS
+## Limitation of the `acme-dns` server
 
 The [`acme-dns`](https://github.com/joohoi/acme-dns) server has a [known
 limitation](https://github.com/jetstack/cert-manager/issues/3610): the same


### PR DESCRIPTION

| Preview: https://deploy-preview-574--cert-manager.netlify.app/docs/configuration/acme/dns01/acme-dns/#limitation-of-acmedns|
|-|

Fixes https://github.com/jetstack/cert-manager/issues/3610
