### PR TITLE
Retro 1.5 follow-up: PR to website on every feature PR

### DIFF
--- a/content/en/docs/contributing/contributing-flow.md
+++ b/content/en/docs/contributing/contributing-flow.md
@@ -75,6 +75,12 @@ To let people know that your PR is still a work in progress, we usually add a
 `WIP:` prefix to the title of the PR. Prow will then automatically set the label
 `do-not-merge/work-in-progress`.
 
+It is advised to keep the PR description and title up to date as the review
+goes, e.g., with the review discussions outcome.
+
+If the pull request contains a new feature, the pull request description is
+expected to contain a link to another pull request that describes the feature on
+the website.
 
 ### Cherry Picking
 


### PR DESCRIPTION
During our 1.4 retro, we decided to have a link to a website PR for every PR that contains a new feature. This PR documents this new requirement.

<img alt="" src="https://user-images.githubusercontent.com/2195781/130453540-c5a60dd3-2808-421d-b7c1-e1646a0d62c6.png" width="300">