### PR TITLE
Document the use of the HTTP01 Gateway API solver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# We kept having rebase conflicts anytime someone would add a word to the
+# .spelling list. Unless the same word is added on both sides simultaenously
+# (which isn't a big deal), let's just let Git do the merge for us.
+.spelling merge=union

--- a/.spelling
+++ b/.spelling
@@ -281,6 +281,8 @@ benlangfeld
 manual-rotation-private-key
 issuances
 HTTPRoute
+gatewayhttproute-labels
+gatewayhttproute-service-type
 
 # As per https://tools.ietf.org/html/rfc5280, the spelling "X.509" is the
 # correct spelling. The spelling "x509" and "X509" are incorrect.

--- a/content/en/docs/configuration/acme/http01/_index.md
+++ b/content/en/docs/configuration/acme/http01/_index.md
@@ -8,7 +8,7 @@ type: "docs"
 {{% pageinfo color="info" %}}
 
 📌  This page focuses on solving ACME HTTP-01 challenges. If you are looking for
-on how automatically creating Certificate resources by annotating Ingress or
+how to automatically create Certificate resources by annotating Ingress or
 Gateway resources, see [Securing Ingress Resources](/docs/usage/ingress/) and
 [Securing Gateway Resources](/docs/usage/gateway/).
 
@@ -174,15 +174,15 @@ No other fields of the ingress can be edited.
 **FEATURE STATE**: cert-manager 1.5 [alpha]
 
 The Gateway and HTTPRoute resources are part of the [Gateway API][gwapi], a set
-of CRDs that you install on your Kubernetes cluster and which provide various
+of CRDs that you install on your Kubernetes cluster that provide various
 improvements over the Ingress API.
 
 [gwapi]: https://gateway-api.sigs.k8s.io
 
 {{% pageinfo color="info" %}}
 
-📌  This feature requires to pass a feature flag to the cert-manager controller
-and the installation of the Gateway API CRDs.
+📌  This feature requires the installation of the Gateway API CRDs and passing a
+feature flag to the cert-manager controller.
 
 To install the Gateway API CRDs, run the following command:
 
@@ -195,7 +195,8 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 - If you are using Helm:
 
   ```sh
-  helm upgrade --install cert-manager jetstack/cert-manager --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
+  helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager \
+    --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
   ```
 
 - If you are using the raw cert-manager manifests, add the following flag to the
@@ -304,7 +305,7 @@ spec:
   gateways:
     allow: All
   hostnames:
-  - traefik.mael-valais-gcp.jetstacker.net
+  - example.net
   rules:
   - forwardTo:
     - port: 8089
@@ -323,6 +324,9 @@ After the Certificate is issued, the HTTPRoute is deleted.
 These labels are copied into the temporary HTTPRoute created by cert-manager for
 solving the HTTP-01 challenge. These labels must match one of the Gateway
 resources on your cluster. The matched Gateway have a listener on port 80.
+
+Note that when the labels do not match any Gateway on your cluster, cert-manager
+will create the temporary HTTPRoute challenge and nothing will happen.
 
 ### `serviceType` {#gatewayhttproute-service-type}
 

--- a/content/en/docs/configuration/acme/http01/_index.md
+++ b/content/en/docs/configuration/acme/http01/_index.md
@@ -195,7 +195,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 - If you are using Helm:
 
   ```sh
-  helm upgrade --install cert-manager jetstack/cert-manager --set "extraArgs={--feature-gates=GatewayAPI=true}"
+  helm upgrade --install cert-manager jetstack/cert-manager --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
   ```
 
 - If you are using the raw cert-manager manifests, add the following flag to the
@@ -203,7 +203,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 
   ```yaml
   args:
-    - --feature-gates=GatewayAPI=true
+    - --feature-gates=ExperimentalGatewayAPISupport=true
   ```
 
 The Gateway API CRDs should either be installed before cert-manager starts or

--- a/content/en/docs/usage/gateway.md
+++ b/content/en/docs/usage/gateway.md
@@ -9,9 +9,9 @@ type: "docs"
 
 {{% pageinfo color="info" %}}
 
-📌  This page focuses on automatically creating Certificate resources by setting
-annotations on the Gateway resource. If you are looking for using an ACME Issuer
-along with HTTP-01 challenges using the Gateway API, see [ACME
+📌  This page focuses on automatically creating Certificate resources by
+annotating Gateway resource. If you are looking for using an ACME Issuer along
+with HTTP-01 challenges using the Gateway API, see [ACME
 HTTP-01](/docs/configuration/acme/http01/).
 
 {{% /pageinfo %}}
@@ -46,8 +46,8 @@ HTTPRoute for Istio][istio#31747]).
 
 {{% pageinfo color="info" %}}
 
-📌  This feature requires to pass a feature flag to the cert-manager controller
-and the installation of the Gateway API CRDs.
+📌  This feature requires the installation of the Gateway API CRDs and passing a
+feature flag to the cert-manager controller.
 
 To install the Gateway API CRDs, run the following command:
 
@@ -60,7 +60,8 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 - If you are using Helm:
 
   ```sh
-  helm upgrade --install cert-manager jetstack/cert-manager --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
+  helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager \
+    --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
   ```
 
 - If you are using the raw cert-manager manifests, add the following flag to the

--- a/content/en/docs/usage/gateway.md
+++ b/content/en/docs/usage/gateway.md
@@ -60,7 +60,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 - If you are using Helm:
 
   ```sh
-  helm upgrade --install cert-manager jetstack/cert-manager --set "extraArgs={--feature-gates=GatewayAPI=true}"
+  helm upgrade --install cert-manager jetstack/cert-manager --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
   ```
 
 - If you are using the raw cert-manager manifests, add the following flag to the
@@ -68,7 +68,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 
   ```yaml
   args:
-    - --feature-gates=GatewayAPI=true
+    - --feature-gates=ExperimentalGatewayAPISupport=true
   ```
 
 The Gateway API CRDs should either be installed before cert-manager starts or

--- a/content/en/docs/usage/gateway.md
+++ b/content/en/docs/usage/gateway.md
@@ -5,12 +5,20 @@ weight: 105
 type: "docs"
 ---
 
-**FEATURE STATE**: cert-manager 1.5 [stable]
+**FEATURE STATE**: cert-manager 1.5 [alpha]
+
+{{% pageinfo color="info" %}}
+
+📌  This page focuses on automatically creating Certificate resources by setting
+annotations on the Gateway resource. If you are looking for using an ACME Issuer
+along with HTTP-01 challenges using the Gateway API, see [ACME
+HTTP-01](/docs/configuration/acme/http01/).
+
+{{% /pageinfo %}}
 
 cert-manager can generate TLS certificates for Gateway resources. This is
 configured by adding annotations to a Gateway and is similar to the process for
 [Securing Ingress Resources](/docs/usage/ingress/).
-
 
 The Gateway resource is part of the [Gateway API][gwapi], a set of CRDs that you
 install on your Kubernetes cluster and which provide various improvements over
@@ -35,17 +43,45 @@ HTTPRoute for Istio][istio#31747]).
 [istio#31747]: https://github.com/istio/istio/issues/31747
 [gateway-api#577]: https://github.com/kubernetes-sigs/gateway-api/issues/577
 
-Before enabling the Gateway support, you will have to install the Gateway API
-CRDs:
+
+{{% pageinfo color="info" %}}
+
+📌  This feature requires to pass a feature flag to the cert-manager controller
+and the installation of the Gateway API CRDs.
+
+To install the Gateway API CRDs, run the following command:
 
 ```sh
 kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0" | kubectl apply -f -
 ```
 
+To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
+
+- If you are using Helm:
+
+  ```sh
+  helm upgrade --install cert-manager jetstack/cert-manager --set "extraArgs={--feature-gates=GatewayAPI=true}"
+  ```
+
+- If you are using the raw cert-manager manifests, add the following flag to the
+  cert-manager controller Deployment:
+
+  ```yaml
+  args:
+    - --feature-gates=GatewayAPI=true
+  ```
+
 The Gateway API CRDs should either be installed before cert-manager starts or
 the cert-manager Deployment should be restarted after installing the Gateway API
 CRDs. This is important because some of the cert-manager components only perform
-the Gateway API check on startup.
+the Gateway API check on startup. You can restart cert-manager with the
+following command:
+
+```sh
+kubectl rollout restart deployment cert-manager -n cert-manager
+```
+
+{{% /pageinfo %}}
 
 The annotations `cert-manager.io/issuer` or `cert-manager.io/cluster-issuer`
 tell cert-manager  to create a Certificate for a Gateway. For example, the


### PR DESCRIPTION
| Preview: https://deploy-preview-625--cert-manager-website.netlify.app/docs/configuration/acme/http01/#configuring-the-http01-gateway-api-solver |
|-|

This is the documentation for https://github.com/jetstack/cert-manager/pull/4276.