### PR TITLE
Fix docs for DNS solver for AzureDNS

### DIFF
--- a/content/en/docs/configuration/acme/dns01/azuredns.md
+++ b/content/en/docs/configuration/acme/dns01/azuredns.md
@@ -79,7 +79,7 @@ kind: AzureIdentity
 metadata:
   annotations:
     # recommended to use namespaced identites https://azure.github.io/aad-pod-identity/docs/configure/match_pods_in_namespace/
-    aadpodidentity.k8s.io/Behavior: namespaced 
+    aadpodidentity.k8s.io/Behavior: namespaced
   name: certman-identity
   namespace: cert-manager # change to your preferred namespace
 spec:
@@ -126,7 +126,7 @@ spec:
     ...
     solvers:
     - dns01:
-        azureDNS:
+        azuredns:
           subscriptionID: AZURE_SUBSCRIPTION_ID
           resourceGroupName: AZURE_DNS_ZONE_RESOURCE_GROUP
           hostedZoneName: AZURE_DNS_ZONE
@@ -136,7 +136,7 @@ spec:
 
 ## Managed Identity Using AKS Kubelet Identity
 
-When creating an AKS cluster in Azure there is the option to use a managed identity that is assigned to the kubelet. This identity is assigned to the underlying node pool in the AKS cluster and can then be used by the cert-manager pods to authenticate to Azure Active Directory. 
+When creating an AKS cluster in Azure there is the option to use a managed identity that is assigned to the kubelet. This identity is assigned to the underlying node pool in the AKS cluster and can then be used by the cert-manager pods to authenticate to Azure Active Directory.
 
 There are some caveats with this approach, these mainly being:
 
@@ -156,7 +156,7 @@ ZONE_ID=$(az network dns zone show --name $ZONE_NAME --resource-group $ZONE_GROU
 
 # Create role assignment
 az role assignment create --role "DNS Zone Contributor" --assignee $PRINCIPAL_ID --scope $ZONE_ID
-``` 
+```
 
 - Example terraform:
 ```terraform
@@ -174,8 +174,8 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
 resource "azurerm_role_assignment" "dns_contributor" {
   scope                            = var.dns_zone_id
-  role_definition_name             = "DNS Zone Contributor"  
-  principal_id                     = azurerm_kubernetes_cluster.cluster.kubelet_identity[0].object_id 
+  role_definition_name             = "DNS Zone Contributor"
+  principal_id                     = azurerm_kubernetes_cluster.cluster.kubelet_identity[0].object_id
   skip_service_principal_aad_check = true # Allows skipping propagation of identity to ensure assignment succeeds.
 }
 ```
@@ -191,7 +191,7 @@ spec:
     ...
     solvers:
     - dns01:
-        azureDNS:
+        azuredns:
           subscriptionID: AZURE_SUBSCRIPTION_ID
           resourceGroupName: AZURE_DNS_ZONE_RESOURCE_GROUP
           hostedZoneName: AZURE_DNS_ZONE
@@ -273,7 +273,7 @@ spec:
     ...
     solvers:
     - dns01:
-        azureDNS:
+        azuredns:
           clientID: AZURE_CERT_MANAGER_SP_APP_ID
           clientSecretSecretRef:
           # The following is the secret we created in Kubernetes. Issuer will use this to present challenge to Azure DNS.


### PR DESCRIPTION
Having it as `azureDNS` throws this error message:

```
error validating data:
ValidationError(ClusterIssuer.spec.acme.solvers[0].dns01): unknown
field "azureDNS" in
io.cert-manager.v1alpha2.ClusterIssuer.spec.acme.solvers.dns01; if you
choose to ignore these errors, turn validation off with
--validate=false
```

Changing it to `azuredns` fixes it.

Signed-off-by: Sibi Prabakaran <sibi@psibi.in>