### PR TITLE
Redirect all 404s to the root of the site

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -77,3 +77,7 @@ https://docs.cert-manager.io/en/release-0.16/* https://cert-manager.io/docs/rele
 https://docs.cert-manager.io/en/release-* https://cert-manager.io/docs/release-notes/release-notes-:splat 301!
 https://docs.cert-manager.io https://cert-manager.io/docs 301!
 https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 302!
+
+# redirect anything else to our custom 404 page. this is required as the site generator / theme uses relative links for the 404 page, which break if the
+# 404 page isn't served from /404.html
+/* /404.html 404


### PR DESCRIPTION
I think this is required because the theme we use uses relative links for CSS files, which break if the 404 page isn't served from the root.

Currently a [404 on the root](https://cert-manager.io/dasdub) looks vaguely correct while a [404 under /docs](https://cert-manager.io/docs/asdasdasd) looks totally broken. This should hopefully fix that.

This line was taken from the [hugo docs](https://gohugo.io/templates/404/#automatic-loading). The [netlify docs](https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling) seem to contradict and suggest that this line is not needed, but I think it's only not needed if the 404 page uses absolute paths.

/kind cleanup