### PR TITLE
adding redirect rules to prevent google links from reaching page not …

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -36,8 +36,13 @@ https://cert-manager.io/docs/usage/kubectl-plugin/#completion https://cert-manag
 https://cert-manager.io/docs/usage/kubectl-plugin/#experimental https://cert-manager.io/docs/usage/cmctl/#experimental
 https://cert-manager.io/docs/usage/kubectl-plugin/#certificatesigningrequest https://cert-manager.io/docs/usage/cmctl/#certificatesigningrequest
 
-# docs.cert-manager.io was previously a separately hosted service. The dns has since been redirect to the main site and the following redirect
-# rule will force people with historical links or browser to docs.cert-manager.io to be redirected to the /docs endpoint
+# docs.cert-manager.io was previously a separately hosted service. The dns has since been redirected and the following rules are required for historical links
+# These rules are in place to capture traffic that is specifically referencing these source urls
+https://docs.cert-manager.io/en/latest/getting-started/index.html https://cert-manager.io/docs/tutorials/
+https://docs.cert-manager.io/en/latest/tutorials/acme/index.html https://cert-manager.io/docs/tutorials/
+https://docs.cert-manager.io/en/latest/tasks/issuers/index.html https://cert-manager.io/docs/configuration/
+# These rules should capture all historical links that reference endpoints for specfic release versions. Whilst these endpoints might not exist anymore these
+# redirect rules will capture the request and route the user to the specific release-note page
 https://docs.cert-manager.io/en/release-0.1/* https://cert-manager.io/docs/release-notes/release-notes-0.1/ 301!
 https://docs.cert-manager.io/en/release-0.2/* https://cert-manager.io/docs/release-notes/release-notes-0.2/ 301!
 https://docs.cert-manager.io/en/release-0.3/* https://cert-manager.io/docs/release-notes/release-notes-0.3/ 301!
@@ -54,5 +59,7 @@ https://docs.cert-manager.io/en/release-0.13/* https://cert-manager.io/docs/rele
 https://docs.cert-manager.io/en/release-0.14/* https://cert-manager.io/docs/release-notes/release-notes-0.14/ 301!
 https://docs.cert-manager.io/en/release-0.15/* https://cert-manager.io/docs/release-notes/release-notes-0.15/ 301!
 https://docs.cert-manager.io/en/release-0.16/* https://cert-manager.io/docs/release-notes/release-notes-0.16/ 301!
+# These rules should capture requests to release-notes pages and re-route them accordingly
 https://docs.cert-manager.io/en/release-* https://cert-manager.io/docs/release-notes/release-notes-:splat 301!
-https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 301!
+https://docs.cert-manager.io https://cert-manager.io/docs 301!
+https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 302!

--- a/_redirects
+++ b/_redirects
@@ -38,4 +38,21 @@ https://cert-manager.io/docs/usage/kubectl-plugin/#certificatesigningrequest htt
 
 # docs.cert-manager.io was previously a separately hosted service. The dns has since been redirect to the main site and the following redirect
 # rule will force people with historical links or browser to docs.cert-manager.io to be redirected to the /docs endpoint
+https://docs.cert-manager.io/en/release-0.1/* https://cert-manager.io/docs/release-notes/release-notes-0.1/ 301!
+https://docs.cert-manager.io/en/release-0.2/* https://cert-manager.io/docs/release-notes/release-notes-0.2/ 301!
+https://docs.cert-manager.io/en/release-0.3/* https://cert-manager.io/docs/release-notes/release-notes-0.3/ 301!
+https://docs.cert-manager.io/en/release-0.4/* https://cert-manager.io/docs/release-notes/release-notes-0.4/ 301!
+https://docs.cert-manager.io/en/release-0.5/* https://cert-manager.io/docs/release-notes/release-notes-0.5/ 301!
+https://docs.cert-manager.io/en/release-0.6/* https://cert-manager.io/docs/release-notes/release-notes-0.6/ 301!
+https://docs.cert-manager.io/en/release-0.7/* https://cert-manager.io/docs/release-notes/release-notes-0.7/ 301!
+https://docs.cert-manager.io/en/release-0.8/* https://cert-manager.io/docs/release-notes/release-notes-0.8/ 301!
+https://docs.cert-manager.io/en/release-0.9/* https://cert-manager.io/docs/release-notes/release-notes-0.9/ 301!
+https://docs.cert-manager.io/en/release-0.10/* https://cert-manager.io/docs/release-notes/release-notes-0.10/ 301!
+https://docs.cert-manager.io/en/release-0.11/* https://cert-manager.io/docs/release-notes/release-notes-0.11/ 301!
+https://docs.cert-manager.io/en/release-0.13/* https://cert-manager.io/docs/release-notes/release-notes-0.12/ 301!
+https://docs.cert-manager.io/en/release-0.13/* https://cert-manager.io/docs/release-notes/release-notes-0.13/ 301!
+https://docs.cert-manager.io/en/release-0.14/* https://cert-manager.io/docs/release-notes/release-notes-0.14/ 301!
+https://docs.cert-manager.io/en/release-0.15/* https://cert-manager.io/docs/release-notes/release-notes-0.15/ 301!
+https://docs.cert-manager.io/en/release-0.16/* https://cert-manager.io/docs/release-notes/release-notes-0.16/ 301!
+https://docs.cert-manager.io/en/release-* https://cert-manager.io/docs/release-notes/release-notes-:splat 301!
 https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 301!

--- a/_redirects
+++ b/_redirects
@@ -54,7 +54,7 @@ https://docs.cert-manager.io/en/release-0.8/* https://cert-manager.io/docs/relea
 https://docs.cert-manager.io/en/release-0.9/* https://cert-manager.io/docs/release-notes/release-notes-0.9/ 301!
 https://docs.cert-manager.io/en/release-0.10/* https://cert-manager.io/docs/release-notes/release-notes-0.10/ 301!
 https://docs.cert-manager.io/en/release-0.11/* https://cert-manager.io/docs/release-notes/release-notes-0.11/ 301!
-https://docs.cert-manager.io/en/release-0.13/* https://cert-manager.io/docs/release-notes/release-notes-0.12/ 301!
+https://docs.cert-manager.io/en/release-0.12/* https://cert-manager.io/docs/release-notes/release-notes-0.12/ 301!
 https://docs.cert-manager.io/en/release-0.13/* https://cert-manager.io/docs/release-notes/release-notes-0.13/ 301!
 https://docs.cert-manager.io/en/release-0.14/* https://cert-manager.io/docs/release-notes/release-notes-0.14/ 301!
 https://docs.cert-manager.io/en/release-0.15/* https://cert-manager.io/docs/release-notes/release-notes-0.15/ 301!

--- a/content/en/docs/installation/upgrading/upgrading-0.7-0.8.md
+++ b/content/en/docs/installation/upgrading/upgrading-0.7-0.8.md
@@ -94,7 +94,7 @@ spec:
       dns01:
         # Adjust the configuration below according to your environment.
         # You can view more example configurations for different DNS01
-        # providers in the documentation: https://docs.cert-manager.io/en/latest/tasks/issuers/setup-acme/dns01/index.html
+        # providers in the documentation: https://cert-manager.io/docs/tutorials/acme/dns-validation/
         cloudflare:
           email: my-cloudflare-acc@example.com
           apiKeySecretRef:
@@ -220,7 +220,7 @@ spec:
       dns01:
         # Adjust the configuration below according to your environment.
         # You can view more example configurations for different DNS01
-        # providers in the documentation: https://docs.cert-manager.io/en/latest/tasks/issuers/setup-acme/dns01/index.html
+        # providers in the documentation: https://cert-manager.io/docs/tutorials/acme/dns-validation/
         cloudflare:
           email: my-cloudflare-acc@example.com
           apiKeySecretRef:

--- a/content/en/docs/release-notes/release-notes-0.11.md
+++ b/content/en/docs/release-notes/release-notes-0.11.md
@@ -47,7 +47,7 @@ The changes to our CRD resources mean that upgrading requires more manual
 intervention than in previous releases.
 
 It's recommended that you backup and completely [uninstall
-cert-manager](https://docs.cert-manager.io/en/release-0.12/tasks/uninstall/)
+cert-manager](https://cert-manager.io/docs/installation/uninstall/)
 before re-installing the `v0.11` release.
 
 You will also need to manually update all your backed up cert-manager resource

--- a/content/en/docs/release-notes/release-notes-0.9.md
+++ b/content/en/docs/release-notes/release-notes-0.9.md
@@ -64,7 +64,7 @@ out of tree issuer will follow in later releases. You can read more on the
 motivations and road map in the [enhancement
 proposal](https://github.com/jetstack/cert-manager/blob/master/design/20190708.certificate-request-crd.md)
 or how this resource is used in the
-[docs](https://docs.cert-manager.io/en/release-0.9/reference/certificaterequests.html).
+[docs](https://cert-manager.io/docs/concepts/certificaterequest/).
 
 
 ### DNS Zones support for ACME challenge solver selector

--- a/content/en/docs/tutorials/acme/dns-validation.md
+++ b/content/en/docs/tutorials/acme/dns-validation.md
@@ -44,7 +44,7 @@ spec:
       dns01:
         cloudDNS:
           # The ID of the GCP project
-          # reference: https://docs.cert-manager.io/en/latest/tasks/issuers/setup-acme/dns01/google.html
+          # reference: https://cert-manager.io/docs/tutorials/acme/dns-validation/
           project: $PROJECT_ID
           # This is the secret used to access the service account
           serviceAccountSecretRef:


### PR DESCRIPTION
…found

Signed-off-by: Chance Whittaker <chance19@gmail.com>

Currently some links from Google, such as https://docs.cert-manager.io/en/release-0.11/ would route to https://cert-manager.io/docs/en/release-0.11/ which would take the browser to a 404 page not found (see screenshot)
![image](https://user-images.githubusercontent.com/14806044/140092609-c845fbcc-bf2d-49e5-981a-bfbc0d7c7a2c.png)

This change should ensure that these links are at least routed back to the specific release-note page that was referenced in the link. This is not a full solution to the problem just an improvement on the current situation.