### PR TITLE
Update supported Bazel versions

### DIFF
--- a/content/en/docs/contributing/building.md
+++ b/content/en/docs/contributing/building.md
@@ -8,7 +8,7 @@ type: "docs"
 cert-manager makes use of [Bazel](https://bazel.build/) to build the project. 
 Bazel manages all developer dependencies, Helm chart building, Docker images and the code itself. 
 We try to use it as much as possible.
-We currently use Bazel `v3.7.2`. The minimum supported version is `v3.5.0`.
+We currently use Bazel `v4.2.1`. The minimum supported version is `v4.0.0`.
 
 > **TIP**: are you using GoLand? Make sure to exclude the `bazel-` folders! You can do this by right clicking on the folder -> Mark Directory As -> Excluded
 > This will save you a ton of CPU time!


### PR DESCRIPTION
This small PR updates the supported/required Bazel versions.

It is to be merged after [cert-manager#4478](https://github.com/jetstack/cert-manager/pull/4478) which enforces `v4.0.0` as minimum Bazel version gets merged.



Signed-off-by: irbekrm <irbekrm@gmail.com>