### PR TITLE
Add temp 302 redirect to all other paths than the root

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -38,4 +38,5 @@ https://cert-manager.io/docs/usage/kubectl-plugin/#certificatesigningrequest htt
 
 # docs.cert-manager.io was previously a separately hosted service. The dns has since been redirect to the main site and the following redirect
 # rule will force people with historical links or browser to docs.cert-manager.io to be redirected to the /docs endpoint
-https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 301!
+https://docs.cert-manager.io https://cert-manager.io/docs 301!
+https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 302!


### PR DESCRIPTION
Based on feedback from @munnerz, propose we do the following (for now):

* Use a permanent (301) redirect for `docs.cert-manager.io` 
* Use a temporary (302) redirect for all other paths (which may or may not work currently)

We should follow-up to this PR with redirect rules for specific pages that we know are linked from other pages and feature prominently in search engine listings.