### PR TITLE
Remove lingering refs

### DIFF
--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -27,7 +27,7 @@ Due to the nature of the Kubernetes event mechanism these will be purged after a
 
 ### What happens if a renewal is doesn't happen due to issues? Will it be tried again after sometime?
 
-cert-manager makes use of exponential back off to retry any failures on requesting or renewing certificates. It will retry any failures unless the Issuer gave a fatal error that it marked as not retryable.
+cert-manager makes use of exponential back off to retry non-fatal failures (ones that didn't mark the `CertificateRequest` as failed). If the `CertificateRequest` was marked as failed, issuance will be re-tried in 1 hour.
 
 ### Is ECC (elliptic-curve cryptography) supported?
 

--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -51,9 +51,7 @@ spec:
 ```
 
 ### If `renewBefore` or `duration` is not defined, what will be the default value?
-cert-manager will default to a `duration` of [90 days](https://github.com/jetstack/cert-manager/blob/v1.2.0/pkg/apis/certmanager/v1/const.go#L26) with a `renewBefore` of [30 days](https://github.com/jetstack/cert-manager/blob/v1.2.0/pkg/apis/certmanager/v1/const.go#L32).
-The renewal time of the certificate will be calculated using the formula `min(duration / 3, renewBefore)`, see [renewal](../usage/certificate/#renewal) for more detail.
-When setting `duration` it is recommended to also set `renewBefore`, if `renewBefore` is longer than `duration` you will receive an error.
+Default `duration` is [90 days](https://github.com/jetstack/cert-manager/blob/v1.2.0/pkg/apis/certmanager/v1/const.go#L26). If `renewBefore` has not been set, `Certificate` will be renewed 2/3 through its _actual_ duration.
 
 ## Miscellaneous
 


### PR DESCRIPTION
Remove a lingering ref to default `renewBefore` value.

Correct the FAQ on re-trying failed issuances- I assume that the exponential back off referred to re-queing items in cache.

/kind cleanup
/release-note-none