### PR TITLE
Secret needs to be in cert-manager namespace

### DIFF
--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -26,6 +26,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloudflare-api-token-secret
+  namespace: cert-manager
 type: Opaque
 stringData:
   api-token: <API Token>
@@ -61,6 +62,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloudflare-api-key-secret
+  namespace: cert-manager
 type: Opaque
 stringData:
   api-key: <API Key>

--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -26,7 +26,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloudflare-api-token-secret
-  namespace: cert-manager
+  namespace:  cert-manager
 type: Opaque
 stringData:
   api-token: <API Token>

--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -26,7 +26,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloudflare-api-token-secret
-  namespace:  cert-manager
+  namespace: cert-manager
 type: Opaque
 stringData:
   api-token: <API Token>


### PR DESCRIPTION
To be able to use the secret, it must be in the _cert-manager_ namespace, if not you will get an error saying that the secret can not be found.