### PR TITLE
Adds section in usage/certificates for additional output formats

### DIFF
--- a/content/en/docs/usage/certificate.md
+++ b/content/en/docs/usage/certificate.md
@@ -287,13 +287,12 @@ Once an X.509 certificate has been issued, cert-manager will calculate the renew
 
 ## Additional Certificate Output Formats
 
-This feature is currently in an _experimental_ alpha state, and its behavior is
-subject to change in further releases or removed entirely.
-
 {{% pageinfo color="warning" %}}
 
-⛔️ This feature is only enabled by adding it to the `--feature-gates` flag on
-the cert-manager controller and webhook components:
+⛔️ The additional certificate output formats feature is currently in an
+_experimental_ alpha state, and is subject to breaking changes or complete
+removal in future releases. This feature is only enabled by adding it to the
+`--feature-gates` flag on the cert-manager controller and webhook components:
 
 ```bash
 --feature-gates=AdditionalCertificateOutputFormats=true
@@ -301,10 +300,11 @@ the cert-manager controller and webhook components:
 
 {{% /pageinfo %}}
 
-This feature enables defining extra output formats of the Certificate in the
-target Secret resource. There are currently two supported additional output
-formats: `CombinedPEM` and `DER`. Both output formats can be specified on the
-same Certificate.
+`additionalOutputFormats` is a field on the Certificate `spec` that allows
+specifying additional supplimentory formats of issued certificates and their
+private key. There are currently two supported additional output formats:
+`CombinedPEM` and `DER`. Both output formats can be specified on the same
+Certificate.
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -333,11 +333,12 @@ data:
 
 #### `CombinedPEM`
 
-The `CombinedPEM` option will create a new key entry in the resulting
+The `CombinedPEM` type will create a new key entry in the resulting
 Certificate's Secret `tls-combined.pem`. This entry will contain the PEM encoded
 private key, followed by at least one new line character, followed by the PEM
 encoded signed certificate chain-
-```
+
+```text
 <private key> + "\n" + <signed certificate chain>
 ```
 
@@ -354,9 +355,8 @@ data:
 
 #### `DER`
 
-The `DER` option will create a new key entry in the resulting Certificate's
-Secret `key.der`. This entry will contain the DER binary format of the private
-key.
+The `DER` type will create a new key entry in the resulting Certificate's Secret
+`key.der`. This entry will contain the DER binary format of the private key.
 
 ```yaml
 apiVersion: v1

--- a/content/en/docs/usage/certificate.md
+++ b/content/en/docs/usage/certificate.md
@@ -301,7 +301,7 @@ removal in future releases. This feature is only enabled by adding it to the
 {{% /pageinfo %}}
 
 `additionalOutputFormats` is a field on the Certificate `spec` that allows
-specifying additional supplimentory formats of issued certificates and their
+specifying additional supplementary formats of issued certificates and their
 private key. There are currently two supported additional output formats:
 `CombinedPEM` and `DER`. Both output formats can be specified on the same
 Certificate.

--- a/content/en/docs/usage/certificate.md
+++ b/content/en/docs/usage/certificate.md
@@ -284,3 +284,87 @@ Minimum value for `spec.duration` is 1 hour and minimum value for `spec.renewBef
 It is also required that `spec.duration` > `spec.renewBefore`.
 
 Once an X.509 certificate has been issued, cert-manager will calculate the renewal time for the `Certificate`. By default this will be 2/3 through the X.509 certificate's duration. If `spec.renewBefore` has been set, it will be `spec.renewBefore` amount of time before expiry. cert-manager will set `Certificate`'s `status.RenewalTime` to the time when the renewal will be attempted.
+
+## Additional Certificate Output Formats
+
+This feature is currently in an _experimental_ alpha state, and its behavior is
+subject to change in further releases or removed entirely.
+
+{{% pageinfo color="warning" %}}
+
+⛔️ This feature is only enabled by adding it to the `--feature-gates` flag on
+the cert-manager controller and webhook components:
+
+```bash
+--feature-gates=AdditionalCertificateOutputFormats=true
+```
+
+{{% /pageinfo %}}
+
+This feature enables defining extra output formats of the Certificate in the
+target Secret resource. There are currently two supported additional output
+formats: `CombinedPEM` and `DER`. Both output formats can be specified on the
+same Certificate.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+spec:
+  ...
+  secretName: my-cert-tls
+  additionalOutputFormats:
+  - type: CombinedPEM
+  - type: DER
+
+# Results in:
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-cert-tls
+type: kubernetes.io/tls
+data:
+  ca.crt: <PEM CA certificate>
+  tls.key: <PEM private key>
+  tls.crt: <PEM signed certificate chain>
+  tls-combined.pem: <PEM private key + "\n" + PEM signed certificate chain>
+  key.der: <DER binary format of private key>
+```
+
+#### `CombinedPEM`
+
+The `CombinedPEM` option will create a new key entry in the resulting
+Certificate's Secret `tls-combined.pem`. This entry will contain the PEM encoded
+private key, followed by at least one new line character, followed by the PEM
+encoded signed certificate chain-
+```
+<private key> + "\n" + <signed certificate chain>
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-cert-tls
+type: kubernetes.io/tls
+data:
+  tls-combined.pem: <PEM private key + "\n" + PEM signed certificate chain>
+  ...
+```
+
+#### `DER`
+
+The `DER` option will create a new key entry in the resulting Certificate's
+Secret `key.der`. This entry will contain the DER binary format of the private
+key.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-cert-tls
+type: kubernetes.io/tls
+data:
+  key.der: <DER binary format of private key>
+  ...
+```


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

Adds a section to Usage/Certificates for the Additional Output Formats feature.

See: https://github.com/jetstack/cert-manager/pull/4598