### PR TITLE
DCO Sign Off: Fix broken link

### DIFF
--- a/content/en/docs/contributing/sign-off.md
+++ b/content/en/docs/contributing/sign-off.md
@@ -23,7 +23,7 @@ You can also mass sign-off a whole PR with `git rebase --signoff master`,
 replacing `master` with the branch you are creating a pull request again if
 not master.
 
-By doing this you state that you certify the following (from https://developercertificate.org/):
+By doing this you state that you certify the following (from [https://developercertificate.org/](https://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin


### PR DESCRIPTION
Fixes https://github.com/cert-manager/website/issues/652.