### PR TITLE
Remove references to removed API versions

### DIFF
--- a/content/en/docs/tutorials/acme/ingress.md
+++ b/content/en/docs/tutorials/acme/ingress.md
@@ -644,7 +644,7 @@ Events:
 > Note: If your challenges are not becoming 'valid' and remain in the 'pending'
 > state (or enter into a 'failed' state), it is likely there is some kind of
 > configuration error. Read the [Challenge resource reference
-> docs](../../../reference/api-docs/#acme.cert-manager.io/v1alpha2.Challenge) for more
+> docs](../../../reference/api-docs/#acme.cert-manager.io/v1.Challenge) for more
 > information on debugging failing challenges.
 
 Once the challenge(s) have been completed, their corresponding challenge

--- a/content/en/docs/usage/certificate.md
+++ b/content/en/docs/usage/certificate.md
@@ -119,7 +119,7 @@ The `Certificate` will be issued using the issuer named `ca-issuer` in the
 > days, 23 hours (the _full duration_ remains 90 days).
 
 A full list of the fields supported on the Certificate resource can be found in
-the [API reference documentation](../../reference/api-docs/#cert-manager.io/v1alpha2.CertificateSpec).
+the [API reference documentation](../../reference/api-docs/#cert-manager.io/v1.CertificateSpec).
 
 ## X.509 key usages and extended key usages {#key-usages}
 
@@ -136,7 +136,7 @@ cert-manager will not attempt to request a new certificate if the current
 certificate does not match the current key usage set.
 
 An exhaustive list of supported key usages can be found in the [API reference
-documentation](../../reference/api-docs/#cert-manager.io/v1alpha2.KeyUsage).
+documentation](../../reference/api-docs/#cert-manager.io/v1.KeyUsage).
 
 ## Temporary Certificates while Issuing {#temporary-certificates-whilst-issuing}
 


### PR DESCRIPTION
This PR changes references to the deprecated alpha/beta API resources to refer to v1 resources instead.

I would also like to cherry-pick this PR into release-1.6 branch so that #744 which is currently failing passes.


Signed-off-by: irbekrm <irbekrm@gmail.com>