### PR TITLE
Don't force GOPROXY when generating docs

### DIFF
--- a/scripts/gendocs/generate
+++ b/scripts/gendocs/generate
@@ -40,7 +40,6 @@ trap cleanup EXIT
 # Create fake GOPATH
 echo "+++ Creating temporary GOPATH"
 export GOPATH="${tmpdir}/go"
-export GOPROXY="https://proxy.golang.org"
 export GO111MODULE="on"
 GOROOT="$(go env GOROOT)"
 export GOROOT


### PR DESCRIPTION
Forcing the value is harmful in environments which use a local caching GOPROXY (such as my own :grin:)

This is very similar to something we did in the main cert-manager repo: https://github.com/jetstack/cert-manager/commit/c86f20f4b54d47388dd5f93f2d8de53e9973e0c8