### PR TITLE
Fix incorrect indentation in documentation

### DIFF
--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -371,13 +371,13 @@ solvers:
     apiKeySecretRef:
       name: cloudflare-apikey-secret
       key: apikey
-selector:
-  matchLabels:
-   'email': 'user@example.com'
-   'solver': 'cloudflare'
-  dnsZones:
-    - 'test.example.com'
-    - 'example.dev'
+  selector:
+    matchLabels:
+     'email': 'user@example.com'
+     'solver': 'cloudflare'
+    dnsZones:
+      - 'test.example.com'
+      - 'example.dev'
 ```
 In this case the `DNS01` solver for CloudFlare will only be used to solve a
 challenge for a DNS name if the `Certificate` has a label from

--- a/content/en/docs/configuration/acme/dns01/_index.md
+++ b/content/en/docs/configuration/acme/dns01/_index.md
@@ -115,7 +115,7 @@ spec:
     - selector:
         dnsZones:
         - 'example.com'
-    - dns01:
+      dns01:
         # Valid values are None and Follow
         cnameStrategy: Follow
         route53:


### PR DESCRIPTION
The selector field belongs to the `ACMEChallengeSolver` according to the api
documentation, and we should not add another entry in the list for the `dns01` key

In the `acme` section the selector key was not properly indented.