### PR TITLE
Update supported annotations for ingress-shim Ingress

### DIFF
--- a/content/en/docs/usage/ingress.md
+++ b/content/en/docs/usage/ingress.md
@@ -88,6 +88,20 @@ trigger `Certificate` resources to be automatically created:
   returned.  This is useful for keeping compatibility with the `ingress-gce`
   component.
 
+- `cert-manager.io/common-name`: (optional) this annotation allows you to
+  configure `spec.commonName` for the `Certificate` to be generated.
+
+- ` cert-manager.io/duration`: (optional) this annotation allows you to
+  configure `spec.duration` field for the `Certificate` to be generated.
+
+- `cert-manager.io/renew-before`: (optional) this annotation allows you to
+  configure `spec.renewBefore` field for the `Certificate` to be generated.
+
+- `cert-manager.io/usages`: (optional) this annotation allows you to configure
+  `spec.usages` field for the `Certificate` to be generated. Pass a string with
+  comma-separated values i.e "key agreement,digital signature, server auth"
+
+
 ## Optional Configuration
 
 The ingress-shim sub-component is deployed automatically as part of


### PR DESCRIPTION
This PR updates the list of the documented supported annotations for `ingress-shim` `Ingress`es.
I've added the annotations parsed [here](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/ingress-shim/helper.go#L40-L68).

I have also tested that these annotations are parsed correctly by creating  an `ingress-shim` `Ingress` and verifying the properties of the issued X.509 certificate.


Fixes #592, https://github.com/jetstack/cert-manager/issues/4088

Signed-off-by: irbekrm <irbekrm@gmail.com>