### PR TITLE
Add a section about Certificate's renewal time calculation

### DIFF
--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -15,7 +15,7 @@ Special thanks to the external contributors who contributed to this release:
 
 There have been slight changes in the renewal period calculation for
 certificates. Renewal time (`rt`) is now calculated using formula `rt = notAfter -
-rb` where `rb = min(renewBefore, cert duration / 3)`. (See [docs](/docs/usage/certificate/#renewal) for more
+rb` where `rb = min(renewBefore, cert duration / 3)`. (See [docs](../../usage/certificate/#renewal) for more
 detailed explanation). Previously this was calculated using formula `rt =
 notAfter - rb`  where  `if cert duration < renewBefore; then rb = cert duration
 / 3; else rb = renewBefore`. This change fixes a bug where, if a certificate's
@@ -36,4 +36,4 @@ We have deprecated the following cert-manager APIs:
 
 These APIs will be removed in cert-manager `v1.6.0`.
 If you have a cert-manager installation that is using or has previously used these deprecated APIs you may need to upgrade your cert-manager custom resources and CRDs. This needs to be done before upgrading to cert-manager `v1.6.0`.
-See cert-manager [docs](/docs/installation/upgrading/remove-deprecated-apis/#upgrading-existing-cert-manager-resources) for more detailed upgrade instructions.
+See cert-manager [docs](../../installation/upgrading/remove-deprecated-apis/#upgrading-existing-cert-manager-resources) for more detailed upgrade instructions.


### PR DESCRIPTION
Fixes a bug that is preventing me from merging https://github.com/cert-manager/website/pull/585#issuecomment-854832231. When this page was merged to release-next, it broke the build on master since these new links do not exist yet on `/docs`. They only exist in `/next-docs`.

To remediate that, we use a relative path.

cc @irbekrm 

