### PR TITLE
Update faq/kubed.md: Fix deprecated API in v1.22 (networking.k8s.io/v1beta1)

### DIFF
--- a/content/en/docs/faq/kubed.md
+++ b/content/en/docs/faq/kubed.md
@@ -18,7 +18,7 @@ Most ingress controllers, including [ingress-nginx](https://kubernetes.github.io
 Sample ingress snippet:
 
 ```
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 #[...]
 spec:


### PR DESCRIPTION
Fix incorrect example in `kubed.md` that still using deprecated Ingress API `networking.k8s.io/v1beta1`

Changed to `networking.k8s.io/v1`

References:
- https://kubernetes.io/blog/2021/07/26/update-with-ingress-nginx/
- https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122