### PR TITLE
Remove compat details for GKE autopilot

### DIFF
--- a/content/en/docs/installation/compatibility.md
+++ b/content/en/docs/installation/compatibility.md
@@ -46,18 +46,6 @@ You can read more information on how to add firewall rules for the GKE control
 plane nodes in the [GKE
 docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules).
 
-## GKE Autopilot
-
-As of May 2021, GKE Autopilot has no support for 3rd party webhooks.
-Without webhooks, many Kubernetes plugins such as cert-manager cannot
-operate correctly.
-
-As per [this
-tweet](https://twitter.com/BagadeVivek/status/1365701217469534220), GKE
-Autopilot is meant to support webhooks in a coming release. We will keep
-you updated on the progress on [this
-issue](https://github.com/jetstack/cert-manager/issues/3717).
-
 ## AWS EKS
 
 When using a custom CNI (such as Weave or Calico) on EKS, the webhook cannot be


### PR DESCRIPTION
After [this comment](https://github.com/jetstack/cert-manager/issues/3717#issuecomment-919299192) it should now be supported; there could be other issues which we'll discover and we can add details later, but for now but the compat page is definitely outdated at the very least.