### PR TITLE
Documentation for the new cert-manager release on OperatorHub

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -103,6 +103,7 @@ Jsonnet
 keystore
 keystores
 Knative
+Krew
 KUARD
 kubebuilder
 kube-cert-manager
@@ -138,6 +139,7 @@ OpenAPI
 OpenFaaS
 OpenShift
 OperatorHub
+OperatorHub.io
 OpenWRT
 PEM
 PKCS#12

--- a/content/en/docs/installation/kubernetes.md
+++ b/content/en/docs/installation/kubernetes.md
@@ -141,6 +141,69 @@ The default cert-manager configuration is good for the majority of users, but a
 full list of the available options can be found in the [Helm chart
 README](https://artifacthub.io/packages/helm/cert-manager/cert-manager).
 
+## Installing with Operator Lifecycle Manager and OperatorHub.io
+
+Browse to the [cert-manager page on OperatorHub.io](https://operatorhub.io/operator/cert-manager),
+click the "Install" button and follow the installation instructions.
+
+Alternatively, [install OLM][] and [install the `kubectl operator` plugin][]
+from the [Krew Kubectl plugins index][] and then use that to install the cert-manager as follows:
+
+```sh
+operator-sdk olm install
+kubectl krew install operator
+kubectl operator install cert-manager -n operators --channel stable --approval Automatic
+```
+
+You can monitor the progress of the installation as follows:
+
+```sh
+kubectl get events -w -n operators
+```
+
+And you can see the status of the installation with:
+
+```sh
+kubectl operator list
+```
+
+[install OLM]: https://olm.operatorframework.io/docs/getting-started/
+[install the `kubectl operator` plugin]: https://github.com/operator-framework/kubectl-operator#install
+[Krew Kubectl plugins index]: https://krew.sigs.k8s.io/plugins/
+
+### Release Channels
+
+Whichever installation method you chose, there will now be an [OLM Subscription resource][] for cert-manager,
+tracking the "stable" release channel. E.g.
+
+```console
+$ kubectl get subscription cert-manager -n operators -o yaml
+...
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cert-manager
+...
+status:
+  currentCSV: cert-manager.v1.4.0
+  state: AtLatestKnown
+...
+```
+
+This means that OLM will discover new cert-manager releases in the stable channel,
+and, depending on the Subscription settings it will upgrade cert-manager automatically,
+when new releases become available.
+Read [Manually Approving Upgrades via Subscriptions][] for information about automatic and manual upgrades.
+
+[OLM Subscription resource]: https://olm.operatorframework.io/docs/concepts/crds/subscription/
+[Manually Approving Upgrades via Subscriptions]: https://olm.operatorframework.io/docs/concepts/crds/subscription/#manually-approving-upgrades-via-subscriptions
+
+NOTE: There is a single release channel called "stable" which will contain all cert-manager releases, shortly after they are released.
+In future we may introduce other release channels with alternative release schedules,
+in accordance with [OLM's Recommended Channel Naming][].
+
+[OLM's Recommended Channel Naming]: https://olm.operatorframework.io/docs/best-practices/channel-naming/#recommended-channel-naming
+
 ## Verifying the installation
 
 Once you've installed cert-manager, you can verify it is deployed correctly by

--- a/content/en/docs/installation/openshift.md
+++ b/content/en/docs/installation/openshift.md
@@ -64,10 +64,49 @@ Install the `CustomResourceDefinitions` and cert-manager itself
 oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
 ```
 
-## Installing with cert-manager operator
+## Installing with Operator Lifecycle Manager and OperatorHub Web Console
 
-On OpenShift 4 you can also install cert-manager via the OperatorHub using the [cert-manager operator](https://catalog.redhat.com/software/operators/detail/5e999d862937381642a21c7a), this can be found under Red Hat OpenShift Certified Operators in the Embedded OperatorHub of your OpenShift installation.
-Any values set in the Operator configuration get passed through as Helm values.
+cert-manager is in the [Red Hat-provided Operator catalog][] called "community-operators".
+On OpenShift 4 you can install cert-manager from the [OperatorHub web console][] or from the command line.
+These installation methods are described in Red Hat's [Adding Operators to a cluster][] documentation.
+
+[Red Hat-provided Operator catalog]: https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-rh-catalogs.html#olm-rh-catalogs_olm-rh-catalogs
+[OperatorHub web console]: https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-understanding-operatorhub.html
+[Adding Operators to a cluster]: https://docs.openshift.com/container-platform/4.7/operators/admin/olm-adding-operators-to-cluster.html
+
+
+### Release Channels
+
+Whichever installation method you chose, there will now be an [OLM Subscription resource][] for cert-manager,
+tracking the "stable" release channel. E.g.
+
+```console
+$ kubectl get subscription cert-manager -n operators -o yaml
+...
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cert-manager
+...
+status:
+  currentCSV: cert-manager.v1.4.0
+  state: AtLatestKnown
+...
+```
+
+This means that OLM will discover new cert-manager releases in the stable channel,
+and, depending on the Subscription settings it will upgrade cert-manager automatically,
+when new releases become available.
+Read [Manually Approving Upgrades via Subscriptions][] for information about automatic and manual upgrades.
+
+[OLM Subscription resource]: https://olm.operatorframework.io/docs/concepts/crds/subscription/
+[Manually Approving Upgrades via Subscriptions]: https://olm.operatorframework.io/docs/concepts/crds/subscription/#manually-approving-upgrades-via-subscriptions
+
+NOTE: There is a single release channel called "stable" which will contain all cert-manager releases, shortly after they are released.
+In future we may introduce other release channels with alternative release schedules,
+in accordance with [OLM's Recommended Channel Naming][].
+
+[OLM's Recommended Channel Naming]: https://olm.operatorframework.io/docs/best-practices/channel-naming/#recommended-channel-naming
 
 ## Configuring your first Issuer
 

--- a/content/en/docs/installation/upgrading/upgrading-1.3-1.4.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.3-1.4.md
@@ -5,5 +5,30 @@ weight: 780
 type: "docs"
 ---
 
-When upgrading from `v1.3` to `v1.4`, no special upgrade steps are required 🎉.
+## Removal of the cert-manager operator package on Red Hat Marketplace
+
+Since cert-manager `v0.15` there has been a package for cert-manager on [Red Hat Marketplace][],
+but this has now been removed because it was not maintained and was found to be unreliable:
+[#4055](https://github.com/jetstack/cert-manager/issues/4055)
+[#3732](https://github.com/jetstack/cert-manager/issues/3732)
+[#436](https://github.com/cert-manager/website/issues/436)
+
+[Red Hat Marketplace]: https://marketplace.redhat.com
+
+It is replaced by a new package which is generated via the [Community Operators Repository][],
+and which is therefore available on
+[OperatorHub.io](https://operatorhub.io),
+[OpenShift Container Platform](https://openshift.com) and
+[OKD](https://okd.io).
+
+[Community Operators Repository]: https://github.com/operator-framework/community-operators
+
+Please uninstall the existing cert-manager package and re-install
+by following the [Kubernetes OLM Installation Documentation][] or the [OpenShift OLM Installation Documentation][].
+
+[Kubernetes OLM Installation Documentation]: ../../kubernetes/
+[OpenShift OLM Installation Documentation]: ../../openshift/
+
+## Now Follow the Regular Upgrade Process
+
 From here on you can follow the [regular upgrade process](../).

--- a/content/en/docs/release-notes/release-notes-1.4.md
+++ b/content/en/docs/release-notes/release-notes-1.4.md
@@ -23,6 +23,30 @@ Special thanks to the external contributors who contributed to this release:
 
 ## Deprecated Features and Breaking Changes
 
+### Removal of the cert-manager operator package on Red Hat Marketplace
+
+Since cert-manager `v0.15` there has been a package for cert-manager on [Red Hat Marketplace][],
+but this has now been removed because it was not maintained and was found to be unreliable:
+[#4055](https://github.com/jetstack/cert-manager/issues/4055)
+[#3732](https://github.com/jetstack/cert-manager/issues/3732)
+[#436](https://github.com/cert-manager/website/issues/436)
+
+[Red Hat Marketplace]: https://marketplace.redhat.com
+
+It is replaced by a new package which is generated via the [Community Operators Repository][],
+and which is therefore available on
+[OperatorHub.io](https://operatorhub.io),
+[OpenShift Container Platform](https://openshift.com) and
+[OKD](https://okd.io).
+
+[Community Operators Repository]: https://github.com/operator-framework/community-operators
+
+Please uninstall the existing cert-manager package and re-install
+by following the [Kubernetes OLM Installation Documentation][] or the [OpenShift OLM Installation Documentation][].
+
+[Kubernetes OLM Installation Documentation]: ../../installation/kubernetes/
+[OpenShift OLM Installation Documentation]: ../../installation/openshift/
+
 ### Upgrading cert-manager CRDs and stored versions of cert-manager custom resources
 
 We have deprecated the following cert-manager APIs:


### PR DESCRIPTION
Documentation to accompany the new OLM package that I've published in https://github.com/jetstack/cert-manager-olm/pull/26, https://github.com/operator-framework/community-operators/pull/4103, and https://github.com/operator-framework/community-operators/pull/4128

Fixes: https://github.com/jetstack/cert-manager/issues/4055
Fixes: https://github.com/jetstack/cert-manager/issues/3732
Fixes: https://github.com/cert-manager/website/issues/436

Preview: https://deploy-preview-626--cert-manager.netlify.app/
