### PR TITLE
FAQ Tweaks, Including Root Chain FAQ + Terminology

### DIFF
--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -20,6 +20,32 @@ face:
 
 This is a feature in cert-manager starting in `v0.16` using the kubectl plugin. More information can be found on [the renew command's page](../usage/kubectl-plugin/#renew)
 
+### Why isn't my root certificate in my issued Secret's `tls.crt`?
+
+Occasionally, people work with systems which have made a flawed choice regarding TLS chains. The [TLS spec](https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.2)
+has the following section for the "Server Certificate" section of the TLS handshake:
+
+> This is a sequence (chain) of certificates.  The sender's
+> certificate MUST come first in the list.  Each following
+> certificate MUST directly certify the one preceding it.  Because
+> certificate validation requires that root keys be distributed
+> independently, the self-signed certificate that specifies the root
+> certificate authority MAY be omitted from the chain, under the
+> assumption that the remote end must already possess it in order to
+> validate it in any case.
+
+In a standard, secure and correctly configured TLS environment, adding a root certificate to the chain is almost entirely _pure waste_.
+
+There are two ways that a certificate can be trusted:
+
+- explicitly, by including it in a trust store.
+- through a signature, by following the certificate's chain back up to an explicitly trusted certificate.
+
+Crucially, root certificates are by definition self-signed and they cannot be validated through a signature.
+
+As such, if we have a client trying to validate the certificate chain sent by the server, the client must already have the
+root before the connection is started. If the client already has the root, there was no point in it being sent by the server!
+
 ### How can I see all the historic events related to a certificate object ?
 
 cert-manager publishes all events to the Kubernetes events mechanism, you can get the events for your specific resources using `kubectl describe <resource> <name>`.

--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -34,7 +34,8 @@ has the following section for the "Server Certificate" section of the TLS handsh
 > assumption that the remote end must already possess it in order to
 > validate it in any case.
 
-In a standard, secure and correctly configured TLS environment, adding a root certificate to the chain is almost entirely _pure waste_.
+In a standard, secure and correctly configured TLS environment, adding a root certificate to the chain is
+almost always unnecessary and wasteful.
 
 There are two ways that a certificate can be trusted:
 
@@ -46,19 +47,27 @@ Crucially, root certificates are by definition self-signed and they cannot be va
 As such, if we have a client trying to validate the certificate chain sent by the server, the client must already have the
 root before the connection is started. If the client already has the root, there was no point in it being sent by the server!
 
-### How can I see all the historic events related to a certificate object ?
+The same logic with not sending root certificates applies for servers trying to validate client certificates;
+the [same justification](https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.6) is given in the TLS RFC.
+
+### How can I see all the historic events related to a certificate object?
 
 cert-manager publishes all events to the Kubernetes events mechanism, you can get the events for your specific resources using `kubectl describe <resource> <name>`.
+
 Due to the nature of the Kubernetes event mechanism these will be purged after a while. If you're using a dedicated logging system it might be able or is already also storing Kubernetes events.
 
-### What happens if a renewal is doesn't happen due to issues? Will it be tried again after sometime?
+### What happens if a renewal doesn't happen? Will it be tried again after some time?
 
-cert-manager makes use of exponential back off to retry non-fatal failures (ones that didn't mark the `CertificateRequest` as failed). If the `CertificateRequest` was marked as failed, issuance will be re-tried in 1 hour.
+cert-manager will retry renewal if it encounters temporary failures. It uses an exponential backoff algorithm to calculate the delay between each retry.
+
+A temporary failure is one that doesn't mark the `CertificateRequest` as failed. If the `CertificateRequest` is marked as failed, issuance will be re-tried in 1 hour.
 
 ### Is ECC (elliptic-curve cryptography) supported?
 
 cert-manager supports ECDSA key pairs! You can set your certificate to use ECDSA  in the `privateKey` part of your Certificate resource.
+
 For example:
+
 ```yaml
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -77,6 +86,7 @@ spec:
 ```
 
 ### If `renewBefore` or `duration` is not defined, what will be the default value?
+
 Default `duration` is [90 days](https://github.com/jetstack/cert-manager/blob/v1.2.0/pkg/apis/certmanager/v1/const.go#L26). If `renewBefore` has not been set, `Certificate` will be renewed 2/3 through its _actual_ duration.
 
 ## Miscellaneous

--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -8,7 +8,7 @@ type: "docs"
 Below is an aggregation of solutions to some issues that cert-manager users may
 face:
 
-
+- [TLS Terminology, including commonly misused terms](./terminology/)
 - [Troubleshooting issuing ACME certificates](./acme/)
 - [How to change the Cluster Resource Namespace](./cluster-resource/)
 - [How to sync secrets across namespaces](./kubed/)

--- a/content/en/docs/faq/terminology.md
+++ b/content/en/docs/faq/terminology.md
@@ -1,0 +1,72 @@
+---
+title: "TLS Terminology"
+linkTitle: "TLS Terminology"
+weight: 50
+type: "docs"
+---
+
+With TLS being so widely deployed, terminology can sometimes get confused or be used to mean different things, and that reality
+combined with the complexity of TLS can lead to serious misunderstandings and confusion.
+
+For further reference, you might want to check out some relevant RFCs:
+
+- [RFC 5246: TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246)
+- [RFC 8446: TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446)
+- [RFC 5280: X.509](https://datatracker.ietf.org/doc/html/rfc5280)
+
+### What does "publicly trusted" mean?
+
+Broadly speaking, a "publicly trusted" certificate is one that you can use on the Internet and expect
+that most reasonably up-to-date computers will be able to verify it using their system trust store.
+
+There isn't a single standard trust store containing certs which are "publicly trusted", but generally most
+of the commonly seen trust stores are similar. An example would be [Mozilla's CA Certificate Program](https://wiki.mozilla.org/CA).
+
+### What does "self-signed" mean? Is my CA self-signed?
+
+Self-signed means exactly what it says; a certificate is self-signed if it is signed by its own private key.
+
+Self-signed is a commonly confused term, however, and is very frequently misused to mean "not publicly trusted". We tend to use terms
+like "private PKI" to denote the situation where an organization might have their own internal CA certificates which wouldn't
+be trusted outside of the organization.
+
+As an example, there are _many_ self-signed certificates in [Mozilla's CA Certificate Program](https://wiki.mozilla.org/CA), but
+all of those certificates would usually be described as "publicly trusted".
+
+Your certificate is self-signed only if it's signed with its own key.
+
+### What's the difference between "root", "intermediate", and "leaf" certificates?
+
+cert-manager uses the following definitions:
+
+#### Root Certificates
+
+Roots are self-signed certificates and almost always marked as CA certificates. They're usually not sent over the wire
+during a TLS handshake because they need to be explicitly trusted in order to be validated.
+
+Roots are sometimes defined as "CA certificates which are explicitly trusted"---which can include certificates which
+aren't self-signed. cert-manager doesn't use this definition.
+
+Changing trust stores to include new roots or remove old ones is a non-trivial task which can take months or years for publicly
+trusted roots. For this reason roots are usually issued with very long lifetimes, often on the order of decades.
+
+#### Intermediate Certificates
+
+Intermediates are CA certificates signed by another CA. Most intermediates will be signed by a root certificate, but it's
+possible to construct longer chains where an intermediate can be signed by another intermediate.
+
+Intermediate certificates are usually issued with a much shorter lifetime than the CA which signed them. On the
+Internet, intermediate certificates are used on network-connected machines for day-to-day issuance so that the
+highly-valuable root certificates can remain entirely offline.
+
+While intermediate certificates can also be explicitly trusted via addition to a trust store, they're usually validated
+by "walking up" the chain and validating signatures until an explicitly trusted self-signed root certificate is found.
+
+#### Leaf Certificates
+
+Leaf certificates are usually used to represent a particular identity, rather than being used to sign other certificates.
+On the Internet leaf certificates usually identify a particular domain, such as `example.com`.
+
+Leaf certificates are sent first in a chain of certificates and represent the end of that chain. They must be sent
+along with any intermediates required to create a chain which can be validated by verifying signatures up to a trusted
+root certificate.


### PR DESCRIPTION
:rotating_light: Best reviewed on a per-commit basis, each commit is self-contained.

The root chain FAQ was suggested [here](https://github.com/jetstack/cert-manager/pull/4261#pullrequestreview-716984217)

I figured it would also be useful to add a page explaining some of the terminology used in TLS, too - especially terms which are frequently misused or can cause confusion.