### PR TITLE
Adds a release note for upgrading legacy CRDs

### DIFF
--- a/content/en/docs/installation/upgrading/upgrading-1.1-1.2.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.1-1.2.md
@@ -7,8 +7,13 @@ type: "docs"
 
 In an effort to introduce new features whilst keeping the project maintainable,
 cert-manager now only supports Kubernetes down to version `v1.16`. This means
-the `legacy` manifests have now been removed. You can read more
-[here](/docs/installation/supported-releases/).
+the `legacy` manifests have now been removed. Some users experience issues when
+upgrading the legacy `CRD`s to `v1.2`. To solve this, you could replace the `CRD`s:
+1. Backup `cert-manager` resources as described in [the docs](/docs/tutorials/backup/)
+2. Run `kubectl replace -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.crds.yaml` to replace the CRDs.
+3. Follow the standard upgrade process.
+You can read more about supported Kubernetes versions
+   [here](/docs/installation/supported-releases/).
 
 In this release some features have been deprecated.  Please read the [version
 1.2 release notes](../../../release-notes/release-notes-1.2/) for more details


### PR DESCRIPTION
I've tested the suggested upgrade steps by:

1. Running `kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.0/cert-manager-legacy.yaml`
2. Creating a `v1` `Issuer` and `Certificate` (legacy CRDs only support 1 version)
3. Running `kubectl replace -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.crds.yaml`
4. Running `kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml`
5. Verifying that the existing resources can be retrieved and a new cert can be created

Related [cert-manger#4197](https://github.com/jetstack/cert-manager/issues/4197) which I can reproduce.


Signed-off-by: irbekrm <irbekrm@gmail.com>