### PR TITLE
Bump helm installed cm version v1.5.0 -> v1.5.3

### DIFF
--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -460,3 +460,9 @@ page if a step is missing or if it is outdated.
        updates to the website configuration. To do this, take inspiration from
        [Maartje's PR
        example](https://github.com/cert-manager/website/pull/309/files).
+
+    5. Ensure that any installation commands in
+       [`cert-manager/website`](https://github.com/cert-manager/website) install
+       the latest version. This should be done after every release, including
+       patch releases as we want to encourage users to always install the latest
+       patch.

--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -15,7 +15,7 @@ install methods are listed below for each of the situations.
 
 The default static configuration can be installed as follows:
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 ```
 More information on this install method [can be found here](./kubectl/).
 

--- a/content/en/docs/installation/helm.md
+++ b/content/en/docs/installation/helm.md
@@ -46,7 +46,7 @@ or using the `installCRDs` option when installing the Helm chart.
 
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.0/cert-manager.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -67,7 +67,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.5.0 \
+  --version v1.5.3 \
   # --set installCRDs=true
 ```
 
@@ -80,7 +80,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.5.0 \
+  --version v1.5.3 \
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4s   # Example: changing the wehbook timeout using a Helm parameter
 ```
@@ -97,7 +97,7 @@ $ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.5.0 \
+  --version v1.5.3 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/en/docs/installation/kubectl.md
+++ b/content/en/docs/installation/kubectl.md
@@ -21,7 +21,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`


### PR DESCRIPTION
Bump Helm installed cert-manager version v1.5.0 -> v1.5.3

I think we should always encourage users who want to install a particular minor version to install the latest patch version for that minor version. It feels suboptimal to bump it here every time after releasing a patch. I am not sure what would be the best solution for that - it is possible to specify a range of versions to helm install command with `--version ^X.Y`, but that doesn't seem to work for versions that are prefixed with `v`.
Perhaps we should take the version out of the install command alltogether.

Signed-off-by: irbekrm <irbekrm@gmail.com>