### PR TITLE
venafi: service-generated CSRs must not be locked

### DIFF
--- a/content/en/docs/configuration/venafi.md
+++ b/content/en/docs/configuration/venafi.md
@@ -118,9 +118,22 @@ of the connection parameters are slightly different.
 > this is the only type supported by cert-manager at this time.
 >
 > More specifically, the valid configurations of the "CSR handling" are:
+>
 > - "User Provided CSRs" selected and unlocked,
 > - "User Provided CSRs" selected and locked,
 > - "Service Generated CSRs" selected and unlocked.
+>
+> When using "Service Generated CSRs" selected and unlocked, the default CSR
+> configuration present in your policy folder will override the configuration of
+> your Certificate resource. The subject DN, key algorithm, and key size will be
+> overridden by the values set in the policy folder.
+>
+> With "Service Generated CSRs" selected and locked, the certificate issuance
+> will systematically fail with the following message:
+>
+> ```plain
+> 400 PKCS#10 data will not be processed. Policy "\VED\Policy\foo" is locked to a Server Generated CSR.
+> ```
 
 In order to set up a Venafi Trust Protection Platform `Issuer`, you must first
 create a Kubernetes `Secret` resource containing your Venafi TPP API

--- a/content/en/docs/configuration/venafi.md
+++ b/content/en/docs/configuration/venafi.md
@@ -116,6 +116,11 @@ of the connection parameters are slightly different.
 
 > **Note**: You *must* allow "User Provided CSRs" as part of your TPP policy, as
 > this is the only type supported by cert-manager at this time.
+>
+> More specifically, the valid configurations of the "CSR handling" are:
+> - "User Provided CSRs" selected and unlocked,
+> - "User Provided CSRs" selected and locked,
+> - "Service Generated CSRs" selected and unlocked.
 
 In order to set up a Venafi Trust Protection Platform `Issuer`, you must first
 create a Kubernetes `Secret` resource containing your Venafi TPP API


### PR DESCRIPTION
It seems our documentation isn't precise enough and does not mention the possibility for "Service Generated CSRs" to be a valid configuration as long as it is not locked; for example the following works with cert-manager:

<img width="901" alt="Screenshot 2021-12-02 at 16 34 13" src="https://user-images.githubusercontent.com/2195781/144456068-836bd26e-3465-43c4-a90b-5372ae9284fc.png">

Signed-off-by: Maël Valais <mael@vls.dev>

cc @SpectralHiss