### PR TITLE
kubectl --export is deprecated

### DIFF
--- a/content/en/docs/tutorials/acme/migrating-from-kube-lego.md
+++ b/content/en/docs/tutorials/acme/migrating-from-kube-lego.md
@@ -104,9 +104,17 @@ namespace that it is running in, and we used `cert-manager` when deploying
 cert-manager above. You should change this if you have deployed cert-manager
 into a different namespace.
 
+Install [yq](https://kislyuk.github.io/yq/#installation) then run the command below:
+
 ```bash
-$ kubectl create -f kube-lego-account.yaml \
-    --namespace cert-manager
+$ kubectl get secret kube-lego-account -o yaml \
+    --namespace kube-lego | yq -Y \
+    'del(
+       .metadata.creationTimestamp,
+       .metadata.resourceVersion,
+       .metadata.selfLink,
+       .metadata.uid
+     )' > kube-lego-account.yaml
 ```
 
 ## 4. Creating an ACME `ClusterIssuer` using your old ACME account

--- a/content/en/docs/tutorials/acme/migrating-from-kube-lego.md
+++ b/content/en/docs/tutorials/acme/migrating-from-kube-lego.md
@@ -88,15 +88,20 @@ the value of the `LEGO_SECRET_NAME` environment variable.
 You should download a copy of this secret resource and save it in your local
 directory:
 
+Install [yq](https://kislyuk.github.io/yq/#installation) then run the command below:
+
 ```bash
 $ kubectl get secret kube-lego-account -o yaml \
     --namespace kube-lego \
-    --export > kube-lego-account.yaml
+     | yq -Y \
+    'del(
+       .metadata.creationTimestamp,
+       .metadata.resourceVersion,
+       .metadata.selfLink,
+       .metadata.uid,
+       .metadata.namespace
+     ) | .metadata.name = "letsencrypt-private-key"' > kube-lego-account.yaml
 ```
-
-Once saved, open up this file and change the `metadata.name` field to something
-more relevant to cert-manager. For the rest of this guide, we'll assume you
-chose `letsencrypt-private-key`.
 
 Once done, we need to create this new resource in the `cert-manager` namespace.
 By default, cert-manager stores supporting resources for `ClusterIssuers` in the

--- a/content/en/docs/tutorials/acme/migrating-from-kube-lego.md
+++ b/content/en/docs/tutorials/acme/migrating-from-kube-lego.md
@@ -104,17 +104,9 @@ namespace that it is running in, and we used `cert-manager` when deploying
 cert-manager above. You should change this if you have deployed cert-manager
 into a different namespace.
 
-Install [yq](https://kislyuk.github.io/yq/#installation) then run the command below:
-
 ```bash
-$ kubectl get secret kube-lego-account -o yaml \
-    --namespace kube-lego | yq -Y \
-    'del(
-       .metadata.creationTimestamp,
-       .metadata.resourceVersion,
-       .metadata.selfLink,
-       .metadata.uid
-     )' > kube-lego-account.yaml
+$ kubectl create -f kube-lego-account.yaml \
+    --namespace cert-manager
 ```
 
 ## 4. Creating an ACME `ClusterIssuer` using your old ACME account


### PR DESCRIPTION
kubectl --export is deprecated since `kubectl` v1.14 and has been removed in v1.18.

The new command is emulating the behavior of the deprecated `--export` flag using `yq`.

There is another `kubectl` command line with `--export` flag, but in our cluster the email address was provided as an environmental variable rather than a ConfigMap, therefore no tested command for it, but similar commands should work for both.

Signed-off-by: Zoltan Burgermeiszter <zoltan@backenddoctor.com>