### PR TITLE
cloudflare: don't configure email with API Tokens

### DIFF
--- a/content/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/docs/configuration/acme/dns01/cloudflare.md
@@ -42,7 +42,6 @@ spec:
     solvers:
     - dns01:
         cloudflare:
-          email: my-cloudflare-acc@example.com
           apiTokenSecretRef:
             name: cloudflare-api-token-secret
             key: api-token


### PR DESCRIPTION
API Tokens are not bound to an email address (contrary to API Keys).