### PR TITLE
Write the 1.4 release notes

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -252,8 +252,21 @@ prepended
 retweets
 JetstackHQ
 acme-dns
+Ramlot
 andreas-p
 renewBefore
+erikgb
+eddiehoffman
+inteon
+anton-johansson
+edglynes
+jandersen-plaid
+foosinn
+clatour
+tamalsaha
+JoshVanL
+Kyverno
+
 
 # As per https://tools.ietf.org/html/rfc5280, the spelling "X.509" is the
 # correct spelling. The spelling "x509" and "X509" are incorrect.

--- a/content/en/docs/release-notes/release-notes-1.3.md
+++ b/content/en/docs/release-notes/release-notes-1.3.md
@@ -5,7 +5,20 @@ weight: 800
 type: "docs"
 ---
 
-This release prepares for the implementation of certificate issuance policies and adoption of the upstream [Kubernetes CSR](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) API. It also improves interoperability with HashiCorp [Vault Enterprise](https://www.vaultproject.io/docs/enterprise).
+# Patch Release `v1.3.1`
+
+## Bug and Security Fixes
+
+- A Helm upgrade bug was
+  [fixed](https://github.com/jetstack/cert-manager/pull/3882), you should now
+  able to upgrade from cert-manager 1.2 to 1.3 when `--set installCRDs=true` is
+  used. This issue was due to [a Helm
+  bug](https://github.com/helm/helm/issues/5806#issuecomment-788116838) with the
+  `minimum` field on the CRDs.
+
+# Final Release `v1.3.0`
+
+The 1.3 release prepares for the implementation of certificate issuance policies and adoption of the upstream [Kubernetes CSR](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) API. It also improves interoperability with HashiCorp [Vault Enterprise](https://www.vaultproject.io/docs/enterprise).
 A slew of bugs have also been squashed.
 
 Special thanks to the external contributors who contributed to this release:
@@ -28,9 +41,9 @@ Please read the [upgrade notes](/docs/installation/upgrading/upgrading-1.2-1.3/)
 
 As always, the full change log is available on the [GitHub release](https://github.com/jetstack/cert-manager/releases/tag/v1.3.0).
 
-# Deprecated Features and Breaking Changes
+## Deprecated Features and Breaking Changes
 
-## Venafi Cloud Issuer
+### Venafi Cloud Issuer
 
 This release updates the [Venafi Cloud Issuer][] to use `OutagePREDICT` instead of `DevOpsACCELERATE`.
 
@@ -40,17 +53,17 @@ The zone is now `<Application Name>\<Issuing Template Alias>`
 
 [Venafi Cloud Issuer]: https://cert-manager.io/docs/configuration/venafi/
 
-## cert-manager controller
+### cert-manager controller
 
 The `--renew-before-expiration-duration` flag has been removed from the cert-manager controller, having been deprecated in the previous release.
 
-## cert-manager CRDs
+### cert-manager CRDs
 
 `CertificateRequests` are now immutable - the `spec` and `metadata.annotations` fields cannot be changed after creation. They were always designed to be immutable but this behavior is now *enforced* by the cert-manager webhook.
 
-# New Features
+## New Features
 
-## Policy Support Preparation
+### Policy Support Preparation
 
 * The [design documentation](https://github.com/jetstack/cert-manager/blob/v1.3.0/design/20210203.certificate-request-identity.md) for Certificate Identity is now available.
 * `CertificateRequests` now have identity fields mirroring the upstream [Kubernetes CSR](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) object.
@@ -59,38 +72,38 @@ The `--renew-before-expiration-duration` flag has been removed from the cert-man
 * The cert-manager controller currently always approves any `CertificateRequest`.
 * Added `kubectl cert-manager [approve|deny]` commands to the kubectl plugin.
 
-## cert-manager CRDs
+### cert-manager CRDs
 
 * `CertificateRequests` now support the `revisionHistoryLimit` field to limit the amount of retained history. The default is unlimited (`nil`).
 
-## Vault Enterprise
+### Vault Enterprise
 
 * cert-manager now sends the `X-VAULT-NAMESPACE` header for the `requestTokenWithAppRoleRef` API call.
 
-# Bug Fixes
+## Bug Fixes
 
-## cert-manager Controller
+### cert-manager Controller
 
 * Fixed an issue which could cause multiple `CertificateRequests` to be created in a short time for a single `Certificate` resource.
 * Certificate Readiness controller only updates a certificate's status if something has changed.
 
-## SelfSigned Issuer
+### SelfSigned Issuer
 
 * The issuer now warns if you request a certificate with an empty subject DN - creating a certificate that is in violation of RFC 5280. Some applications will reject such certificates as invalid, such as Java's `keytool`.
 
-## Helm Chart
+### Helm Chart
 
 * The `targetPort` used by the Prometheus service monitor is now correctly set from helm values.
 * The correct permissions are added to the aggregate `edit` role.
 
-# Other Changes
+## Other Changes
 
 ## Repository Hygiene
 
 * `SECURITY.md` now contains information on how to report security issues.
 * The language of `CONTRIBUTING.md` has been updated to match existing copyright notices.
 
-## Tooling
+### Tooling
 
 * cert-manager now can be built with go 1.16 on Apple Silicon.
 * Docker images targets have been added to the Makefile.

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -48,7 +48,10 @@ resources][upgrade-resources] page.
 
 {{% /pageinfo %}}
 
+This change was made in the cert-manager PR [#4021][].
+
 [upgrade-resources]: ../../installation/upgrading/remove-deprecated-apis/#upgrading-existing-cert-manager-resources
+[#4021]: https://github.com/jetstack/cert-manager/pull/4021 "Warn about removal of old v1alpha2, v1alpha3 and v1beta1 in 1.6"
 
 ### Helm chart: `securityContext` defaults to non-root
 
@@ -74,6 +77,10 @@ will need to set this back to `false`.
 
 {{% /pageinfo %}}
 
+Implemented in the cert-manager PR [#4036][].
+
+[#4036]: https://github.com/jetstack/cert-manager/pull/4036 "controller, cainject and webhook now run as non-root"
+
 ### CA, Vault and Venafi issuer handling of `ca.crt` and `tls.crt`
 
 The CA, Vault, and Venafi issuer now produce a `tls.crt` that is de-duplicated,
@@ -84,9 +91,7 @@ The CA issuer now produces a `ca.crt` that contains the "most" root CA that
 cert-manager is aware of. `ca.crt` may thus not be the actual self-signed root
 CA, since cert-manager may not be aware of it.
 
-[#3982]: https://github.com/jetstack/cert-manager/pull/3982 "All issuers + Vault issuer"
-[#3983]: https://github.com/jetstack/cert-manager/pull/3983 "Venafi issuer"
-[#3985]: https://github.com/jetstack/cert-manager/pull/3985 "CA issuer"
+Fixed in the cert-manager PRs [#3982][], [#3983][], and [#3985][].
 
 {{% pageinfo color="warning" %}}
 
@@ -94,6 +99,10 @@ CA, since cert-manager may not be aware of it.
 managed by cert-manager with the CA issuer.
 
 {{% /pageinfo %}}
+
+[#3982]: https://github.com/jetstack/cert-manager/pull/3982 "All issuers + Vault issuer"
+[#3983]: https://github.com/jetstack/cert-manager/pull/3983 "Venafi issuer"
+[#3985]: https://github.com/jetstack/cert-manager/pull/3985 "CA issuer"
 
 
 ### Vault renewal bug
@@ -116,6 +125,10 @@ behavior.
 
 {{% /pageinfo %}}
 
+Fixed in the cert-manager PR [#4092][].
+
+[#4092]: https://github.com/jetstack/cert-manager/pull/4092 "Defaukt renewal changed from 30 days before to 2/3 of the duration before expiry"
+
 ## New Features
 
 ### Experimental Support for Kubernetes CertificateSigningRequests
@@ -136,6 +149,9 @@ cert-manager can sign the CSR.
 The documentation is available on the [the Kubernetes CSR usage
 page](../../usage/kube-csr/).
 
+Implemented in cert-manager PR [#4064][].
+
+[#4064]: https://github.com/jetstack/cert-manager/pull/4064 "CA issuer experimental support for CertificateSigningRequests"
 [CertificateSigningRequest]: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
 
 ### Helm chart: webhook externally accessible for bare-metal
@@ -155,6 +171,8 @@ webhook:
   url:
     host: 198.51.100.20
 ```
+
+Implemented in the cert-manager PR [#4064][].
 
 ### Helm chart: Service labels
 
@@ -180,6 +198,10 @@ With the above example, the source label
 `__meta_kubernetes_service_label_app='armada-api'` becomes the new label
 `app='armada-api'` when metrics related to this Service are scraped.
 
+Implemented in the cert-manager PR [#4009][].
+
+[#4009]: https://github.com/jetstack/cert-manager/pull/4009 "Helm chart: the Service labels can now be set on the controller"
+
 ### Akamai DNS01 solver
 
 The Akamai DNS01 solver has been [updated][4007] to use the v2 of the `OPEN
@@ -192,18 +214,132 @@ EdgeGrid` Go package.
 - The [RFC2136](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/)
   issuer is now able to handle DNS01 challenges that map to multiple `TXT`
   records. This lets you create Let's Encrypt certificates using RFC2136 with
-  multiple DNS names.
+  multiple DNS names. Fixed in the cert-manager PR [#3622][].
 - The comparison function `PublicKeysEqual` is now correct for public keys.
+  Fixed in PR [#3914][].
 - The ACME issuer now works correctly with Certificates that have a long name
   (52 characters or more). These Certificates would not get renewed due to
-  non-unique `Order` names being generated.
+  non-unique Order names being generated. Fixed in the cert-manager PR
+  [#3866][].
 - Orders that are used with a misbehaving ACME server should not get stuck
   anymore. By misbehaving, we mean an ACME server that would validate the
-  authorizations before having set the status of the order to "ready".
-- The internal signers now set the condition `Ready=False` with the reason
-  `RequestDenied` when a CertificateRequest is `Denied`. This is to keep the
-  same behavior where a terminal state of a CertificateRequest should have a
-  `Ready` condition.
+  authorizations before having set the status of the order to "ready". Fixed in
+  the cert-manager PR [#3805][].
+- The internal issuers now set the condition `Ready=False` with the reason
+  `RequestDenied` when a CertificateRequest has been `Denied`. This is to keep
+  the same behavior where a terminal state of a CertificateRequest should have a
+  `Ready` condition. Fixed in the cert-manager PR [#3878][].
+
+[#3622]: https://github.com/jetstack/cert-manager/pull/3622 "RFC2136 fixed when used with challenge domains that contain multiple TXT records"
+[#3914]: https://github.com/jetstack/cert-manager/pull/3914 "Comparison between public keys now works properly"
+[#3866]: https://github.com/jetstack/cert-manager/pull/3866 "Certificates with long names are not generated non-unique Orders anymore"
+[#3805]: https://github.com/jetstack/cert-manager/pull/3805 "Misbehaving ACME servers won't get Orders stuck anymore"
+[#3878]: https://github.com/jetstack/cert-manager/pull/3878 "When a CertificateRequest is Denied, the internal issuers set Ready=False"
+
+## Other Changes
+
+- The cert-manager controller now uses the `configmapsleases` resource instead
+  of the `configmaps` one for leader election. The only noticeable difference is
+  that a new `Lease` object is now being created in the leader election
+  namespace. Implemented in the cert-manager PR [#4016][].
+
+[#4016]: https://github.com/jetstack/cert-manager/pull/4016 "Use the configmapsleases resource instead of configmaps"
+
+- The `keyAlgorithm` for the ACME Issuer is now deprecated, and the EAB MAC
+  algorithm is now hardcoded to `HS256`.
+
+    ```yaml
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+      spec:
+        acme:
+          externalAccountBinding:
+            keyAlgorithm: HS256      # DEPRECATED.
+    ```
+    Previously, we used to have a fork of `golang/crypto` which allowed us to set
+    the EAB MAC algorithm. We now use the upstream version of `golang/crypto`
+    where the EAB MAC algorithm is hardcoded to HS256.
+
+    This change were implemented in the cert-manager PRs [#3877][] and [#3936][].
+
+[#3877]: https://github.com/jetstack/cert-manager/pull/3877 "Deprecation of the keyAlgorithm field"
+[#3936]: https://github.com/jetstack/cert-manager/pull/3936 "Webhook warns the user when keyAlgorithm is used"
+
+- If you happen to look at the cert-manager controller logs, you may see this
+  new message about optimistic locking:
+
+    ```
+    I0419 controller.go:158] msg="re-queuing item due to optimistic locking on resource" error="Operation cannot be fulfilled on certificates.cert-manager.io   sauron-adverts-evo-app-tls: the object has been modified; please apply your changes to the latest version and try again"
+    ```
+
+    This message, shown at the `info` level, replaces the `error` level message
+    that showed previously:
+
+    ```
+    E0419 controller.go:158] msg="re-queuing item due to error processing" error="Operation cannot be fulfilled on certificates.cert-manager.io sauron-adverts-evo-app-tls: the   object has been modified; please apply your changes to the latest version and try again"
+    ```
+
+    The goal is to prevent users from thinking that the optimistic locking
+    mechanism has to do with their issues, when in reality it mostly isn't and is
+    the normal operation mode for Kubernetes controllers.
+
+    Fixed in the cert-manager PR [#3794][].
+
+[#3794]: https://github.com/jetstack/cert-manager/pull/3794 "Less alarming message on optimistic locking errors"
+
+- The `util.UsageContentCommittment` (which contained a spelling mistake) was
+  deprecated in favor of `util.UsageContentCommitment`. The only people impacted
+  by this deprecation are the the people importing the Go package
+  `github.com/jetstack/cert-manager/pkg/api/util`.
+
+[#3860]: https://github.com/jetstack/cert-manager/pull/3860 "Fix a spelling mistake in a cert-manager Go package and deprecate the old name"
+
+- The webhook now panics when it is not able to register the API schemes.
+  Previously, the webhook would silently skip the error and start.
+
+[#4037]: https://github.com/jetstack/cert-manager/pull/4037 "Webhook now panics instead of silently starting if the API scheme cannot be registered"
+
+- A couple of legacy functions in `test/e2e/util` package have been removed.
+  These functions can be found in the `test/unit/gen` package.
+
+[#3873]: https://github.com/jetstack/cert-manager/pull/3873 "Legacy functions in the test/e2e/util have been removed"
+
+- The Kubernetes Go packages have been updated from `v0.19.0` to `v0.21.0`.
+
+[#3926]: https://github.com/jetstack/cert-manager/pull/3926 "Update Kubernetes Go imports from v0.19.0 to v0.21.0"
+
+- When waiting for DNS propagating, the ACME DNS01 self-check now returns a
+  better message when an unexpected DNS response code is received, such as
+  `SERVFAIL`.
+
+    Before:
+    ```
+    Could not find the start of authority
+    ```
+
+    After:
+    ```
+    Could not find the SOA record in the DNS tree
+    for the domain '_acme-challenge.foo.example.com'
+    using nameservers [8.8.8.8, 8.8.4.4]
+    ```
+
+    In addition to the above, you will get a new message when the DNS returns an
+    unexpected response code:
+
+    ```
+    When querying the SOA record for the domain
+    '_acme-challenge.foo.example.com' using nameservers
+    [8.8.8.8, 8.8.4.4], rcode was expected to be 'NOERROR'
+    or 'NXDOMAIN', but got 'SERVFAIL'
+    ```
+
+    Fixed in the cert-manager PR [#3906][].
+
+[#3906]: https://github.com/jetstack/cert-manager/pull/3906 "Better message when the ACME DNS01 self-check gets an unexpected DNS response code"
+
+- The `distroless/static` base image was updated to the latest version as of
+  2021-05-20.
 
 ## Honorable mentions
 

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -133,12 +133,6 @@ page](../../usage/kube-csr/).
 The Vault issuer is now able to fill the `ca.crt` in Secrets. The `ca.crt` set
 by cert-manager may be an intermediate signing CA instead of the actual root CA.
 
-The reason why this feature did not exist previously is that finding which
-certificate is at the top of the chain is not trivial. Take a look at
-[@JoshVanL](https://github.com/JoshVanL)'s excellent
-[`ParseSingleCertificateChain`](https://github.com/jetstack/cert-manager/blob/5e2a6883c1202739902ac94b5f4884152b810925/pkg/util/pki/parse.go#L167-L244)
-to see what this is all about!
-
 ### Helm chart: webhook externally accessible for bare-metal
 
 In [some](https://github.com/kubernetes/kubernetes/issues/72936#issue-399522387)

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -39,16 +39,9 @@ These APIs will be removed in cert-manager 1.6.
 {{% pageinfo color="warning" %}}
 
 ⛔️  If you are upgrading cert-manager on a cluster which has previously had
-cert-manager < `v1.0.0`, you **must** take steps to upgrade all cert-manager
-custom resources which were created by you or by cert-manager < `v1.0.0`.
-
-Such custom resources may still be stored in `etcd` as `v1alpha2` resources and
-when that version of the API is removed in cert-manager 1.6, they will become
-unreadable.
-
-To work around this, you need to force them to be converted by the cert-manager
-conversion webhook. And the simplest way to do that is to perform a no-change
-update on all cert-manager custom resources.
+cert-manager < `v1.0.0`, you will need to ensure that all cert-manager custom resources
+are stored in etcd at `v1` version and that cert-manger CRDs do not reference the deprecated APIs
+**by the time you upgrade to `v1.6`**.
 
 This is explained in more detail in the [Upgrading existing cert-manager
 resources][upgrade-resources] page.

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -39,9 +39,9 @@ These APIs will be removed in cert-manager 1.6.
 {{% pageinfo color="warning" %}}
 
 ⛔️  If you are upgrading cert-manager on a cluster which has previously had
-cert-manager < `v1.0.0`, you will need to ensure that all cert-manager custom resources
-are stored in etcd at `v1` version and that cert-manger CRDs do not reference the deprecated APIs
-**by the time you upgrade to `v1.6`**.
+cert-manager < `v1.0.0`, you will need to ensure that all cert-manager custom
+resources are stored in `etcd` at `v1` version and that cert-manger CRDs do not
+reference the deprecated APIs **by the time you upgrade to `v1.6`**.
 
 This is explained in more detail in the [Upgrading existing cert-manager
 resources][upgrade-resources] page.
@@ -246,7 +246,7 @@ EdgeGrid` Go package.
 [#4016]: https://github.com/jetstack/cert-manager/pull/4016 "Use the configmapsleases resource instead of configmaps"
 
 - The `keyAlgorithm` for the ACME Issuer is now deprecated, and the EAB MAC
-  algorithm is now hardcoded to `HS256`.
+  algorithm is now hard-coded to `HS256`.
 
     ```yaml
     apiVersion: cert-manager.io/v1
@@ -258,7 +258,7 @@ EdgeGrid` Go package.
     ```
     Previously, we used to have a fork of `golang/crypto` which allowed us to set
     the EAB MAC algorithm. We now use the upstream version of `golang/crypto`
-    where the EAB MAC algorithm is hardcoded to HS256.
+    where the EAB MAC algorithm is hard-coded to HS256.
 
     This change were implemented in the cert-manager PRs [#3877][] and [#3936][].
 
@@ -304,7 +304,7 @@ EdgeGrid` Go package.
 
 [#3873]: https://github.com/jetstack/cert-manager/pull/3873 "Legacy functions in the test/e2e/util have been removed"
 
-- The Kubernetes Go packages have been updated from `v0.19.0` to `v0.21.0`.
+- The Kubernetes Go dependencies have been updated from `v0.19.0` to `v0.21.0`.
 
 [#3926]: https://github.com/jetstack/cert-manager/pull/3926 "Update Kubernetes Go imports from v0.19.0 to v0.21.0"
 

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -72,12 +72,20 @@ will need to set this back to `false`.
 
 {{% /pageinfo %}}
 
-### CA Issuer and `ca.crt`
+### CA, Vault and Venafi issuer handling of `ca.crt` and `tls.crt`
 
-The CA issuer now attempts to store the root CA instead of the issuing CA into
-the `ca.crt` field for issued certificates. All of the information which was
-previously available is still available: the intermediate should appear as part
-of the chain in `tls.crt`.
+The CA, Vault, and Venafi issuer now produce a `tls.crt` that is de-duplicated,
+in the correct order (leaf at the top, issuing certificate at the bottom) and
+verified (i.e. each signature can be verified).
+
+The CA issuer now produces a `ca.crt` that contains the root-most CA instead of
+the intermediate CA when the issuing certificate is an intermediate CA. By
+root-most, we mean that `ca.crt` is the root of the chain of certificates that
+cert-manager knows about, but it might not be the self-signed root CA.
+
+[#3982]: https://github.com/jetstack/cert-manager/pull/3982 "All issuers + Vault issuer"
+[#3983]: https://github.com/jetstack/cert-manager/pull/3983 "Venafi issuer"
+[#3985]: https://github.com/jetstack/cert-manager/pull/3985 "CA issuer"
 
 {{% pageinfo color="warning" %}}
 
@@ -85,6 +93,7 @@ of the chain in `tls.crt`.
 managed by cert-manager with the CA issuer.
 
 {{% /pageinfo %}}
+
 
 ### Vault renewal bug
 
@@ -127,11 +136,6 @@ The documentation is available on the [the Kubernetes CSR usage
 page](../../usage/kube-csr/).
 
 [CertificateSigningRequest]: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
-
-### Vault Issuer handle of `ca.crt`
-
-The Vault issuer is now able to fill the `ca.crt` in Secrets. The `ca.crt` set
-by cert-manager may be an intermediate signing CA instead of the actual root CA.
 
 ### Helm chart: webhook externally accessible for bare-metal
 

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -133,7 +133,7 @@ kubectl certificate approve test
 ```
 
 cert-manager then signs the CSR. To know more about it, see [the
-documentation](../../usage/kube-csr) on how use the built-in
+documentation](../../usage/kube-csr/) on how use the built-in
 CertificateSigningRequests with cert-manager.
 
 [CertificateSigningRequest]: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
@@ -246,7 +246,10 @@ effort to have this PR ready and merged for the 1.4 release.
 After a lot of thinking, we have decided that trying to support every custom
 resource for every proxy could not be done in-tree due to the Go dependency
 weight that each integration adds. Jake Sanders proposed an [out-of-tree
-approach](https://github.com/jetstack/cert-manager/issues/3924), and we have Tim
-[has been
+approach](https://github.com/jetstack/cert-manager/issues/3924) that will be
+worked on as part of cert-manager 1.5.
+
+As a side note, we are pleased to announce that Tim [has been
 accepted](https://summerofcode.withgoogle.com/projects/#4841881566969856) for
-the 2021 Google Summer of Code to work on this feature!
+the 2021 Google Summer of Code to work on the `kubectl cert-manager install`
+command.

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -85,6 +85,27 @@ still available: the intermediate should appear as part of the chain in
 
 {{% /pageinfo %}}
 
+## Vault renewal bug
+
+The renewal behaviour has changed when a Certificate has a `duration` value of
+more than 90 days and `renewBefore` has not been set.
+
+Previously, the Certificate was renewed 30 days before expiry;
+[now](https://github.com/jetstack/cert-manager/pull/4092), the renewal happens
+2/3 through the duration.
+
+This change was necessary to fix a bug where users of the Vault issuer would see
+a clash between the default renewal duration of 30 days and the duration of
+certificates issued by the Vault PKI.
+
+{{% pageinfo color="warning" %}}
+
+⛔️  If you were relying on the default renewal happening 30 days before expiry,
+we would advise setting `renewBefore` to 30 days (`720h`) to keep the old
+behavior.
+
+{{% /pageinfo %}}
+
 # New Features
 
 ## Support for the built-in CertificateSigningRequests
@@ -205,11 +226,6 @@ Edgegrid EdgeDNS v2 API.
 
 # Bug Fixes
 
-- The default certificate renewal duration of 30 days was clashing with the
-  duration of certificates issued by the Vault PKI. All Certificates [are
-  now](https://github.com/jetstack/cert-manager/pull/4092) renewed 2/3 through
-  the duration unless a custom renew period is specified with the setting
-  `spec.renewBefore` on the Certificate.
 - The [RFC2136](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/)
   issuer is [now](https://github.com/jetstack/cert-manager/pull/3622) able to
   handle DNS-01 challenges that map to multiple `TXT` records. This lets you

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -38,15 +38,24 @@ These APIs will be removed in cert-manager 1.6.
 
 {{% pageinfo color="warning" %}}
 
-⛔️  If you have a cert-manager installation that is using or has previously used
-these deprecated APIs, you may need to upgrade your cert-manager custom
-resources and CRDs.
+⛔️  If you are upgrading cert-manager on a cluster which has previously had
+cert-manager < `v1.0.0`, you **must** take steps to upgrade all cert-manager
+custom resources which were created by you or by cert-manager < `v1.0.0`.
 
-This needs to be done before upgrading to cert-manager 1.6. See cert-manager
-[docs](../../installation/upgrading/remove-deprecated-apis/#upgrading-existing-cert-manager-resources)
-for more detailed upgrade instructions.
+Such custom resources may still be stored in `etcd` as `v1alpha2` resources and
+when that version of the API is removed in cert-manager 1.6, they will become
+unreadable.
+
+To work around this, you need to force them to be converted by the cert-manager
+conversion webhook. And the simplest way to do that is to perform a no-change
+update on all cert-manager custom resources.
+
+This is explained in more detail in the [Upgrading existing cert-manager
+resources][upgrade-resources] page.
 
 {{% /pageinfo %}}
+
+[upgrade-resources]: ../../installation/upgrading/remove-deprecated-apis/#upgrading-existing-cert-manager-resources
 
 ### Helm chart: `securityContext` defaults to non-root
 

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -50,8 +50,8 @@ for more detailed upgrade instructions.
 
 ### Helm chart: `securityContext` defaults to non-root
 
-The Helm chart [now](https://github.com/jetstack/cert-manager/pull/4036) follows
-the current Pod hardening best practices as defined by the Kyverno [`pod-security
+The Helm chart now follows the current Pod hardening best practices as defined
+by the Kyverno [`pod-security
 restricted`](https://kyverno.io/policies/pod-security/#restricted) policy.
 
 To pass the validation, the controller, webhook, and cainjector Pods are now
@@ -74,11 +74,10 @@ will need to set this back to `false`.
 
 ### CA Issuer and `ca.crt`
 
-The CA issuer [now](https://github.com/jetstack/cert-manager/pull/3865) attempts
-to store the root CA instead of the issuing CA into the `ca.crt` field for
-issued certificates. All of the information which was previously available is
-still available: the intermediate should appear as part of the chain in
-`tls.crt`.
+The CA issuer now attempts to store the root CA instead of the issuing CA into
+the `ca.crt` field for issued certificates. All of the information which was
+previously available is still available: the intermediate should appear as part
+of the chain in `tls.crt`.
 
 {{% pageinfo color="warning" %}}
 
@@ -92,9 +91,8 @@ still available: the intermediate should appear as part of the chain in
 The renewal behavior has changed when a Certificate has a `duration` value of
 more than 90 days and `renewBefore` has not been set.
 
-Previously, the Certificate was renewed 30 days before expiry;
-[now](https://github.com/jetstack/cert-manager/pull/4092), the renewal happens
-2/3 through the duration.
+Previously, the Certificate was renewed 30 days before expiry; now, the renewal
+happens 2/3 through the duration.
 
 This change was necessary to fix a bug where users of the Vault issuer would see
 a clash between the default renewal duration of 30 days and the duration of
@@ -112,11 +110,10 @@ behavior.
 
 ### Support for the built-in CertificateSigningRequests
 
-It is [now](https://github.com/jetstack/cert-manager/pull/4064) possible to use
-the built-in Kubernetes [CertificateSigningRequest][] resources with
-cert-manager. The CA Issuer is currently the only supported issuer. The feature
-is experimental and can be enabled by adding a flag to the cert-manager
-controller. For example, with Helm:
+It is now possible to use the built-in Kubernetes [CertificateSigningRequest][]
+resources with cert-manager. The CA Issuer is currently the only supported
+issuer. The feature is experimental and can be enabled by adding a flag to the
+cert-manager controller. For example, with Helm:
 
 ```sh
 helm install cert-manager jetstack/cert-manager \
@@ -182,8 +179,7 @@ In [some](https://github.com/kubernetes/kubernetes/issues/72936#issue-399522387)
 Kubernetes setups, the apiserver is not able to talk to `kube-dns` (i.e., when
 Kubernetes is running on bare-metal with no special `resolv.conf`).
 
-To work around that, the cert-manager webhook can
-[now](https://github.com/jetstack/cert-manager/pull/3876) be configured to be
+To work around that, the cert-manager webhook can now be configured to be
 accessible from outside of the cluster. For example, in `values.yaml`:
 
 ```yaml
@@ -197,9 +193,8 @@ webhook:
 
 ### Helm chart: Service labels
 
-The cert-manager controller Service
-[now](https://github.com/jetstack/cert-manager/pull/4009) supports custom labels
-using the top-level field in `values.yaml`:
+The cert-manager controller Service now supports custom labels using the
+top-level field in `values.yaml`:
 
 ```yaml
 # values.yaml
@@ -229,24 +224,20 @@ the `OPEN EdgeGrid` Go package.
 ## Bug Fixes
 
 - The [RFC2136](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/)
-  issuer is [now](https://github.com/jetstack/cert-manager/pull/3622) able to
-  handle DNS01 challenges that map to multiple `TXT` records. This lets you
-  create Let's Encrypt certificates using RFC2136 with multiple DNS names.
-- The comparison function `PublicKeysEqual` is
-  [now](https://github.com/jetstack/cert-manager/pull/3914) correct for public
-  keys.
-- The ACME issuer [now](https://github.com/jetstack/cert-manager/pull/3866)
-  works correctly with Certificates that have a long name (52 characters or
-  more). These Certificates would not get renewed due to non-unique `Order`
-  names being generated.
+  issuer is now able to handle DNS01 challenges that map to multiple `TXT`
+  records. This lets you create Let's Encrypt certificates using RFC2136 with
+  multiple DNS names.
+- The comparison function `PublicKeysEqual` is now correct for public keys.
+- The ACME issuer now works correctly with Certificates that have a long name
+  (52 characters or more). These Certificates would not get renewed due to
+  non-unique `Order` names being generated.
 - Orders that are used with a misbehaving ACME server should not get stuck
-  [anymore](https://github.com/jetstack/cert-manager/pull/3805). By misbehaving,
-  we mean an ACME server that would validate the authorizations before having
-  set the status of the order to "ready".
-- The internal signers [now](https://github.com/jetstack/cert-manager/pull/3878)
-  set the condition `Ready=False` with the reason `RequestDenied` when a
-  CertificateRequest is `Denied`. This is to keep the same behavior where a
-  terminal state of a CertificateRequest should have a `Ready` condition.
+  anymore. By misbehaving, we mean an ACME server that would validate the
+  authorizations before having set the status of the order to "ready".
+- The internal signers now set the condition `Ready=False` with the reason
+  `RequestDenied` when a CertificateRequest is `Denied`. This is to keep the
+  same behavior where a terminal state of a CertificateRequest should have a
+  `Ready` condition.
 
 ## Honorable mentions
 
@@ -260,8 +251,3 @@ resource for every proxy could not be done in-tree due to the Go dependency
 weight that each integration adds. Jake Sanders proposed an [out-of-tree
 approach](https://github.com/jetstack/cert-manager/issues/3924) that will be
 worked on as part of cert-manager 1.5.
-
-As a side note, we are pleased to announce that Tim [has been
-accepted](https://summerofcode.withgoogle.com/projects/#4841881566969856) for
-the 2021 Google Summer of Code to work on the `kubectl cert-manager install`
-command.

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -187,11 +187,12 @@ With the above example, the source label
 `__meta_kubernetes_service_label_app='armada-api'` becomes the new label
 `app='armada-api'` when metrics related to this Service are scraped.
 
-### Akamai issuer
+### Akamai DNS01 solver
 
-The Akamai issuer has been
-[updated](https://github.com/jetstack/cert-manager/pull/4007) to use the v2 of
-the `OPEN EdgeGrid` Go package.
+The Akamai DNS01 solver has been [updated][4007] to use the v2 of the `OPEN
+EdgeGrid` Go package.
+
+[#4007]: https://github.com/jetstack/cert-manager/pull/4007 "Update of the Akamai DNS01 solver"
 
 ## Bug Fixes
 

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -125,7 +125,7 @@ behavior.
 
 ## New Features
 
-### Support for the built-in CertificateSigningRequests
+### Experimental Support for Kubernetes CertificateSigningRequests
 
 It is now possible to use the built-in Kubernetes [CertificateSigningRequest][]
 resources with cert-manager. The CA Issuer is currently the only supported

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -130,12 +130,8 @@ page](../../usage/kube-csr/).
 
 ### Vault Issuer handle of `ca.crt`
 
-The Vault issuer is now able to fill the `ca.crt` in Secrets. To do that,
-cert-manager reconstructs the certificate chain that is returned by Vault and
-uses the certificate at the start of the chain as the `ca.crt`.
-
-Note that this `ca.crt` may be an intermediate signing CA instead of the actual
-root CA.
+The Vault issuer is now able to fill the `ca.crt` in Secrets. The `ca.crt` set
+by cert-manager may be an intermediate signing CA instead of the actual root CA.
 
 The reason why this feature did not exist previously is that finding which
 certificate is at the top of the chain is not trivial. Take a look at

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -49,10 +49,10 @@ for more detailed upgrade instructions.
 ## Helm chart: `securityContext` defaults to non-root
 
 The Helm chart [now](https://github.com/jetstack/cert-manager/pull/4036) follows
-the current Pod hardening best practices as defined by the Kyverno [pod-security
-restricted](https://kyverno.io/policies/pod-security/#restricted) policy.
+the current Pod hardening best practices as defined by the Kyverno [`pod-security
+restricted`](https://kyverno.io/policies/pod-security/#restricted) policy.
 
-To pass the validation, the controller, webbook, and cainjector Pods are now
+To pass the validation, the controller, webhook, and cainjector Pods are now
 running as non-root:
 
 ```yaml
@@ -87,7 +87,7 @@ still available: the intermediate should appear as part of the chain in
 
 ## Vault renewal bug
 
-The renewal behaviour has changed when a Certificate has a `duration` value of
+The renewal behavior has changed when a Certificate has a `duration` value of
 more than 90 days and `renewBefore` has not been set.
 
 Previously, the Certificate was renewed 30 days before expiry;
@@ -177,7 +177,7 @@ to see what this is all about!
 ### Helm chart: webhook externally accessible for bare-metal
 
 In [some](https://github.com/kubernetes/kubernetes/issues/72936#issue-399522387)
-Kubernetes setups, the apiserver is not able to talk to kube-dns (i.e., when
+Kubernetes setups, the apiserver is not able to talk to `kube-dns` (i.e., when
 Kubernetes is running on bare-metal with no special `resolv.conf`).
 
 To work around that, the cert-manager webhook can
@@ -218,17 +218,17 @@ With the above example, the source label
 `__meta_kubernetes_service_label_app='armada-api'` becomes the new label
 `app='armada-api'` when metrics related to this Service are scraped.
 
-## Akamai issuer and Open Edgegrid EdgeDNS v2
+## Akamai issuer
 
 The Akamai issuer has been
-[updated](https://github.com/jetstack/cert-manager/pull/4007) to use Open
-Edgegrid EdgeDNS v2 API.
+[updated](https://github.com/jetstack/cert-manager/pull/4007) to use the v2 of
+the `OPEN EdgeGrid` Go package.
 
 # Bug Fixes
 
 - The [RFC2136](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/)
   issuer is [now](https://github.com/jetstack/cert-manager/pull/3622) able to
-  handle DNS-01 challenges that map to multiple `TXT` records. This lets you
+  handle DNS01 challenges that map to multiple `TXT` records. This lets you
   create Let's Encrypt certificates using RFC2136 with multiple DNS names.
 - The comparison function `PublicKeysEqual` is
   [now](https://github.com/jetstack/cert-manager/pull/3914) correct for public
@@ -255,7 +255,7 @@ Edgegrid EdgeDNS v2 API.
 # Honorable mentions
 
 Tim Ramlot ([@inteon](https://github.com/inteon)) has done a fantastic job at
-adding the Istio VirtualService support for HTTP01 challenges in
+adding the Istio `VirtualService` support for HTTP01 challenges in
 [#3724](https://github.com/jetstack/cert-manager/pull/3724). It took an immense
 effort to have this PR ready and merged for the 1.4 release.
 

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -81,8 +81,8 @@ of the chain in `tls.crt`.
 
 {{% pageinfo color="warning" %}}
 
-⛔️  This is a change of behavior with the CA Issuer, make sure that the change in
-`ca.crt` does not impact you current use.
+⛔️  You may need to adjust systems that consume the `ca.crt` from Secrets
+managed by cert-manager with the CA issuer.
 
 {{% /pageinfo %}}
 
@@ -120,41 +120,11 @@ helm install cert-manager jetstack/cert-manager \
   --set extraArgs="{--feature-gates=ExperimentalCertificateSigningRequestControllers=true}"
 ```
 
-Imagining that you have an existing CA issuer named `my-ca-issuer` in the
-default namespace. To let cert-manager sign your CSR, you (the entity creating
-the CSR) need a [specific
-role](../../usage/kube-csr/#referencing-namespaced-issuers). You can then
-create a CertificateSigningRequest:
+Note that you will still need to manually approve the CSR object before
+cert-manager can sign the CSR.
 
-```sh
-openssl genrsa -out test.key 2048
-kubectl apply -f - <<EOF
-apiVersion: certificates.k8s.io/v1
-kind: CertificateSigningRequest
-metadata:
-  name: test
-spec:
-  groups:
-  - system:authenticated
-  request: $(openssl req -new -key test.key -out /dev/stdout | base64 | tr -d "\n")
-  signerName: issuers.cert-manager.io/default.my-ca-issuer
-  usages:
-  - client auth
-EOF
-```
-
-You will still need to manually approve the CSR since cert-manager does not
-approve CSRs by default
-([unlike](../../concepts/certificaterequest/#approval)
-CertificateRequests that get automatically approved by default):
-
-```sh
-kubectl certificate approve test
-```
-
-cert-manager then signs the CSR. To know more about it, see [the
-documentation](../../usage/kube-csr/) on how use the built-in
-CertificateSigningRequests with cert-manager.
+The documentation is available on the [the Kubernetes CSR usage
+page](../../usage/kube-csr/).
 
 [CertificateSigningRequest]: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
 

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -217,9 +217,10 @@ Edgegrid EdgeDNS v2 API.
 - The comparison function `PublicKeysEqual` is
   [now](https://github.com/jetstack/cert-manager/pull/3914) correct for public
   keys.
-- The upgrade from v1.3.0 to 1.4.0 with Helm and `--set installCRDs=true` is
-  [now](https://github.com/jetstack/cert-manager/pull/3882) possible. This issue
-  was due to [a Helm
+- A Helm upgrade bug was
+  [fixed](https://github.com/jetstack/cert-manager/pull/3882), you should now
+  able to upgrade from 1.3.1 to 1.4.0 when `--set installCRDs=true` is used.
+  This issue was due to [a Helm
   bug](https://github.com/helm/helm/issues/5806#issuecomment-788116838) with the
   `minimum` field on the CRDs.
 - The ACME issuer [now](https://github.com/jetstack/cert-manager/pull/3866)

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -87,10 +87,9 @@ The CA, Vault, and Venafi issuer now produce a `tls.crt` that is de-duplicated,
 in the correct order (leaf at the top, issuing certificate at the bottom) and
 verified (i.e. each signature can be verified).
 
-The CA issuer now produces a `ca.crt` that contains the root-most CA instead of
-the intermediate CA when the issuing certificate is an intermediate CA. By
-root-most, we mean that `ca.crt` is the root of the chain of certificates that
-cert-manager knows about, but it might not be the self-signed root CA.
+The CA issuer now produces a `ca.crt` that contains the "most" root CA that
+cert-manager is aware of. `ca.crt` may thus not be the actual self-signed root
+CA, since cert-manager may not be aware of it.
 
 [#3982]: https://github.com/jetstack/cert-manager/pull/3982 "All issuers + Vault issuer"
 [#3983]: https://github.com/jetstack/cert-manager/pull/3983 "Venafi issuer"

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -158,9 +158,9 @@ accessible from outside of the cluster. For example, in `values.yaml`:
 # values.yaml
 webhook:
   serviceType: LoadBalancer
-  loadBalancerIP: 85.78.90.100
+  loadBalancerIP: 198.51.100.20
   url:
-    host: 85.78.90.100
+    host: 198.51.100.20
 ```
 
 ### Helm chart: Service labels

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -5,6 +5,8 @@ weight: 800
 type: "docs"
 ---
 
+# Final Release `v1.4.0`
+
 Special thanks to the external contributors who contributed to this release:
 
 * [@andreas-p](https://github.com/andreas-p)
@@ -19,9 +21,9 @@ Special thanks to the external contributors who contributed to this release:
 * [@clatour](https://github.com/clatour)
 * [@tamalsaha](https://github.com/tamalsaha)
 
-# Deprecated Features and Breaking Changes
+## Deprecated Features and Breaking Changes
 
-## Upgrading cert-manager CRDs and stored versions of cert-manager custom resources
+### Upgrading cert-manager CRDs and stored versions of cert-manager custom resources
 
 We have deprecated the following cert-manager APIs:
 
@@ -46,7 +48,7 @@ for more detailed upgrade instructions.
 
 {{% /pageinfo %}}
 
-## Helm chart: `securityContext` defaults to non-root
+### Helm chart: `securityContext` defaults to non-root
 
 The Helm chart [now](https://github.com/jetstack/cert-manager/pull/4036) follows
 the current Pod hardening best practices as defined by the Kyverno [`pod-security
@@ -70,7 +72,7 @@ will need to set this back to `false`.
 
 {{% /pageinfo %}}
 
-## CA Issuer and `ca.crt`
+### CA Issuer and `ca.crt`
 
 The CA issuer [now](https://github.com/jetstack/cert-manager/pull/3865) attempts
 to store the root CA instead of the issuing CA into the `ca.crt` field for
@@ -85,7 +87,7 @@ still available: the intermediate should appear as part of the chain in
 
 {{% /pageinfo %}}
 
-## Vault renewal bug
+### Vault renewal bug
 
 The renewal behavior has changed when a Certificate has a `duration` value of
 more than 90 days and `renewBefore` has not been set.
@@ -106,9 +108,9 @@ behavior.
 
 {{% /pageinfo %}}
 
-# New Features
+## New Features
 
-## Support for the built-in CertificateSigningRequests
+### Support for the built-in CertificateSigningRequests
 
 It is [now](https://github.com/jetstack/cert-manager/pull/4064) possible to use
 the built-in Kubernetes [CertificateSigningRequest][] resources with
@@ -159,7 +161,7 @@ CertificateSigningRequests with cert-manager.
 
 [CertificateSigningRequest]: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
 
-## Vault Issuer handle of `ca.crt`
+### Vault Issuer handle of `ca.crt`
 
 The Vault issuer is now able to fill the `ca.crt` in Secrets. To do that,
 cert-manager reconstructs the certificate chain that is returned by Vault and
@@ -218,13 +220,13 @@ With the above example, the source label
 `__meta_kubernetes_service_label_app='armada-api'` becomes the new label
 `app='armada-api'` when metrics related to this Service are scraped.
 
-## Akamai issuer
+### Akamai issuer
 
 The Akamai issuer has been
 [updated](https://github.com/jetstack/cert-manager/pull/4007) to use the v2 of
 the `OPEN EdgeGrid` Go package.
 
-# Bug Fixes
+## Bug Fixes
 
 - The [RFC2136](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/)
   issuer is [now](https://github.com/jetstack/cert-manager/pull/3622) able to
@@ -233,12 +235,6 @@ the `OPEN EdgeGrid` Go package.
 - The comparison function `PublicKeysEqual` is
   [now](https://github.com/jetstack/cert-manager/pull/3914) correct for public
   keys.
-- A Helm upgrade bug was
-  [fixed](https://github.com/jetstack/cert-manager/pull/3882), you should now
-  able to upgrade from 1.3.1 to 1.4.0 when `--set installCRDs=true` is used.
-  This issue was due to [a Helm
-  bug](https://github.com/helm/helm/issues/5806#issuecomment-788116838) with the
-  `minimum` field on the CRDs.
 - The ACME issuer [now](https://github.com/jetstack/cert-manager/pull/3866)
   works correctly with Certificates that have a long name (52 characters or
   more). These Certificates would not get renewed due to non-unique `Order`
@@ -252,7 +248,7 @@ the `OPEN EdgeGrid` Go package.
   CertificateRequest is `Denied`. This is to keep the same behavior where a
   terminal state of a CertificateRequest should have a `Ready` condition.
 
-# Honorable mentions
+## Honorable mentions
 
 Tim Ramlot ([@inteon](https://github.com/inteon)) has done a fantastic job at
 adding the Istio `VirtualService` support for HTTP01 challenges in

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -8,20 +8,18 @@ type: "docs"
 Special thanks to the external contributors who contributed to this release:
 
 * [@andreas-p](https://github.com/andreas-p)
+* [@erikgb](https://github.com/erikgb)
+* [@eddiehoffman](https://github.com/eddiehoffman)
+* [@inteon](https://github.com/inteon)
+* [@anton-johansson](https://github.com/anton-johansson)
+* [@edglynes](https://github.com/edglynes)
+* [@jandersen-plaid](https://github.com/jandersen-plaid)
+* [@foosinn](https://github.com/foosinn)
+* [@jsoref](https://github.com/jsoref)
+* [@clatour](https://github.com/clatour)
+* [@tamalsaha](https://github.com/tamalsaha)
 
 # Deprecated Features and Breaking Changes
-
-## Certificate renewal period calculation
-
-There have been slight changes in the renewal period calculation for
-certificates. Renewal time (`rt`) is now calculated using formula `rt = notAfter -
-rb` where `rb = min(renewBefore, cert duration / 3)`. (See [docs](../../usage/certificate/#renewal) for more
-detailed explanation). Previously this was calculated using formula `rt =
-notAfter - rb`  where  `if cert duration < renewBefore; then rb = cert duration
-/ 3; else rb = renewBefore`. This change fixes a bug where, if a certificate's
-duration is very slightly larger than `renewBefore` period, then a cert gets
-renewed at `notAfter - renewBefore` which can lead to a continuous renewal loop,
-see [`cert-manager#3897`](https://github.com/jetstack/cert-manager/issues/3897).
 
 ## Upgrading cert-manager CRDs and stored versions of cert-manager custom resources
 
@@ -34,6 +32,247 @@ We have deprecated the following cert-manager APIs:
 - `acme.cert-manager.io/v1alpha3`
 - `acme.cert-manager.io/v1beta1`
 
-These APIs will be removed in cert-manager `v1.6.0`.
-If you have a cert-manager installation that is using or has previously used these deprecated APIs you may need to upgrade your cert-manager custom resources and CRDs. This needs to be done before upgrading to cert-manager `v1.6.0`.
-See cert-manager [docs](../../installation/upgrading/remove-deprecated-apis/#upgrading-existing-cert-manager-resources) for more detailed upgrade instructions.
+These APIs will be removed in cert-manager 1.6.
+
+{{% pageinfo color="warning" %}}
+
+⛔️  If you have a cert-manager installation that is using or has previously used
+these deprecated APIs, you may need to upgrade your cert-manager custom
+resources and CRDs.
+
+This needs to be done before upgrading to cert-manager 1.6. See cert-manager
+[docs](../../installation/upgrading/remove-deprecated-apis/#upgrading-existing-cert-manager-resources)
+for more detailed upgrade instructions.
+
+{{% /pageinfo %}}
+
+## Helm chart: `securityContext` defaults to non-root
+
+The Helm chart [now](https://github.com/jetstack/cert-manager/pull/4036) follows
+the current Pod hardening best practices as defined by the Kyverno [pod-security
+restricted](https://kyverno.io/policies/pod-security/#restricted) policy.
+
+To pass the validation, the controller, webbook, and cainjector Pods are now
+running as non-root:
+
+```yaml
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    runAsNonRoot: true
+```
+
+{{% pageinfo color="warning" %}}
+
+⛔️  If you are using custom containers that run as root with the Helm chart, you
+will need to set this back to `false`.
+
+{{% /pageinfo %}}
+
+## CA Issuer and `ca.crt`
+
+The CA issuer [now](https://github.com/jetstack/cert-manager/pull/3865) attempts
+to store the root CA instead of the issuing CA into the `ca.crt` field for
+issued certificates. All of the information which was previously available is
+still available: the intermediate should appear as part of the chain in
+`tls.crt`.
+
+{{% pageinfo color="warning" %}}
+
+⛔️  This is a change of behavior with the CA Issuer, make sure that the change in
+`ca.crt` does not impact you current use.
+
+{{% /pageinfo %}}
+
+# New Features
+
+## Support for the built-in CertificateSigningRequests
+
+It is [now](https://github.com/jetstack/cert-manager/pull/4064) possible to use
+the built-in Kubernetes [CertificateSigningRequest][] resources with
+cert-manager. The CA Issuer is currently the only supported issuer. The feature
+is experimental and can be enabled by adding a flag to the cert-manager
+controller. For example, with Helm:
+
+```sh
+helm install cert-manager jetstack/cert-manager \
+  --set extraArgs="{--feature-gates=ExperimentalCertificateSigningRequestControllers=true}"
+```
+
+Imagining that you have the following CA issuer:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  namespace: default
+  name: my-ca-issuer
+spec:
+  ca:
+    secretName: ca-key-pair
+```
+
+You will make sure to be given the following role so that cert-manager can sign
+your CSR:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+rules:
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - signers
+  verbs:
+  - reference
+  namespaces:
+  - default
+  resourceNames:
+  - my-ca-issuer
+```
+
+You can create your Kubernetes CSR:
+
+```sh
+openssl genrsa -out test.key 2048
+kubectl apply -f - <<EOF
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: test
+spec:
+  groups:
+  - system:authenticated
+  request: $(openssl req -new -key test.key -out /dev/stdout | base64 | tr -d "\n")
+  signerName: kubernetes.io/kube-apiserver-client
+  usages:
+  - client auth
+EOF
+```
+
+You will still need to manually approve the CSR since cert-manager does not
+approve CSRs by default
+([unlike](../../concepts/certificaterequest/#approval)
+CertificateRequests that get automatically approved by default):
+
+```sh
+kubectl certificate approve test
+```
+
+See [the documentation](../../usage/kube-csr) on how use the built-in
+CertificateSigningRequests with cert-manager.
+
+[CertificateSigningRequest]: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
+
+## Vault Issuer handle of `ca.crt`
+
+The Vault issuer is now able to fill the `ca.crt` in Secrets. To do that,
+cert-manager reconstructs the certificate chain that is returned by Vault and
+uses the certificate at the start of the chain as the `ca.crt`.
+
+Note that this `ca.crt` may be an intermediate signing CA instead of the actual
+root CA.
+
+The reason why this feature did not exist previously is that finding which
+certificate is at the top of the chain is not trivial. Take a look at
+[@JoshVanL](https://github.com/JoshVanL)'s excellent
+[`ParseSingleCertificateChain`](https://github.com/jetstack/cert-manager/blob/5e2a6883c1202739902ac94b5f4884152b810925/pkg/util/pki/parse.go#L167-L244)
+to see what this is all about!
+
+### Helm chart: webhook externally accessible for bare-metal
+
+In [some](https://github.com/kubernetes/kubernetes/issues/72936#issue-399522387)
+Kubernetes setups, the apiserver is not able to talk to kube-dns (i.e., when
+Kubernetes is running on bare-metal with no special `resolv.conf`).
+
+To work around that, the cert-manager webhook can
+[now](https://github.com/jetstack/cert-manager/pull/3876) be configured to be
+accessible from outside of the cluster. For example, in `values.yaml`:
+
+```yaml
+# values.yaml
+webhook:
+  serviceType: LoadBalancer
+  loadBalancerIP: 85.78.90.100
+  url:
+    host: 85.78.90.100
+```
+
+### Helm chart: Service labels
+
+The cert-manager controller Service
+[now](https://github.com/jetstack/cert-manager/pull/4009) supports custom labels
+using the top-level field in `values.yaml`:
+
+```yaml
+# values.yaml
+serviceLabels:
+  app: armada-api
+```
+
+This may be useful in conjunction with Prometheus' `labelmap`. For example, with
+the following sample Prometheus configuration:
+
+```yaml
+# prometheus.yaml
+- action: labelmap
+  regex: __meta_kubernetes_service_label_(.+)
+```
+
+With the above example, the source label
+`__meta_kubernetes_service_label_app='armada-api'` becomes the new label
+`app='armada-api'` when metrics related to this Service are scraped.
+
+## Akamai issuer and Open Edgegrid EdgeDNS v2
+
+The Akamai issuer has been
+[updated](https://github.com/jetstack/cert-manager/pull/4007) to use Open
+Edgegrid EdgeDNS v2 API.
+
+# Bug Fixes
+
+- The default certificate renewal duration of 30 days was clashing with the
+  duration of certificates issued by the Vault PKI. All Certificates [are
+  now](https://github.com/jetstack/cert-manager/pull/4092) renewed 2/3 through
+  the duration unless a custom renew period is specified with the setting
+  `spec.renewBefore` on the Certificate.
+- The [RFC2136](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/)
+  issuer is [now](https://github.com/jetstack/cert-manager/pull/3622) able to
+  handle DNS-01 challenges that map to multiple `TXT` records. This lets you
+  create Let's Encrypt certificates using RFC2136 with multiple DNS names.
+- The comparison function `PublicKeysEqual` is
+  [now](https://github.com/jetstack/cert-manager/pull/3914) correct for public
+  keys.
+- The upgrade from v1.3.0 to 1.4.0 with Helm and `--set installCRDs=true` is
+  [now](https://github.com/jetstack/cert-manager/pull/3882) possible. This issue
+  was due to [a Helm
+  bug](https://github.com/helm/helm/issues/5806#issuecomment-788116838) with the
+  `minimum` field on the CRDs.
+- The ACME issuer [now](https://github.com/jetstack/cert-manager/pull/3866)
+  works correctly with Certificates that have a long name (52 characters or
+  more). These Certificates would not get renewed due to non-unique `Order`
+  names being generated.
+- Orders that are used with a misbehaving ACME server should not get stuck
+  [anymore](https://github.com/jetstack/cert-manager/pull/3805). By misbehaving,
+  we mean an ACME server that would validate the authorizations before having
+  set the status of the order to "ready".
+- The internal signers [now](https://github.com/jetstack/cert-manager/pull/3878)
+  set the condition `Ready=False` with the reason `RequestDenied` when a
+  CertificateRequest is `Denied`. This is to keep the same behavior where a
+  terminal state of a CertificateRequest should have a `Ready` condition.
+
+# Honorable mentions
+
+Tim Ramlot ([@inteon](https://github.com/inteon)) has done a fantastic job at
+adding the Istio VirtualService support for HTTP01 challenges in
+[#3724](https://github.com/jetstack/cert-manager/pull/3724). It took an immense
+effort to have this PR ready and merged for the 1.4 release.
+
+After a lot of thinking, we have decided that trying to support every custom
+resource for every proxy could not be done in-tree due to the Go dependency
+weight that each integration adds. Jake Sanders proposed an [out-of-tree
+approach](https://github.com/jetstack/cert-manager/issues/3924), and we have Tim
+[has been
+accepted](https://summerofcode.withgoogle.com/projects/#4841881566969856) for
+the 2021 Google Summer of Code to work on this feature!


### PR DESCRIPTION
| Preview | no preview since the Netlify previews are only done on `master`, not `release-next` |
|-|-|

Sorry for the delay, I hope that the review of this PR won't affect tomorrow's 1.4 release.

cc @irbekrm @wallrj 

Command used to generate the notes:

```sh
export RELEASE_VERSION=1.4.0
export BRANCH=release-1.4
export END_REV=master
export START_REV=v1.3.0
export GITHUB_TOKEN=$(lpass show github.com -p)
release-notes --debug --repo-path cert-manager \
  --org jetstack --repo cert-manager \
  --required-author "jetstack-bot" \
  --output release-notes.md
```