### PR TITLE
Tweak landing page, main docs page + footer

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -32,14 +32,6 @@
     @import url($web-font-path);
 }
 
-footer {
-    min-height: 150px;
-
-    @include media-breakpoint-down(md) {
-         min-height: 200px;
-    }
-}
-
 // Adjust anchors vs the fixed menu.
 @include media-breakpoint-up(md) {
     .td-offset-anchor:target {

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -48,19 +48,19 @@ title = "cert-manager"
 <section class="row td-box td-box--2">
 	<div class="col">
 		<div class="row justify-content-center">
-			<div class="col-6 text-center">
+			<div class="col-md-6 col-lg-6 col-sm-12 text-center">
 				<div class="mb-4 h1 text-white">
 					<i class="fab fa-slack"></i>
 				</div>
 				<h4>Chat With Us on Slack</h4>
 				<p>
 				<a class="text-white" href="https://kubernetes.slack.com/">
-					<button type="button" class="btn btn-secondary" style="width:150px; margin-top: 12px;">Talk</button>
+					<button type="button" class="btn btn-secondary" style="width:150px; margin-top: 12px;">Chat</button>
 				</a>
 				</p>
 				<p>Interested in learning more, finding answers or chatting to other users?</p>
 			</div>
-			<div class="col-6 text-center">
+			<div class="col-md-6 col-lg-6 col-sm-12 text-center">
 				<div class="mb-4 h1">
 					<i class="fab fa-github"></i>
 				</div>
@@ -80,7 +80,7 @@ title = "cert-manager"
 		<div class="col-sm-12 col-md-12 col-lg-5 text-center">
 			<h4>cert-manager is a CNCF member project</h4>
 			<br>
-			<img src="/png/cncf.png" alt="cert-manager is a CNCF member project" width="400">
+			<img src="/png/cncf.png" alt="cert-manager is a CNCF member project" width="400" height="65" class="img-fluid">
 		</div>
 	</div>
 </section>

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -10,8 +10,8 @@ title = "cert-manager"
 
 	</div>
 	<div class="col-md-7 col-lg-8 order-xs-2 order-sm-2 order-md-2">
-		<h1>cert-manager</h1>
-		<p class="lead mt-2">X.509 certificate management for Kubernetes</p>
+		<p class="lead mt-2 display-4">Cloud native certificate management</p>
+		<p class="lead mt-2 display-5">X.509 certificate management for Kubernetes</p>
 		<div class="mx-auto mt-5">
 			<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "docs" >}}">
 				Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
@@ -24,98 +24,63 @@ title = "cert-manager"
 </section>
 
 <section class="row td-box td-box--0">
-		<div class="col">
-			<div class="row">
-				<div class="col-md-1 hidden-xs hidden-sm"></div>
-				<div class="col-10">
-					<h2>Automate certificate management in cloud native environments</h2>
-					<p>cert-manager builds on top of Kubernetes, introducing certificate authorities and certificates as first-class resource types in the Kubernetes API. This makes it possible to provide to developers 'certificates as a service' in your Kubernetes cluster.</p>
-					<div>&nbsp;</div>
-					<h3>Highlights</h3>
-					<ul class="fa-ul">
-						<li><span class="fa-li"><i class="fas fa-check"></i></span>Provide easy to use tools to manage certificates.</li>
-						<li><span class="fa-li"><i class="fas fa-check"></i></span>A standardised API for interacting with multiple certificate authorities (CAs).</li>
-						<li><span class="fa-li"><i class="fas fa-check"></i></span>Gives security teams the confidence to allow developers to manage their own certificates.</li>
-						<li><span class="fa-li"><i class="fas fa-check"></i></span>Support for ACME (Let's Encrypt), HashiCorp Vault, Venafi, self signed and internal certificate authorities.</li>
-						<li><span class="fa-li"><i class="fas fa-check"></i></span>Extensible to support custom, internal or otherwise unsupported CAs.</li>
-					</ul>
-					<div>&nbsp;</div>
-				</div>
+	<div class="col">
+		<div class="row">
+			<div class="col-md-1 hidden-xs hidden-sm"></div>
+			<div class="col-10">
+				<h3>Automate certificate management in cloud native environments</h3>
+				<p class="lead">cert-manager builds on top of Kubernetes and OpenShift to provide X.509 certificates and issuers as first-class resource types.</p>
+				<p>Provide 'certificates as a service' securely to developers and applications working within your cluster.</p>
+				<div>&nbsp;</div>
+				<ul class="fa-ul lead">
+					<li><span class="fa-li"><i class="fas fa-check text-secondary"></i></span>Supports Let's Encrypt, HashiCorp Vault, Venafi and private PKI</li>
+					<li><span class="fa-li"><i class="fas fa-check text-secondary"></i></span>Easy to use Kubernetes-native certificate management</li>
+					<li><span class="fa-li"><i class="fas fa-check text-secondary"></i></span>Secure issuance of public and private certificates</li>
+					<li><span class="fa-li"><i class="fas fa-check text-secondary"></i></span>Simple to extend, if you need more control</li>
+					<li><span class="fa-li"><i class="fas fa-check text-secondary"></i></span>Actively developed, maintained and improved</li>
+				</ul>
+			<div class="col-md-1 hidden-xs hidden-sm"></div>
 			</div>
-	</div>
-</section>
-
-<section class="row td-box td-box--1">
-		<div class="col">
-			<div class="row">
-				<div class="col-12 ">
-					<h3 class="d-flex justify-content-center">Features</h3>
-					<br>
-				</div>
-			</div>
-			<div class="row justify-content-center">
-				<div class="col-sm-12 col-md-6 col-lg-4">
-					<div class="d-flex justify-content-center"><h4>Support for popular CA types</h4></div>
-					<p>Out of the box, cert-manager supports ACME (i.e. Let's Encrypt), HashiCorp Vault, Venafi, self signed and internal CA issuer types.</p>
-				</div>
-				<div class="col-sm-12 col-md-6 col-lg-4">
-						<div class="d-flex justify-content-center"><h4>Kubernetes native</h4></div>
-                        <p>cert-manager natively targets Kubernetes and OpenShift. This means it integrates well with other ecosystem tools and addons for your cluster, in order to seamlessly secure all your cloud native infrastructure.</p>
-                </div>
-			</div>
+		</div>
 	</div>
 </section>
 
 <section class="row td-box td-box--2">
-		<div class="col">
-			<div class="row justify-content-center">
-				<div class="col-sm-12 col-md-4 col-lg-3 text-center">
-					<div class="mb-4 h1 text-white">
-						<i class="fab fa-slack"></i>
-					</div>
-					<h4 >Talk to us on Slack</h4>
-					<p>
-						<a class="text-white" href="https://kubernetes.slack.com/">
-							<button type="button" class="btn btn-secondary" style="width:150px; margin-top: 12px;">Talk</button>
-						</a>
-					</p>
-					<p>Interested in learning more, speaking to other contributors, or finding answers?</p>
-			</div>
-			<div class="col-sm-12 col-md-4 col-lg-3 text-center">
-					<div class="mb-4 h1">
-						<i class="fab fa-github"></i>
-					</div>
-					<h4>Contributions welcome</h4>
-					<p><a href="https://github.com/jetstack/cert-manager">
-						<button type="button" class="btn btn-secondary" style="width:150px; margin-top: 12px;">Contribute</button>
-					</a>
-				</p>
-				<p>Want to join the fun on Github? New users are always welcome!</p>
-			</div>
-			<div class="col-sm-12 col-md-4 col-lg-3 text-center">
-				<div class="mb-4 h1">
-					<i class="fab fa-twitter"></i>
-				</div>
-				<h4>Follow us on Twitter</h4>
-				<p><a href="https://twitter.com/jetstackhq">
-						<button type="button" class="btn btn-secondary" style="width:150px; margin-top: 12px;">Follow</button>
-					</a>
-				</p>
-				<p>For features announcements, interesting cert-manager news, and other great things.</p>
-			</div>
-			</div>
-		</div>
-</section>
-<section>
 	<div class="col">
 		<div class="row justify-content-center">
-			<div class="col-sm-12 col-md-2 col-lg-5 text-center">
-				<h4>cert-manager is a CNCF member project</h4>
-				</br>
+			<div class="col-6 text-center">
+				<div class="mb-4 h1 text-white">
+					<i class="fab fa-slack"></i>
+				</div>
+				<h4>Chat With Us on Slack</h4>
 				<p>
-					<img src="/png/cncf.png" alt="cert-manager is a CNCF member project" width="400">
+				<a class="text-white" href="https://kubernetes.slack.com/">
+					<button type="button" class="btn btn-secondary" style="width:150px; margin-top: 12px;">Talk</button>
+				</a>
 				</p>
+				<p>Interested in learning more, finding answers or chatting to other users?</p>
 			</div>
+			<div class="col-6 text-center">
+				<div class="mb-4 h1">
+					<i class="fab fa-github"></i>
+				</div>
+				<h4>Contributions Welcome</h4>
+				<p><a href="https://github.com/jetstack/cert-manager">
+					<button type="button" class="btn btn-secondary" style="width:150px; margin-top: 12px;">Contribute</button>
+				</a>
+				</p>
+				<p>Join the fun on GitHub; new contributors are always welcome!</p>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section>
+	<div class="row justify-content-center">
+		<div class="col-sm-12 col-md-12 col-lg-5 text-center">
+			<h4>cert-manager is a CNCF member project</h4>
+			<br>
+			<img src="/png/cncf.png" alt="cert-manager is a CNCF member project" width="400">
 		</div>
 	</div>
 </section>

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,16 +1,17 @@
 ---
-title: "Welcome to cert-manager"
-linkTitle: "Welcome to cert-manager"
+title: "cert-manager"
+linkTitle: "cert-manager"
 weight: 10
 type: "docs"
 ---
 
-cert-manager is a native [Kubernetes](https://kubernetes.io) certificate
-management controller. It can help with issuing certificates from a
-variety of sources, such as [Let's Encrypt](https://letsencrypt.org),
-[HashiCorp Vault](https://www.vaultproject.io),
-[Venafi](https://www.venafi.com/), a simple signing key pair, or self
-signed.
+cert-manager adds certificates and certificate issuers as resource types in
+Kubernetes clusters, and simplifies the process of obtaining, renewing and
+using those certificates.
+
+It can issue certificates from a variety of supported sources, including
+[Let's Encrypt](https://letsencrypt.org), [HashiCorp Vault](https://www.vaultproject.io),
+and [Venafi](https://www.venafi.com/) as well as private PKI.
 
 It will ensure certificates are valid and up to date, and attempt to
 renew certificates at a configured time before expiry.
@@ -22,5 +23,6 @@ wisdom from other similar projects such as
 
 ![High level overview diagram explaining cert-manager architecture](/images/high-level-overview.svg)
 
-This is the full technical documentation for the project, and should be
-used as a source of references when seeking help with the project.
+This website provides the full technical documentation for the project, and can be
+used as a reference; if you feel that there's anything missing, please let us know
+or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,34 +1,35 @@
 {{ $links := .Site.Params.links }}
-<footer class="bg-dark py-1">
-  <div class="container-fluid mx-sm-5">
+<footer class="bg-dark">
+  <div class="container-fluid">
     <div class="row">
-      <div class="col-6 col-sm-4 text-xs-center order-sm-2">
+      <div class="col-6">
         {{ with $links }}
         {{ with index . "user"}}
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
       </div>
-      <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
+      <div class="col-6 text-right">
         {{ with $links }}
         {{ with index . "developer"}}
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
       </div>
-      <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
+      <div class="col-12 text-center py-2 order-sm-2">
         {{ with .Site.Params.copyright }}
-            <small class="text-white">
-              &copy; {{ now.Year}} The cert-manager Authors.<br/>
-              &copy; {{ now.Year}} The Linux Foundation. All rights reserved.
-              The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a class="text-white" href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage page</a>.<br />
-              cert-manager was originally created by <a href="https://jetstack.io"><span id="jetstack-footer">{{ with resources.Get "icons/jetstack.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}</span></a>.
-            </small>
+        <small class="text-white">
+          &copy; {{ now.Year}} The cert-manager Authors.<br />
+          &copy; {{ now.Year}} The Linux Foundation. All rights reserved.<br />
+          The Linux Foundation has registered trademarks and uses trademarks.<br />
+          For a list of trademarks of The Linux Foundation, please see our <a class="text-white" href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage page</a>.<br />
+          cert-manager was originally created by <a href="https://jetstack.io"><span id="jetstack-footer">{{ with resources.Get "icons/jetstack.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}</span></a>.
+        </small>
         {{ end }}
         {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
-	{{ if not .Site.Params.ui.footer_about_disable }}
-		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
-	{{ end }}
+        {{ if not .Site.Params.ui.footer_about_disable }}
+        {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+        {{ end }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
1. Rewords a lot of text on the landing page
2. Removes twitter link (there's no cert-manager Twitter account)
3. Fixes CNCF text/logo on smaller displays
4. Fixes footer on smaller displays
5. Removes footer min size
6. Fixes some broken HTML
7. Change some language on main docs page (don't say 'welcome')

I've attached some screenshots taken from my laptop, intentionally highlighting the broken layout on smaller screens.

## cert-manager.io Today

![cm_current](https://user-images.githubusercontent.com/1972547/122782062-4e019f80-d2a8-11eb-8920-2e26e809a53a.png)

## Preview of this PR

![cm_next](https://user-images.githubusercontent.com/1972547/122782134-5fe34280-d2a8-11eb-806a-4aab61b4014b.png)
