### PR TITLE
Use v1.5.5 in the installation documentation for 1.5

### DIFF
--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -15,7 +15,7 @@ install methods are listed below for each of the situations.
 
 The default static configuration can be installed as follows:
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.yaml
 ```
 More information on this install method [can be found here](./kubectl/).
 

--- a/content/en/docs/installation/helm.md
+++ b/content/en/docs/installation/helm.md
@@ -46,7 +46,7 @@ or using the `installCRDs` option when installing the Helm chart.
 
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -67,7 +67,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.5.4 \
+  --version v1.5.5 \
   # --set installCRDs=true
 ```
 
@@ -80,7 +80,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.5.4 \
+  --version v1.5.5 \
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the wehbook timeout using a Helm parameter
 ```
@@ -97,7 +97,7 @@ $ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.5.4 \
+  --version v1.5.5 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/en/docs/installation/kubectl.md
+++ b/content/en/docs/installation/kubectl.md
@@ -21,7 +21,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/en/docs/installation/operator-lifecycle-manager.md
+++ b/content/en/docs/installation/operator-lifecycle-manager.md
@@ -69,7 +69,7 @@ spec:
   name: cert-manager
 ...
 status:
-  currentCSV: cert-manager.v1.5.4
+  currentCSV: cert-manager.v1.5.5
   state: AtLatestKnown
 ...
 ```

--- a/content/en/docs/usage/kubectl-plugin.md
+++ b/content/en/docs/usage/kubectl-plugin.md
@@ -12,7 +12,7 @@ You need the `kubectl-cert-manager.tar.gz` file for the platform you're using, t
 In order to use the kubectl plugin you need its binary to be accessible under the name `kubectl-cert_manager` in your `$PATH`.
 Run the following commands to set up the plugin:
 ```console
-$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/latest/download/kubectl-cert_manager-linux-amd64.tar.gz
+$ curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/download/v1.5.5/kubectl-cert_manager-linux-amd64.tar.gz
 $ tar xzf kubectl-cert-manager.tar.gz
 $ sudo mv kubectl-cert_manager /usr/local/bin
 ```
@@ -68,7 +68,7 @@ Use "kubectl cert-manager [command] --help" for more information about a command
 > **Note**: for cert-manager `v0.15` this feature requires the `ExperimentalCertificateControllers` feature gate set.
 > From cert-manager `v0.16` onward, the experimental certificate controller is the default.
 
-`kubectl cert-manager renew` allows you to manually trigger a renewal of a specific certificate. 
+`kubectl cert-manager renew` allows you to manually trigger a renewal of a specific certificate.
 This can be done either one certificate at a time, using label selectors (`-l app=example`), or with the `--all` flag:
 
 For example you can renew the certificate `example-com-tls`:
@@ -99,7 +99,7 @@ as well as `kubectl` global flags like `--context` and `--namespace`.
 ### Convert
 `kubectl cert-manager convert` can be used to convert cert-manager manifest files between different API versions. Both YAML and JSON formats are accepted.
 The command takes file name, directory, or URL as input, and converts into the
-format of the latest version or the one specified by --output-version flag. 
+format of the latest version or the one specified by --output-version flag.
 
 The default output will be printed to stdout in YAML format. One can use -o option to change the output destination.
 
@@ -113,8 +113,8 @@ kubectl cert-manager convert -f cert.yaml
 to create different resources:
 
 #### CertificateRequest
-To create a cert-manager CertificateRequest, use `kubectl cert-manager create certificaterequest`. The command takes in the name of the CertificateRequest to be created, 
-and creates a new CertificateRequest resource based on the YAML manifest of a Certificate resource as specified by `--from-certificate-file` flag, by generating a private key locally and creating a 'certificate signing request' 
+To create a cert-manager CertificateRequest, use `kubectl cert-manager create certificaterequest`. The command takes in the name of the CertificateRequest to be created,
+and creates a new CertificateRequest resource based on the YAML manifest of a Certificate resource as specified by `--from-certificate-file` flag, by generating a private key locally and creating a 'certificate signing request'
 to be submitted to a cert-manager Issuer. The private key will be written to a local file, where the default is `<name_of_cr>.key`, or it can be specified using the `--output-key-file` flag.
 
 If you wish to wait for the CertificateRequest to be signed and store the X.509 certificate in a file, you can set


### PR DESCRIPTION
To ensure that people visiting https://cert-manager.io/v1.5-docs/installation/ get the latest patch release.