### PR TITLE
Change links in usage certificate to kubectl plugin #renew to be relative

### DIFF
--- a/content/en/docs/usage/certificate.md
+++ b/content/en/docs/usage/certificate.md
@@ -200,7 +200,7 @@ certificate object is reissued under the following circumstances:
   kubectl cert-manager renew cert-1
   ```
   Note that the above command requires the [kubectl
-  cert-manager](/docs/usage/kubectl-plugin/#renew) plugin.
+  cert-manager](../kubectl-plugin/#renew) plugin.
 
 {{% pageinfo color="warning" %}}
 
@@ -208,7 +208,7 @@ certificate object is reissued under the following circumstances:
 **not a recommended solution** for manually rotating the private key. The
 recommended way to manually rotate the private key is to trigger the reissuance
 of the Certificate resource with the following command (requires the [`kubectl
-cert-manager`](/docs/usage/kubectl-plugin/#renew) plugin):
+cert-manager`](../kubectl-plugin/#renew) plugin):
 
 ```sh
 kubectl cert-manager renew cert-1


### PR DESCRIPTION
Same as #718

/assign @jakexks

This PR changes references in release-1.5/usage/certificate to usage/kubectl-plugin/#renew to use a relative path. When using an absolute path, it looks like it will reference the latest docs, which will no longer exist after this PR #715. Changing to the relative path should now link to the page within the correct version.