### PR TITLE
Supported-releases: add the supported versions of OpenShift

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -252,6 +252,7 @@ versioning
 cert-manager-dev
 backport
 kubernetes-supported-versions
+openshift-supported-versions
 prepended
 retweets
 upstream

--- a/content/en/docs/installation/supported-releases.md
+++ b/content/en/docs/installation/supported-releases.md
@@ -17,37 +17,37 @@ release every two months.
 
 ## Supported releases {#supported-releases}
 
-| Release | Release Date |     EOL      | [Supported Kubernetes versions][s] |
-|---------|:------------:|:------------:|:----------------------------------:|
-| [1.4][] | Jun 15, 2021 | Oct 13, 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
-| [1.3][] | Apr 08, 2021 | Aug 11, 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
+| Release | Release Date | End of life  | [Supported Kubernetes versions][s] | [Supported OpenShift versions][o] |
+| ------- | :----------: | :----------: | :--------------------------------: | :-------------------------------: |
+| [1.4][] | Jun 15, 2021 | Oct 13, 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |      4.3, 4.4, 4.5, 4.6, 4.7      |
+| [1.3][] | Apr 08, 2021 | Aug 11, 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |      4.3, 4.4, 4.5, 4.6, 4.7      |
 
 ## Upcoming releases
 
-| Release | Release Date |     EOL      |    [Supported Kubernetes versions][s]    |
-|---------|:------------:|:------------:|:----------------------------------------:|
-| [1.5][] | Aug 11, 2021 | Dec 15, 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22 |
-| 1.6     | Oct 13, 2021 | Feb 16, 2022 |              to be defined               |
-| 1.7     | Dec 15, 2021 | Apr 13, 2022 |              to be defined               |
+| Release | Release Date | End of life  |    [Supported Kubernetes versions][s]    | [Supported OpenShift versions][o] |
+| ------- | :----------: | :----------: | :--------------------------------------: | :-------------------------------: |
+| [1.5][] | Aug 11, 2021 | Dec 15, 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22 |   4.3, 4.4, 4.5, 4.6, 4.7, 4.8    |
+| 1.6     | Oct 13, 2021 | Feb 16, 2022 |              to be defined               |           to be defined           |
+| 1.7     | Dec 15, 2021 | Apr 13, 2022 |              to be defined               |           to be defined           |
 
-> Note that dates in the future are uncertain and might change. The "EOL"
-> abbreviation stands for End Of Life.
+Note that dates in the future are uncertain and might change.
 
 ## Old releases
 
-| Release  | Release Date |     EOL      | Compatible Kubernetes versions |
-|----------|:------------:|:------------:|:------------------------------:|
-| [1.2][]  | Feb 10, 2021 | Jun 15, 2021 |          1.16 → 1.21           |
-| [1.1][]  | Nov 24, 2021 | Apr 08, 2021 |          1.11 → 1.21           |
-| [1.0][]  | Sep 02, 2020 | Feb 10, 2021 |          1.11 → 1.21           |
-| [0.16][] | Jul 23, 2020 | Nov 24, 2020 |          1.11 → 1.21           |
-| [0.15][] | May 06, 2020 | Sep 02, 2020 |          1.11 → 1.21           |
-| [0.14][] | Mar 11, 2020 | Jul 23, 2020 |          1.11 → 1.21           |
-| [0.13][] | Jan 21, 2020 | May 06, 2020 |          1.11 → 1.21           |
-| [0.12][] | Nov 27, 2019 | Mar 11, 2020 |          1.11 → 1.21           |
-| [0.11][] | Oct 10, 2019 | Jan 21, 2020 |           1.9 → 1.21           |
+| Release  | Release Date |     EOL      | Compatible Kubernetes versions | Compatible OpenShift versions |
+| -------- | :----------: | :----------: | :----------------------------: | :---------------------------: |
+| [1.2][]  | Feb 10, 2021 | Jun 15, 2021 |          1.16 → 1.21           |           4.3 → 4.7           |
+| [1.1][]  | Nov 24, 2021 | Apr 08, 2021 |          1.11 → 1.21           |          3.11 → 4.7           |
+| [1.0][]  | Sep 02, 2020 | Feb 10, 2021 |          1.11 → 1.21           |          3.11 → 4.7           |
+| [0.16][] | Jul 23, 2020 | Nov 24, 2020 |          1.11 → 1.21           |          3.11 → 4.7           |
+| [0.15][] | May 06, 2020 | Sep 02, 2020 |          1.11 → 1.21           |          3.11 → 4.7           |
+| [0.14][] | Mar 11, 2020 | Jul 23, 2020 |          1.11 → 1.21           |          3.11 → 4.7           |
+| [0.13][] | Jan 21, 2020 | May 06, 2020 |          1.11 → 1.21           |          3.11 → 4.7           |
+| [0.12][] | Nov 27, 2019 | Mar 11, 2020 |          1.11 → 1.21           |          3.11 → 4.7           |
+| [0.11][] | Oct 10, 2019 | Jan 21, 2020 |           1.9 → 1.21           |          3.09 → 4.7           |
 
 [s]: #kubernetes-supported-versions
+[o]: #openshift-supported-versions
 [1.5]: https://github.com/jetstack/cert-manager/milestone/26
 [1.4]: https://cert-manager.io/docs/release-notes/release-notes-1.4
 [1.3]: https://cert-manager.io/docs/release-notes/release-notes-1.3
@@ -230,17 +230,42 @@ Our testing coverage is:
 The oldest Kubernetes release supported by cert-manager is 1.16, as we want
 to be supporting most commercial Kubernetes offerings.
 
-|   Vendor   | Oldest Kubernetes Release\* |                Other Old Kubernetes Releases                 |
-|:----------:|:---------------------------:|--------------------------------------------------------------|
+|   Vendor   | Oldest Kubernetes Release\* | Other Old Kubernetes Releases                                |
+| :--------: | :-------------------------: | ------------------------------------------------------------ |
 | [EKS][eks] |     1.16 (EOL Jul 2021)     | 1.17 (EOL Sep 2021), 1.18 (EOL Nov 2021), 1.9 (EOF Apr 2022) |
 | [GKE][gke] |     1.17 (EOL Nov 2021)     | 1.18 (EOL Dec 2021), 1.19 (EOL Feb 2022)                     |
 | [AKS][aks] |     1.18 (EOL Jul 2021)     | 1.19 (EOL Aug 2021)                                          |
 
-\*As of June 15, 2021.
+\*As of June 22, 2021.
 
 [eks]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar
 [gke]: https://cloud.google.com/kubernetes-engine/docs/release-schedule
 [aks]: https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions#aks-kubernetes-release-calendar
+
+## OpenShift supported versions {#openshift-supported-versions}
+
+With regards to OpenShift Container Platform 3, cert-manager 1.2 is the last
+release to support OpenShift 3.11 (Kubernetes 1.11). Although OpenShift 3.11 is
+still supported by Red Hat until June 2022, keeping support for very old
+versions of Kubernetes had become too much of a burden.
+
+We maintain the following table to remember the mapping between
+OpenShift and Kubernetes versions:
+
+| Version | Kubernetes | EOL            |
+| ------- | ---------- | -------------- |
+| 4.8     | 1.21       | 01 Nov 2022\*  |
+| 4.7     | 1.20       | 01 Jun 2022\*  |
+| 4.6 EUS | 1.19       | 24 May 2022    |
+| 4.6     | 1.19       | 01 Dec 2021\*  |
+| 4.5     | 1.18       | 01 July 2021\* |
+| 4.4     | 1.17       | 24 Feb 2021    |
+| 4.3     | 1.16       | 27 Oct 2020    |
+| 4.2     | 1.14       | 13 Jul 2020    |
+| 4.1     | 1.13       | 05 May 2020    |
+
+\*Estimated as of June 22, 2021 given that the average number of months between
+two OpenShift releases is 5 to 6 months.
 
 ## Terminology
 

--- a/content/en/docs/installation/supported-releases.md
+++ b/content/en/docs/installation/supported-releases.md
@@ -244,8 +244,9 @@ to be supporting most commercial Kubernetes offerings.
 
 ## OpenShift supported versions {#openshift-supported-versions}
 
-We maintain the following table to remember the mapping between
-OpenShift and Kubernetes versions:
+We maintain the following table to remember the mapping between OpenShift and
+Kubernetes versions. The dates are an estimate based on the [OpenShift Updates
+page](https://access.redhat.com/support/policy/updates/openshift#dates).
 
 | Version | Kubernetes | EOL            |
 | ------- | ---------- | -------------- |

--- a/content/en/docs/installation/supported-releases.md
+++ b/content/en/docs/installation/supported-releases.md
@@ -244,11 +244,6 @@ to be supporting most commercial Kubernetes offerings.
 
 ## OpenShift supported versions {#openshift-supported-versions}
 
-With regards to OpenShift Container Platform 3, cert-manager 1.2 is the last
-release to support OpenShift 3.11 (Kubernetes 1.11). Although OpenShift 3.11 is
-still supported by Red Hat until June 2022, keeping support for very old
-versions of Kubernetes had become too much of a burden.
-
 We maintain the following table to remember the mapping between
 OpenShift and Kubernetes versions:
 
@@ -264,8 +259,13 @@ OpenShift and Kubernetes versions:
 | 4.2     | 1.14       | 13 Jul 2020    |
 | 4.1     | 1.13       | 05 May 2020    |
 
-\*Estimated as of June 22, 2021 given that the average number of months between
+\*Estimated as of June 22, 2021, given that the average number of months between
 two OpenShift releases is 5 to 6 months.
+
+With regard to OpenShift Container Platform 3, cert-manager 1.2 is the last
+release to support OpenShift 3.11 (Kubernetes 1.11). Although OpenShift 3.11 is
+still supported by Red Hat until June 2022, keeping support for very old
+versions of Kubernetes had become too much of a burden.
 
 ## Terminology
 


### PR DESCRIPTION
After this morning's internal discussion, we thought it would be good to keep track of the OpenShift -> Kubernetes mapping