### PR TITLE
Update supported releases to remove 1.16

### DIFF
--- a/content/en/docs/installation/supported-releases.md
+++ b/content/en/docs/installation/supported-releases.md
@@ -19,14 +19,14 @@ release every two months.
 
 | Release | Release Date | End of life |    [Supported Kubernetes versions][s]    | [Supported OpenShift versions][s] |
 |---------|:------------:|:-----------:|:----------------------------------------:|:---------------------------------:|
-| [1.6][] | Oct 26, 2021 | Feb 9, 2022 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22 | 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9 |
+| [1.6][] | Oct 26, 2021 | Feb 9, 2022 |    1.17, 1.18, 1.19, 1.20, 1.21, 1.22    |   4.4, 4.5, 4.6, 4.7, 4.8, 4.9    |
 | [1.5][] | Aug 11, 2021 | Dec 7, 2021 | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22 |   4.3, 4.4, 4.5, 4.6, 4.7, 4.8    |
 
 ## Upcoming releases
 
 | Release | Release Date | End of life  | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |---------|:------------:|:------------:|:----------------------------------:|:---------------------------------:|
-| [1.7][] | Dec 7, 2021  | Apr 6, 2022  |           to be defined            |           to be defined           |
+| [1.7][] | Dec 7, 2021  | Apr 6, 2022  |      1.18+, to be confirmed        |       4.5+, to be confirmed       |
 | 1.8     | Feb 9, 2022  | June 8, 2022 |           to be defined            |           to be defined           |
 
 Note that dates in the future are uncertain and might change.
@@ -207,7 +207,7 @@ to be supporting most commercial Kubernetes offerings.
 
 |      Vendor       | Oldest Kubernetes Release\* |               Other Old\*\* Kubernetes Releases               |
 |:-----------------:|-----------------------------|---------------------------------------------------------------|
-|    [EKS][eks]     | 1.16 (EOL Sep 2021)         | 1.17 (EOL Nov 2021), 1.18 (EOL Dec 2021), 1.19 (EOL Apr 2022) |
+|    [EKS][eks]     | 1.17 (EOL Nov 2021)         | 1.18 (EOL Dec 2021), 1.19 (EOL Apr 2022)                      |
 |    [GKE][gke]     | 1.17 (EOL Nov 2021)         | 1.18 (EOL Mar 2022), 1.19 (EOL Jun 2022)                      |
 |    [AKS][aks]     | 1.18 (EOL Jul 2021)         | 1.19 (EOL Aug 2021)                                           |
 | [OpenShift 4][os] | 1.18 (4.5, EOL July 2021)   | 1.19 (4.6 EUS, EOL May 2022)                                  |


### PR DESCRIPTION
Also updates vendor supported platforms and hints at the removal of support for v1.17 in cert-manager 1.7