### PR TITLE
Stored objects update instructions

### DIFF
--- a/content/en/docs/contributing/crds.md
+++ b/content/en/docs/contributing/crds.md
@@ -20,7 +20,12 @@ This will also update the version conversion code if needed.
 
 ## Versions
 
-cert-manager at time of writing has 4 CRD versions in use- `v1alpha2`, `v1alpha3`, `v1beta1` and `v1`. `v1alpha2`, `v1alpha3` and `v1beta1` are getting deprecated in cert-manager `v1.4.0` and will be removed in `v1.6.0`.
+cert-manager currently has 4 CRD versions in use:
+
+- `v1`
+- `v1beta1` (deprecated in cert-manager `v1.4.0`, removed `v1.6.0`)
+- `v1alpha3` (deprecated in cert-manager `v1.4.0`, removed `v1.6.0`)
+- `v1alpha2` (deprecated in cert-manager `v1.4.0`, removed `v1.6.0`)
 
 These versions are defined in [`//pkg/apis/certmanager`](https://github.com/jetstack/cert-manager/tree/master/pkg/apis/certmanager). ACME related resources are in [`//pkg/apis/acme`](https://github.com/jetstack/cert-manager/tree/master/pkg/apis/certmanager).
 
@@ -33,7 +38,7 @@ We also have an internal API version, it lives at [`//pkg/internal/apis`](https:
 This is a version that is only used for validation and conversion, controllers should not use it as it is not meant to be user-friendly and not stable.
 However all new fields also have to be added here for the conversion logic to work.
 
-See the [official Kubernetes docs for CRD versioning](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/) to understand conversion, which version are stored and served etc.
+See the [official Kubernetes docs for CRD versioning](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/) to understand conversion, which versions are stored and served etc.
 
 
 ## Kubebuilder

--- a/content/en/docs/contributing/crds.md
+++ b/content/en/docs/contributing/crds.md
@@ -20,11 +20,10 @@ This will also update the version conversion code if needed.
 
 ## Versions
 
-cert-manager at time of writing has 4 CRD versions in use.
+cert-manager at time of writing has 4 CRD versions in use- `v1alpha2`, `v1alpha3`, `v1beta1` and `v1`. `v1alpha2`, `v1alpha3` and `v1beta1` are getting deprecated in cert-manager `v1.4.0` and will be removed in `v1.6.0`.
 
-These versions are defined in [`//pkg/apis/certmanager`](https://github.com/jetstack/cert-manager/tree/master/pkg/apis/certmanager). ACME related resources are in `//pkg/apis/acme`.
+These versions are defined in [`//pkg/apis/certmanager`](https://github.com/jetstack/cert-manager/tree/master/pkg/apis/certmanager). ACME related resources are in [`//pkg/apis/acme`](https://github.com/jetstack/cert-manager/tree/master/pkg/apis/certmanager).
 
-This has the versions `v1alpha2`, `v1alpha3`, `v1beta1` and `v1`.
 If you need to introduce a new field in any of them it **must** be present in all 4 versions so conversion can be used.
 
 Code comments on these fields are being converted into documentation on our website and text of `kubectl explain`.
@@ -33,6 +32,8 @@ These comments should be written to be user-facing not developer-facing, they al
 We also have an internal API version, it lives at [`//pkg/internal/apis`](https://github.com/jetstack/cert-manager/tree/master/pkg/internal/apis).
 This is a version that is only used for validation and conversion, controllers should not use it as it is not meant to be user-friendly and not stable.
 However all new fields also have to be added here for the conversion logic to work.
+
+See the [official Kubernetes docs for CRD versioning](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/) to understand conversion, which version are stored and served etc.
 
 
 ## Kubebuilder

--- a/content/en/docs/installation/upgrading/remove-deprecated-apis.md
+++ b/content/en/docs/installation/upgrading/remove-deprecated-apis.md
@@ -1,0 +1,52 @@
+---
+title: "Removing Deprecated API Resources"
+linkTitle: "Removing Deprecated API Resources"
+weight: 20
+type: "docs"
+---
+
+We have deprecated the following cert-manager APIs: 
+
+- `cert-manager.io/v1alpha2`
+- `cert-manager.io/v1alpha3`
+- `cert-manager.io/v1beta1`
+- `acme.cert-manager.io/v1alpha2`
+- `acme.cert-manager.io/v1alpha3`
+- `acme.cert-manager.io/v1beta1`
+
+These APIs will be removed in cert-manager `v1.6.0`.
+If you have a cert-manager installation that is using or has previously used these deprecated APIs you may need to upgrade your cert-manager custom resources and CRDs. This needs to be done before upgrading to cert-manager `v1.6.0`. 
+
+
+## Upgrading existing cert-manager resources
+
+1. Familiarize yourself with the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#writing-reading-and-updating-versioned-customresourcedefinition-objects) on CRD versioning.
+2. Make sure your installed cert-manager deployment is `v1.0.0` or later.
+
+3. Make sure any version-controlled cert-manager custom resource config files that still use the deprecated APIs are updated to use the `cert-manager.io/v1` API and re-applied. This should update stored versions of the given resources.
+
+After that, follow the official Kubernetes documentation [here](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version):
+
+1. If there are other resources (e.g. `Certificate`s created by ingress-shim, `CertificateRequest`s, etc.) that are not version controlled and may have been created using the deprecated APIs, run
+   ```bash
+   kubectl get <resource_name> -oyaml | kubectl apply -f -
+   ```
+   to force the resources to be stored in `etcd` at the current storage version.
+
+2. To remove legacy API versions from cert-manager CRDs run the following `curl` commands:
+
+```bash
+kubectl proxy &
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/certificates.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/certificaterequests.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/issuers.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/clusterissuers.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/orders.acme.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/challenges.acme.cert-manager.io/status
+```

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -23,33 +23,17 @@ duration is very slightly larger than `renewBefore` period, then a cert gets
 renewed at `notAfter - renewBefore` which can lead to a continuous renewal loop,
 see [`cert-manager#3897`](https://github.com/jetstack/cert-manager/issues/3897).
 
-## Updating cert-manager CRDs and stored versions of cert-manager custom resources
+## Upgrading cert-manager CRDs and stored versions of cert-manager custom resources
 
-We have deprecated `cert-manager.io/v1alpha2`, `cert-manager.io/v1alpha3`, `cert-manager.io/v1beta1`, `acme.cert-manager.io/v1alpha2`, `acme.cert-manager.io/v1alpha3`, `acme.cert-manager.io/v1beta1` APIs.
-These APIs will be removed in `cert-manager` `v1.6`.
-If you have a `cert-manager` installation that is using or has previously used these APIs you may need to update `cert-manager` custom resources and CRDs. This needs to be done before upgrading to `cert-manager` `v1.6`. (See Kubernetes docs for more detailed explanation [here](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version))
+We have deprecated the following cert-manager APIs:
 
-Steps:
+- `cert-manager.io/v1alpha2`
+- `cert-manager.io/v1alpha3`
+- `cert-manager.io/v1beta1`
+- `acme.cert-manager.io/v1alpha2`
+- `acme.cert-manager.io/v1alpha3`
+- `acme.cert-manager.io/v1beta1`
 
-1. Make sure your `cert-manager` deployment is `v1` or later.
-2. Make sure any version-controlled `cert-manager` custom resource config files updated to use `cert-manager.io/v1` API and re-applied. This should update stored versions for the given resources.
-
-Further please follow the official Kubernetes documentation [here](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version):
-
-1. If there are other resources (`ingress-shim` `Certificate`s, `CertificateRequest`s etc that aren't stored in Git and may have been created using the deprecated APIs, you can run  `kubectl get <resource_name> -oyaml | kubectl apply -f -` to force the resources to be stored in `etcd` at the current storage version.
-2. To remove legacy API versions from `cert-manager` CRDs, you can run the following `curl` commands:
-```
-kubectl proxy &
-
-curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/certificates.cert-manager.io/status
-
-curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/certificaterequests.cert-manager.io/status
-
-curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/issuers.cert-manager.io/status
-
-curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/clusterissuers.cert-manager.io/status
-
-curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/orders.acme.cert-manager.io/status
-
-curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/challenges.acme.cert-manager.io/status
-```
+These APIs will be removed in cert-manager `v1.6.0`.
+If you have a cert-manager installation that is using or has previously used these deprecated APIs you may need to upgrade your cert-manager custom resources and CRDs. This needs to be done before upgrading to cert-manager `v1.6.0`.
+See cert-manager [docs](/docs/installation/upgrading/remove-deprecated-apis/#upgrading-existing-cert-manager-resources) for more detailed upgrade instructions.

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -22,3 +22,34 @@ notAfter - rb`  where  `if cert duration < renewBefore; then rb = cert duration
 duration is very slightly larger than `renewBefore` period, then a cert gets
 renewed at `notAfter - renewBefore` which can lead to a continuous renewal loop,
 see [`cert-manager#3897`](https://github.com/jetstack/cert-manager/issues/3897).
+
+## Updating cert-manager CRDs and stored versions of cert-manager custom resources
+
+We have deprecated `cert-manager.io/v1alpha2`, `cert-manager.io/v1alpha3`, `cert-manager.io/v1beta1`, `acme.cert-manager.io/v1alpha2`, `acme.cert-manager.io/v1alpha3`, `acme.cert-manager.io/v1beta1` APIs.
+These APIs will be removed in `cert-manager` `v1.6`.
+If you have a `cert-manager` installation that is using or has previously used these APIs you may need to update `cert-manager` custom resources and CRDs. This needs to be done before upgrading to `cert-manager` `v1.6`. (See Kubernetes docs for more detailed explanation [here](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version))
+
+Steps:
+
+1. Make sure your `cert-manager` deployment is `v1` or later.
+2. Make sure any version-controlled `cert-manager` custom resource config files updated to use `cert-manager.io/v1` API and re-applied. This should update stored versions for the given resources.
+
+Further please follow the official Kubernetes documentation [here](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version):
+
+1. If there are other resources (`ingress-shim` `Certificate`s, `CertificateRequest`s etc that aren't stored in Git and may have been created using the deprecated APIs, you can run  `kubectl get <resource_name> -oyaml | kubectl apply -f -` to force the resources to be stored in `etcd` at the current storage version.
+2. To remove legacy API versions from `cert-manager` CRDs, you can run the following `curl` commands:
+```
+kubectl proxy &
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/certificates.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/certificaterequests.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/issuers.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/clusterissuers.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/orders.acme.cert-manager.io/status
+
+curl -d '[{ "op": "replace", "path":"/status/storedVersions", "value": ["v1"] }]' -H "Content-Type: application/json-patch+json"  -X PATCH http://localhost:8001/apis/apiextensions.k8s.io/v1/customresourcedefinitions/challenges.acme.cert-manager.io/status
+```


### PR DESCRIPTION
This PR adds a section to the release notes about what users may need to do following the API deprecation.

In practice this would affect users who have a `cert-manager` installation that has been previously deployed at `cert-manager` version `v0.16` because the stored versions of custom resources at that time were `v1alpha2`, `v1beta` etc. 

These steps need to be done before upgrading to `cert-manager` `v1.6`. I thought it might be useful to have them ready with `v1.4` release notes as the deprecation warnings are added in `v1.4`, but perhaps this is too early?

This PR is against release-next branch as it adds v1.4 specific documentation. Once v1.4 is released, we should also merge this into master.