### PR TITLE
Fix inconsistency within yaml examples

### DIFF
--- a/content/en/docs/configuration/acme/dns01/cloudflare.md
+++ b/content/en/docs/configuration/acme/dns01/cloudflare.md
@@ -47,7 +47,7 @@ spec:
           email: my-cloudflare-acc@example.com
           apiTokenSecretRef:
             name: cloudflare-api-token-secret
-            key: api-token
+            key: api-key
 ```
 
 ## API Keys


### PR DESCRIPTION
The Cloudflare examples, documents uses `api-key` and `api-token` if some one was to follow this, it would end in a none working example, This PR resolves this issue.