### PR TITLE
Added kubectl config for recursive nameservers

### DIFF
--- a/content/en/docs/configuration/acme/dns01/_index.md
+++ b/content/en/docs/configuration/acme/dns01/_index.md
@@ -80,6 +80,15 @@ with `--set`:
 --set 'extraArgs={--dns01-recursive-nameservers-only,--dns01-recursive-nameservers=8.8.8.8:53\,1.1.1.1:53}'
 ```
 
+If you are deploying using kubectl, then you can add the following line, to the `spec.template.spec.containers.args`
+```bash
+- args:
+        - --v=2
+        - --cluster-resource-namespace=$(POD_NAMESPACE)
+        - --leader-election-namespace=kube-system
+        - --dns01-self-check-nameservers="8.8.8.8:53"
+```
+
 ## Delegated Domains for DNS01
 
 By default, cert-manager will not follow CNAME records pointing to subdomains.


### PR DESCRIPTION
The documentation, is lacking how to set recursive nameservers, when deploying using kubectl.

I found the answer in the following issue : 
https://github.com/jetstack/cert-manager/issues/1163#issuecomment-912671595

I have testet it, and it works perfect. 
