### PR TITLE
Use v1.6.2 in the installation documentation for 1.6 

### DIFF
--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -15,7 +15,7 @@ install methods are listed below for each of the situations.
 
 The default static configuration can be installed as follows:
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.2/cert-manager.yaml
 ```
 More information on this install method [can be found here](./kubectl/).
 

--- a/content/en/docs/installation/helm.md
+++ b/content/en/docs/installation/helm.md
@@ -46,7 +46,7 @@ or using the `installCRDs` option when installing the Helm chart.
 
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.2/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -67,7 +67,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.6.1 \
+  --version v1.6.2 \
   # --set installCRDs=true
 ```
 
@@ -80,7 +80,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.6.1 \
+  --version v1.6.2 \
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
 ```
@@ -97,7 +97,7 @@ $ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.6.1 \
+  --version v1.6.2 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/en/docs/installation/kubectl.md
+++ b/content/en/docs/installation/kubectl.md
@@ -21,7 +21,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.2/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/en/docs/usage/cmctl.md
+++ b/content/en/docs/usage/cmctl.md
@@ -23,7 +23,7 @@ Run the following commands to set up the CLI. Replace OS and ARCH with your
 systems equivalents:
 
 ```console
-OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -L -o cmctl.tar.gz https://github.com/jetstack/cert-manager/releases/latest/download/cmctl-$OS-$ARCH.tar.gz
+OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -L -o cmctl.tar.gz https://github.com/jetstack/cert-manager/releases/download/v1.6.2/cmctl-$OS-$ARCH.tar.gz
 tar xzf cmctl.tar.gz
 sudo mv cmctl /usr/local/bin
 ```

--- a/content/en/docs/usage/kubectl-plugin.md
+++ b/content/en/docs/usage/kubectl-plugin.md
@@ -19,13 +19,13 @@ In order to use the kubectl plugin you need its binary to be accessible under th
 ### macOS/Linux
 Run the following commands to set up the plugin:
 ```console
-$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/latest/download/kubectl-cert_manager-linux-amd64.tar.gz
+$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/download/v1.6.2/kubectl-cert_manager-linux-amd64.tar.gz
 $ tar xzf kubectl-cert-manager.tar.gz
 $ sudo mv kubectl-cert_manager /usr/local/bin
 ```
 
 ### Windows
-1. Download the [latest version](https://github.com/jetstack/cert-manager/releases/latest/download/kubectl-cert_manager-windows-amd64.tar.gz).
+1. Download the [latest version](https://github.com/jetstack/cert-manager/releases/download/v1.6.2/kubectl-cert_manager-windows-amd64.tar.gz).
 2. Extract the archive.
 3. Add the `.exe` file extension to the extracted `kubectl-cert_manager`.
 4. Copy `kubectl-cert_manager.exe` to a location which is also in your `PATH`.


### PR DESCRIPTION
Merging this into the release-1.6 branch will ensure that the 1.6 installation docs are up to date:
 * https://cert-manager.io/v1.6-docs/installation/

