### PR TITLE
Document that DNS-01 ClusterIssuer use kube-system secret

### DIFF
--- a/content/en/docs/configuration/acme/dns01/route53.md
+++ b/content/en/docs/configuration/acme/dns01/route53.md
@@ -180,6 +180,8 @@ spec:
 
 Note that, as mentioned above, the pod is using `arn:aws:iam::XXXXXXXXXXX:role/cert-manager` as a credentials source in Account X, but the `ClusterIssuer` ultimately assumes the `arn:aws:iam::YYYYYYYYYYYY:role/dns-manager` role to actually make changes in Route53 zones located in Account Y.
 
+When using a `ClusterIssuer` provided secret have to live inside the `kube-system` namespace so that challenges can properly fetch the secret.
+
 ## EKS IAM Role for Service Accounts (IRSA)
 
 While [`kiam`](https://github.com/uswitch/kiam) / [`kube2iam`](https://github.com/jtblin/kube2iam) work directly with cert-manager, some special attention is needed for using the [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) feature available on EKS.


### PR DESCRIPTION
When using a ClusterIssuer with DNS-01 ans route 53, you have to reference a secret that live inside the kube-system namespace