### PR TITLE
Adding Netlify redirect config for legacy docs url

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -95,3 +95,9 @@ googleAnalytics = "UA-78700849-2"
 [algolia]
 index = "cert-manager-latest"
 appID = "18N9PEKHUC"
+
+[[redirects]]
+  from = "https://docs.cert-manager.io"
+  to = "https://cert-manager.io/docs/"
+  status = 301
+  force = true


### PR DESCRIPTION
Recently https://docs.cert-manager.io has stopped working, ideally, this URL would redirect to https://cert-manager.io/docs/

This netlify config addition along with a DNS change should resolve this issue.