### PR TITLE
Update kubed sync example and use secret template instead of pre-annotated secret

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -34,6 +34,7 @@ boolean
 CAs
 CertificateRequest
 CertificateRequests
+CertificateSecretTemplate
 CertificateSigningRequest
 CertificateSigningRequests
 Changelog

--- a/content/en/docs/faq/kubed.md
+++ b/content/en/docs/faq/kubed.md
@@ -47,19 +47,6 @@ metadata:
   labels:
     cert-manager-tls: sandbox # Define namespace label for kubed
 ---
-apiVersion: v1
-data:
-  ca.crt: ''
-  tls.crt: ''
-  tls.key: ''
-kind: Secret
-metadata:
-  name: sandbox-tls
-  namespace: cert-manager
-  annotations:
-    kubed.appscode.com/sync: "cert-manager-tls=sandbox" # Sync certificate to matching namespaces
-type: kubernetes.io/tls
----
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -72,6 +59,9 @@ spec:
     name: sandbox-ca
     kind: Issuer
     group: cert-manager.io
+  secretTemplate:
+    annotations:
+      kubed.appscode.com/sync: "cert-manager-tls=sandbox" # Sync certificate to matching namespaces
 ```
 
 [CertificateSecretTemplate]: ../../reference/api-docs/#cert-manager.io/v1alpha3.CertificateSecretTemplate

--- a/content/en/docs/faq/kubed.md
+++ b/content/en/docs/faq/kubed.md
@@ -62,4 +62,4 @@ spec:
       kubed.appscode.com/sync: "cert-manager-tls=sandbox" # Sync certificate to matching namespaces
 ```
 
-[CertificateSecretTemplate]: ../../reference/api-docs/#cert-manager.io/v1alpha3.CertificateSecretTemplate
+[CertificateSecretTemplate]: ../../reference/api-docs/#cert-manager.io/v1.CertificateSecretTemplate

--- a/content/en/docs/faq/kubed.md
+++ b/content/en/docs/faq/kubed.md
@@ -73,3 +73,5 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ```
+
+[CertificateSecretTemplate]: ../../reference/api-docs/#cert-manager.io/v1alpha3.CertificateSecretTemplate

--- a/content/en/docs/faq/kubed.md
+++ b/content/en/docs/faq/kubed.md
@@ -33,9 +33,7 @@ spec:
 
 ## Syncing arbitrary secrets across namespaces using kubed
 
-In order for the target Secret to be synced, the Secret resource must first be
-created with the correct annotations before the creation of the Certificate,
-else the Secret will need to be edited instead. The example below shows syncing
+In order for the target Secret to be synced, you can use the `secretTemplate` field for annotating the generated secret with the kubed sync annotation (See [CertificateSecretTemplate]). The example below shows syncing
 a certificate belonging to the `sandbox` Certificate from the `cert-manager`
 namespace, into the `sandbox` namespace.
 


### PR DESCRIPTION
Because the use of pre-annotated secrets for syncing certificates across namespaces is error-prone and `secretTemplate` is available since [1.5.0](https://github.com/jetstack/cert-manager/pull/3828), this PR updates the kubed example for syncing secrets to use `secretTemplate` instead of pre-created secrets.