### PR TITLE
Adding a second usecase when using ingress-shim

### DIFF
--- a/content/en/docs/usage/ingress.md
+++ b/content/en/docs/usage/ingress.md
@@ -141,3 +141,4 @@ guide](../../installation/).
 ## Troubleshooting
 
 If you do not see a `Certificate` resource being created after applying the ingress-shim annotations check that at least `cert-manager.io/issuer` or `cert-manager.io/cluster-issuer` is set. If you want to use `kubernetes.io/tls-acme: "true"` make sure to have checked all steps above and you might want to look for errors in the cert-manager pod logs if not resolved.
+

--- a/content/en/docs/usage/ingress.md
+++ b/content/en/docs/usage/ingress.md
@@ -133,6 +133,8 @@ In the above example, cert-manager will create `Certificate` resources that
 reference the `ClusterIssuer` `letsencrypt-prod` for all Ingresses that have a
 `kubernetes.io/tls-acme: "true"` annotation.
 
+If you are using the `cert-manager.io/cluster-issuer : "letsencrypt-prod-custom"` (for example) second annotation on your Ingress, then this reference will be overriden and a `Certificate` resource referencing the `ClusterIssuer` `letsencrypt-prod-custom` will be created instead.
+
 For more information on deploying cert-manager, read the [installation
 guide](../../installation/).
 


### PR DESCRIPTION
It can be useful for new people discovering cert-manager