### PR TITLE
Update the link and name of the aws-privateca-issuer

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -18,6 +18,7 @@ AWS
 allowlist
 awspca
 aws-pca-issuer
+aws-privateca-issuer
 AzureDNS
 backend
 backends

--- a/content/en/docs/configuration/external.md
+++ b/content/en/docs/configuration/external.md
@@ -23,7 +23,7 @@ authors are as follows:
 
 # Issuers that Honour Approval
 
-- [aws-pca-issuer](https://github.com/jniebuhr/aws-pca-issuer): Used to
+- [aws-privateca-issuer](https://github.com/cert-manager/aws-privateca-issuer): Used to
   request certificates from [AWS Private Certificate Authority]
   (https://aws.amazon.com/certificate-manager/private-certificate-authority/)
   for cloud native/hybrid environments.


### PR DESCRIPTION
Update link and name following move to the cert-manager org