### PR TITLE
Fix kuard example WSOD

### DIFF
--- a/content/en/docs/tutorials/acme/example/ingress-tls-final.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress-tls-final.yaml
@@ -16,7 +16,7 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Exact
+        pathType: Prefix
         backend:
           service:
             name: kuard

--- a/content/en/docs/tutorials/acme/example/ingress-tls.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress-tls.yaml
@@ -16,7 +16,7 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Exact
+        pathType: Prefix
         backend:
           service:
             name: kuard

--- a/content/en/docs/tutorials/acme/example/ingress.yaml
+++ b/content/en/docs/tutorials/acme/example/ingress.yaml
@@ -16,7 +16,7 @@ spec:
     http:
       paths:
       - path: /
-        pathType: Exact
+        pathType: Prefix
         backend:
           service:
             name: kuard


### PR DESCRIPTION
When using `Exact` as `pathType`, static resources (and any other resource outside of the `/` path) will fail to load causing the page to display only a white screen.
The `Prefix` `pathType` has to be used.

Signed-off-by: Bryan CS <yanser25@gmail.com>