### PR TITLE
Update website config for the 1.6 release

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -22,7 +22,7 @@
 # Set to "docs" path
 
 [[versions]]
-  version = "v1.5"
+  version = "v1.6"
   # 'master' is used to store the 'current' version documentation.
   # Once the 'next' release becomes 'current', we branch master to
   # release-X.Y and merge 'release-next' into 'master'.
@@ -33,7 +33,7 @@
 # 'Next' version
 ################
 [[versions]]
-  version = "v1.6"
+  version = "v1.7"
   ghbranchname = "release-next"
   url = "/next-docs/"
   dirpath = "next-docs"
@@ -41,6 +41,12 @@
 # Archived versions
 ###################
 # Use format `v0.#-docs` for past version's dirpath
+
+[[versions]]
+  version = "v1.5"
+  ghbranchname = "release-1.5"
+  url = "/v1.5-docs/"
+  dirpath = "v1.5-docs"
 
 [[versions]]
   version = "v1.4"

--- a/scripts/gendocs/generate
+++ b/scripts/gendocs/generate
@@ -76,8 +76,9 @@ genversion() {
 
 # The branches named here exist in the `jetstack/cert-manager` repo.
 
-genversion "release-1.6" "next-docs"
-genversion "release-1.5" "docs"
+genversion "release-1.7" "next-docs"
+genversion "release-1.6" "docs"
+genversion "release-1.6" "v1.6-docs"
 genversion "release-1.5" "v1.5-docs"
 genversion "release-1.4" "v1.4-docs"
 genversion "release-1.3" "v1.3-docs"

--- a/scripts/update-content
+++ b/scripts/update-content
@@ -30,6 +30,7 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 	--repo-url https://github.com/cert-manager/website.git \
 	--repo-content-dir content/en/docs \
 	--output-dir "${REPO_ROOT}/content/en" \
+	--branches v1.6-docs=release-1.6 \
 	--branches v1.5-docs=release-1.5 \
 	--branches v1.4-docs=release-1.4 \
 	--branches v1.3-docs=release-1.3 \

--- a/scripts/verify-lint
+++ b/scripts/verify-lint
@@ -53,6 +53,7 @@ echo "+++ Running spell check"
   "!content/en/v1.3-docs/reference/api-docs.md" \
   "!content/en/v1.4-docs/reference/api-docs.md" \
   "!content/en/v1.5-docs/reference/api-docs.md" \
+  "!content/en/v1.6-docs/reference/api-docs.md" \
   "!content/en/next-docs/**/*.md"
 
 # About "!content/en/next-docs/**/*.md":


### PR DESCRIPTION
Based on:
 * #680 

The default documentation version in the version drop down list is now 1.6
 * https://deploy-preview-733--cert-manager-website.netlify.app/