### PR TITLE
Add a blank release notes and upgrade page for v1.5

### DIFF
--- a/content/en/docs/installation/upgrading/upgrading-1.4-1.5.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.4-1.5.md
@@ -1,0 +1,12 @@
+---
+title: "Upgrading from v1.4 to v1.5"
+linkTitle: "v1.4 to v1.5"
+weight: 770
+type: "docs"
+---
+
+## TODO
+
+## Now Follow the Regular Upgrade Process
+
+From here on you can follow the [regular upgrade process](../).

--- a/content/en/docs/release-notes/_index.md
+++ b/content/en/docs/release-notes/_index.md
@@ -9,6 +9,7 @@ no_list: true
 Here you will find a link to all release notes for each version release of
 cert-manager:
 
+- [`v1.5`](./release-notes-1.5/)
 - [`v1.4`](./release-notes-1.4/)
 - [`v1.3`](./release-notes-1.3/)
 - [`v1.2`](./release-notes-1.2/)

--- a/content/en/docs/release-notes/release-notes-1.5.md
+++ b/content/en/docs/release-notes/release-notes-1.5.md
@@ -1,0 +1,27 @@
+---
+title: "Release Notes"
+linkTitle: "v1.5"
+weight: 780
+type: "docs"
+---
+
+# Release `v1.5.0`
+
+Special thanks to the external contributors who contributed to this release:
+- TODO
+
+## Deprecated Features and Breaking Changes
+
+### TODO
+
+## New Features
+
+### TODO
+
+## Bug Fixes
+
+### TODO
+
+## Other Changes
+
+### TODO


### PR DESCRIPTION
This is to make it easier for contributors to write their own release note paragraphs, such as in https://github.com/cert-manager/website/pull/634 where I want to ask the author to write a release note paragraph at the same time as writing the feature documentation.

 * https://deploy-preview-666--cert-manager-website.netlify.app/docs/release-notes/
 * https://deploy-preview-666--cert-manager-website.netlify.app/docs/installation/upgrading/upgrading-1.4-1.5/