### PR TITLE
Work around spelling exceptions added to release-next

### DIFF
--- a/scripts/verify-lint
+++ b/scripts/verify-lint
@@ -26,13 +26,13 @@ cd "${REPO_ROOT}"
 
 echo "+++ Running 'alex' - ignoring any failures"
 "${REPO_ROOT}/node_modules/.bin/alex" \
-	content/ || true
+  content/ || true
 
 echo "+++ Running remark"
 "${REPO_ROOT}/node_modules/.bin/remark" \
-	--rc-path ".remarkrc" \
-	--frail \
-	content/
+  --rc-path ".remarkrc" \
+  --frail \
+  content/
 
 echo "+++ Running spell check"
 "${REPO_ROOT}/node_modules/.bin/mdspell" \
@@ -55,4 +55,16 @@ echo "+++ Running spell check"
   "!content/en/v1.1-docs/reference/api-docs.md" \
   "!content/en/v1.2-docs/reference/api-docs.md" \
   "!content/en/v1.3-docs/reference/api-docs.md" \
-  "!content/en/next-docs/reference/api-docs.md"
+  "!content/en/next-docs/**/*.md"
+
+# About "!content/en/next-docs/**/*.md":
+#
+# mdspell can fail on master due to words that have been added to the
+# release-next branch and aren't on master yet. Since we pull the release-next
+# branch into content/en/next-docs, the yet-to-be-ignored words are unknown to
+# mdspell.
+#
+# As an example, the PR https://github.com/cert-manager/website/pull/570 added
+# the new spellings "andreas-p" and "renewBefore" to the release-next branch.
+# After the merge, all builds on master started failing since "andreas-p" and
+# "renewBefore" were not present on the master branch's .spelling file.


### PR DESCRIPTION
## The problem

Whenever we run `mdspell`, we first clone every branch (release-1.3, release-1.4, release-next...) into the `content/en/docs/` folder.

When words are added to the release-next branch and aren't on master yet, master fails due to the yet-to-be-ignored words are unknown to `mdspell`.

As an example, the PR https://github.com/cert-manager/website/pull/570 added the new spellings "andreas-p" and "renewBefore" to the release-next branch. After the merge, all builds on master started failing since "andreas-p" and "renewBefore" were not present on the master branch's .spelling file.


## Idea 1 (this PR)

Ignore spelling of release-next. PRs merged to release-next already have no spelling mistake, so we don't really need to enforce the spelling again.

```
!content/en/next-docs/**/*.md
```

## Idea 2

Use mdspell's `--target-relative` which requires copying the `.spelling` file from the release-next branch and copy it into `content/en/next-docs`. After looking at [verify-lint](https://github.com/maelvls/website/blob/cf89afa56040cc0790f7d7a72d711af7d6fdf9dc/scripts/verify-lint#L38-L58), one way could be to have a new flag to [hugo-multiversion](https://github.com/maelvls/website/blob/cf89afa56040cc0790f7d7a72d711af7d6fdf9dc/scripts/bin/multiversion#L42), e.g.,

```diff
 ./scripts/bin/multiversion" \
 	--repo-url https://github.com/cert-manager/website.git \
 	--repo-content-dir content/en/docs \
+ 	--repo-content-extra-file .spelling \
 	--output-dir "${REPO_ROOT}/content/en" \
 	--branches v0.13-docs=release-0.13 \
 	--branches v0.12-docs=release-0.12 \
 	--branches next-docs=release-next
```

Not sure what is the right solution 😅

cc @irbekrm @munnerz 