### PR TITLE
Update certificate concepts doc, clarifying lack of root in tls.crt

### DIFF
--- a/content/en/docs/concepts/certificate.md
+++ b/content/en/docs/concepts/certificate.md
@@ -37,27 +37,30 @@ spec:
 
 This `Certificate` will tell cert-manager to attempt to use the `Issuer` named
 `letsencrypt-prod` to obtain a certificate key pair for the `foo.example.com`
-and `bar.example.com` domains. If successful, resulting TLS key and certificate 
+and `bar.example.com` domains. If successful, the resulting TLS key and certificate
 will be stored in a secret named `acme-crt-secret`, with keys of `tls.key`, and
 `tls.crt` respectively. This secret will live in the same namespace as the
 `Certificate` resource.
 
-Additionally, if the Certificate Authority is known, the corresponding CA 
-certificate will be stored in the secret with key `ca.crt`. For example, with 
-the ACME issuer, the CA is not known and `ca.crt` will not exist in 
+When a certificate is issued by an intermediate CA and the `Issuer` can provide
+the issued certificate's chain, the contents of `tls.crt` will be the requested
+certificate followed by the certificate chain.
+
+Additionally, if the Certificate Authority is known, the corresponding CA
+certificate will be stored in the secret with key `ca.crt`. For example, with
+the ACME issuer, the CA is not known and `ca.crt` will not exist in
 `acme-crt-secret`.
 
-When a certificate is issued by intermediates of the CA and the `Issuer` knows the
-intermediates, the content of `tls.crt` will be a resulting certificate followed by
-a certificate chain. The certificate chain doesn't include a root CA certificate, as
-it is stored in `ca.crt`.
+cert-manager intentionally avoids adding root certificates to `tls.crt`, because they
+are useless in a situation where TLS is being done securely. For more information,
+see [RFC 5246 section 7.4.2](https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.2)
+which contains the following explanation:
 
-This format is used as it allows TLS implementations to validate the leaf certificate
-as long as the root CA is already trusted. During the TLS handshake, peers construct
-a full trust chain by checking the issuer of each certificate until they end up at a 
-root in their trust store. If the intermediates aren't sent along with the leaf,
-there's no way to know that the issuing CA was signed by the root, and the
-certificate won't be trusted.
+> Because certificate validation requires that root keys be distributed
+> independently, the self-signed certificate that specifies the root
+> certificate authority MAY be omitted from the chain, under the
+> assumption that the remote end must already possess it in order to
+> validate it in any case.
 
 The `dnsNames` field specifies a list of [`Subject Alternative
 Names`](https://en.wikipedia.org/wiki/Subject_Alternative_Name) to be associated
@@ -67,13 +70,14 @@ The referenced `Issuer` must exist in the same namespace as the `Certificate`.
 A `Certificate` can alternatively reference a `ClusterIssuer` which is
 non-namespaced and so can be referenced from any namespace.
 
-
 You can read more on how to configure your `Certificate` resources
 [here](../../usage/certificate/).
 
-## What happens to my Certificate
+## Certificate Lifecycle
 
-Here is a diagram of the life of a Certificate named `cert-1` using a Let's
-Encrypt issuer:
+This diagram shows the lifecycle of a Certificate named `cert-1` using an
+ACME / Let's Encrypt issuer. You don't need to understand all of these steps
+to use cert-manager; this is more of an explanation of the logic which happens
+under the hood for those curious about the process.
 
 ![Life of a Certificate](/images/letsencrypt-flow-cert-manager.png)


### PR DESCRIPTION
Also contains other minor changes including grammar, removing trailing
whitespace and some small rewording.

Signed-off-by: Ashley Davis <ashley.davis@jetstack.io>