### PR TITLE
Release-process: I did not know how to update the release branch

### DIFF
--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -138,14 +138,14 @@ page if a step is missing or if it is outdated.
 1. Make sure to note which type of release you are doing. That will be helpful
    in the next steps.
 
-    | Type of release          | Example of git tag |
-    | ------------------------ | ------------------ |
-    | initial alpha release    | `v1.3.0-alpha.0`   |
-    | subsequent alpha release | `v1.3.0-alpha.1`   |
-    | initial beta release     | `v1.3.0-beta.0`    |
-    | subsequent beta release  | `v1.3.0-beta.1`    |
-    | final release            | `v1.3.0`           |
-    | patch release            | `v1.3.1`           |
+    |          Type of release           | Example of git tag |
+    |------------------------------------|--------------------|
+    | initial alpha release              | `v1.3.0-alpha.0`   |
+    | subsequent alpha release           | `v1.3.0-alpha.1`   |
+    | initial beta release               | `v1.3.0-beta.0`    |
+    | subsequent beta release            | `v1.3.0-beta.1`    |
+    | final release                      | `v1.3.0`           |
+    | patch release (or "point release") | `v1.3.1`           |
     </br>
 
 2. **(final release only)** Make sure that a PR with the new upgrade

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -26,8 +26,8 @@ following conditions:
 2. You currently need to be at Jetstack to get the required GitHub and GCP
    permissions. (we'd like contributors outside Jetstack to be able to get
    access; if that's of interest to you, please let us know).
-3. You need to have the GitHub `write` permission on the cert-manager project.
-   To check that you have the `write` role, run:
+3. You need to have the GitHub `admin` permission on the cert-manager project.
+   To check that you have the `admin` role, run:
 
     ```sh
     brew install gh
@@ -35,8 +35,8 @@ following conditions:
     gh api /repos/jetstack/cert-manager/collaborators/$(gh api /user | jq -r .login)/permission | jq .permission
     ```
 
-    If your permission is `write` or `admin`, then you are good to go. To request
-    the `write` permission on the cert-manager project, [open a
+    If your permission is `admin`, then you are good to go. To request the
+    `admin` permission on the cert-manager project, [open a
     PR](https://github.com/jetstack/platform-board/pulls/new) with a link to
     here.
 
@@ -142,7 +142,8 @@ page if a step is missing or if it is outdated.
     | ------------------------ | ------------------ |
     | initial alpha release    | `v1.3.0-alpha.0`   |
     | subsequent alpha release | `v1.3.0-alpha.1`   |
-    | beta release             | `v1.3.0-beta.0`    |
+    | initial beta release     | `v1.3.0-beta.0`    |
+    | subsequent beta release  | `v1.3.0-beta.1`    |
     | final release            | `v1.3.0`           |
     | patch release            | `v1.3.1`           |
     </br>
@@ -155,8 +156,10 @@ page if a step is missing or if it is outdated.
 
 3. Update the release branch:
 
-      Update the release branch with the latest commits from the master
-      branch, as follows:
+   - **(initial alpha, subsequent alpha and initial beta)** The release branch
+      should already exist (it was created at the end of the last final
+      release). Update the release branch with the latest commits from the
+      master branch, as follows:
 
        ```bash
        # Must be run from the cert-manager repo folder.
@@ -165,6 +168,7 @@ page if a step is missing or if it is outdated.
        git checkout release-1.0
        git merge --ff-only origin/master # don't run for a point release!
        ```
+
     - **(subsequent beta, patch release and final release)**: do nothing since
       things have been merged using `/cherry-pick release-1.0`.
 
@@ -201,9 +205,11 @@ page if a step is missing or if it is outdated.
         git push --set-upstream origin release-1.0
         ```
 
-        **(initial alpha only)**: `git push` will only work if you have the
-        `write` or `admin` GitHub permission on the cert-manager repo to create
-        or push to the branch, see [prerequisites](#prerequisites).
+        **GitHub permissions**: `git push` will only work if you have the
+       `admin` GitHub permission on the cert-manager repo to create or push to
+       the branch, see [prerequisites](#prerequisites). If you do not have this
+       permission, you will have to open a PR to merge master into the release
+       branch), and wait for the PR checks to become green.
 
 5. Generate and edit the release notes:
 

--- a/content/en/docs/installation/supported-releases.md
+++ b/content/en/docs/installation/supported-releases.md
@@ -138,47 +138,18 @@ them.
 
 **Critical bugs** include both regression bugs as well as upgrade bugs.
 
-Regressions are functionalities that worked in a previous release but no
-longer work. [#3393][] and [#2857][] are two examples of regressions.
+Regressions are functionalities that worked in a previous release but no longer
+work. [#4142][], [#3393][] and [#2857][] are three examples of regressions.
 
 Upgrade bugs are issues (often Helm-related) preventing users from
 upgrading to currently supported releases from earlier releases of
 cert-manager. [#3882][] and [#3644][] are examples of upgrade bugs.
 
-Note that [intentional breaking changes](#breaking-changes) do not belong
-to this category.
+Note that [intentional breaking changes](#breaking-changes) do not belong to
+this category.
 
-Once merged to the master branch, fixes for critical bugs are not
-immediately back-ported. Instead, we wait until the next final release for
-triggering a patch release. The patch release will be made for all
-supported release, but note that since we do only support the two last
-releases, a single patch release is made for the last release.
-
-In the example below, the release branches `release-1.2` and `release-1.3`
-are the two supported releases at the time of the release of 1.3.0, which
-means that critical bug fixes 1 and 2 will only be back-ported to
-`release-1.2` and not to `release-1.1`:
-
-```diagram
-   v1.2.1                                v1.2.2
-------+-------------------------------------+-----------> release-1.2
-       \      backport ^  backport ^        ^
-        \     commit  /   commit  /         | v1.2.2 is created
-         \           /           /          | along with v1.3.0
-          \         /           /
-           \       /           /
-            \     /           /          v1.3.0
-             --------master-----------------+-----------> release-1.3
-                 ^           ^               \
-                 |           |                \
-                 |           |                 \
-           critical      critical               \
-           bug fix 1     bug fix 2               \
-           merged to     merged to                \
-           master        master                    ------> master
-```
-
-<!-- Diagram source: https://textik.com/#7c4096204b3c0ad3 -->
+Fixes for critical bugs are (usually) immediately back-ported by creating a new
+patch release for the two currently supported releases.
 
 #### Long-standing bugs {#long-standing-bugs}
 
@@ -198,9 +169,11 @@ possible.
 
 [#3393]: https://github.com/jetstack/cert-manager/issues/3393 "Broken CloudFlare DNS01 challenge"
 [#2857]: https://github.com/jetstack/cert-manager/issues/2857 "CloudDNS DNS01 challenge crashes cert-manager"
+[#4142]: https://github.com/jetstack/cert-manager/issues/4142 "Cannot issue a certificate that has the same subject and issuer"
 [#3444]: https://github.com/jetstack/cert-manager/issues/3444 "Certificates do not get immediately updated after updating them"
 [#3882]: https://github.com/jetstack/cert-manager/pull/3882: "Helm upgrade from v1.2 to v1.2 impossible due to a Helm bug"
 [#3644]: https://github.com/jetstack/cert-manager/issues/3644 "Helm upgrade from v1.2 to v1.2 impossible due to a Helm bug"
+
 
 ## How we determine supported Kubernetes versions {#kubernetes-supported-versions}
 


### PR DESCRIPTION
Here is a couple of nits that I found while releasing 1.4.0-alpha.0. I added you must have the `admin` Github permission to do the whole process.