### PR TITLE
Add the missing entries to the release notes 1.5 and 1.6

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -338,6 +338,12 @@ v0.23.1
 v1
 v1.16
 v1.19
+v1.5
+v1.5.0
+v1.5.0.
+v1.5.1
+v1.5.1.
+v1.5.2
 v1.5.3
 v1.5.4
 v1.5.5
@@ -363,7 +369,14 @@ wildcard
 wildcards
 wpjunior
 yann-soubeyrand
+mfmbarros
+maelvls
+bitscuit
 zsh
+PodSecurityPolicy
+ClusterIP
+NodePort
+pprof
 
 # As per https://tools.ietf.org/html/rfc5280, the spelling "X.509" is the
 # correct spelling. The spelling "x509" and "X509" are incorrect.

--- a/content/en/docs/release-notes/release-notes-1.5.md
+++ b/content/en/docs/release-notes/release-notes-1.5.md
@@ -35,7 +35,7 @@ type: "docs"
 
 - Fix a regression introduced in v1.5.0 where the Ingress created for solving HTTP-01 challenges was created with `pathType: Exact` instead of `pathType: ImplementationSpecific`. ([#4385](https://github.com/jetstack/cert-manager/pull/4385), [@jakexks](https://github.com/jakexks))
 - Fixed the HTTP-01 solver creating ClusterIP instead of NodePort services by default. ([#4394](https://github.com/jetstack/cert-manager/pull/4394), [@jakexks](https://github.com/jakexks))
-- Removes status fields from CRD configs ([#4387](https://github.com/jetstack/cert-manager/pull/4387), [@irbekrm](https://github.com/irbekrm))
+- Helm chart and static manifest: the pointless `status` field is now stripped from the CRD manifests. ([#4387](https://github.com/jetstack/cert-manager/pull/4387), [@irbekrm](https://github.com/irbekrm))
 
 ## v1.5.1
 

--- a/content/en/docs/release-notes/release-notes-1.5.md
+++ b/content/en/docs/release-notes/release-notes-1.5.md
@@ -12,7 +12,7 @@ type: "docs"
 #### Bug or Regression
 
 - Fixed a bug that caused cert-manager to panic when the Vault Issuer failed to reach the health endpoint. ([#4476](https://github.com/jetstack/cert-manager/pull/4476), [@JoshVanL](https://github.com/JoshVanL))
-- Helm chart: the post-install hook `startupapicheck` is now compatible with PodSecurityPolicy. ([#4432](https://github.com/jetstack/cert-manager/pull/4432), [@ndegory](https://github.com/ndegory))
+- Helm chart: the post-install hook `startupapicheck` is now compatible with the PodSecurityPolicy resource. ([#4432](https://github.com/jetstack/cert-manager/pull/4432), [@ndegory](https://github.com/ndegory))
 - Helm chart: the post-install hook `startupapicheck` now deletes any post-install hook resources left after a previous failed install allowing `helm install` to be re-run after a failed attempt. ([#4435](https://github.com/jetstack/cert-manager/pull/4435), [@wallrj](https://github.com/wallrj))
 
 #### Other (Cleanup or Flake)
@@ -25,7 +25,7 @@ type: "docs"
 
 #### Bug or Regression
 
-- Fix a bug where a Certificate may not get renewed when the issued Certificate has a one-second skew between `notBefore` and `notAfter` and `spec.duration` is not used. This one-second skew can be observed on certificates issued with Let's Encrypt and caused a mismatch in time precision between the time stored in `status.renewalTime` and the time internally computed by cert-manager. ([#4403](https://github.com/jetstack/cert-manager/pull/4403), @irbekrm). Thanks to @mfmbarros for help with debugging the issue!
+- Fix a bug where a Certificate may not get renewed when the issued Certificate has a one-second skew between `notBefore` and `notAfter` and `spec.duration` is not used. This one-second skew can be observed on certificates issued with Let's Encrypt and caused a mismatch in time precision between the time stored in `status.renewalTime` and the time internally computed by cert-manager. ([#4403](https://github.com/jetstack/cert-manager/pull/4403), [@irbekrm](https://github.com/irbekrm)). Thanks to [@mfmbarros](https://github.com/mfmbarros) for help with debugging the issue!
 
 ## v1.5.2
 
@@ -50,7 +50,7 @@ v1beta1 are all deprecated and will be removed in a future release.
 
 #### Bug or Regression
 
-- Fix `v1beta1` CRDs which were accidentally changed in cert-manager v1.5.0 ([#4355](https://github.com/jetstack/cert-manager/pull/4355), [@jetstack-bot](https://github.com/jetstack-bot))
+- Fix `v1beta1` CRDs which were accidentally changed in cert-manager v1.5.0 ([#4355](https://github.com/jetstack/cert-manager/pull/4355), [@SgtCoDFish](https://github.com/SgtCoDFish))
 
 ## v1.5.0
 

--- a/content/en/docs/release-notes/release-notes-1.5.md
+++ b/content/en/docs/release-notes/release-notes-1.5.md
@@ -1,15 +1,62 @@
 ---
-title: "Release Notes"
+title: "Release 1.5"
 linkTitle: "v1.5"
 weight: 780
 type: "docs"
 ---
 
-# Release `v1.5.0`
+## v1.5.4
 
-## Major Themes
+### Changelog since v1.5.3
 
-### API Deprecation
+#### Bug or Regression
+
+- Fixed a bug that caused cert-manager to panic when the Vault Issuer failed to reach the health endpoint. ([#4476](https://github.com/jetstack/cert-manager/pull/4476), [@JoshVanL](https://github.com/JoshVanL))
+- Helm chart: the post-install hook `startupapicheck` is now compatible with PodSecurityPolicy. ([#4432](https://github.com/jetstack/cert-manager/pull/4432), [@ndegory](https://github.com/ndegory))
+- Helm chart: the post-install hook `startupapicheck` now deletes any post-install hook resources left after a previous failed install allowing `helm install` to be re-run after a failed attempt. ([#4435](https://github.com/jetstack/cert-manager/pull/4435), [@wallrj](https://github.com/wallrj))
+
+#### Other (Cleanup or Flake)
+
+- Update cert-manager base image versions ([#4479](https://github.com/jetstack/cert-manager/pull/4479), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
+## v1.5.3
+
+### Changelog since v1.5.2
+
+#### Bug or Regression
+
+- Fix a bug where a Certificate may not get renewed when the issued Certificate has a one-second skew between `notBefore` and `notAfter` and `spec.duration` is not used. This one-second skew can be observed on certificates issued with Let's Encrypt and caused a mismatch in time precision between the time stored in `status.renewalTime` and the time internally computed by cert-manager. ([#4403](https://github.com/jetstack/cert-manager/pull/4403), @irbekrm). Thanks to @mfmbarros for help with debugging the issue!
+
+## v1.5.2
+
+### Changelog since v1.5.1
+
+#### Bug or Regression
+
+- Fix a regression introduced in v1.5.0 where the Ingress created for solving HTTP-01 challenges was created with `pathType: Exact` instead of `pathType: ImplementationSpecific`. ([#4385](https://github.com/jetstack/cert-manager/pull/4385), [@jakexks](https://github.com/jakexks))
+- Fixed the HTTP-01 solver creating ClusterIP instead of NodePort services by default. ([#4394](https://github.com/jetstack/cert-manager/pull/4394), [@jakexks](https://github.com/jakexks))
+- Removes status fields from CRD configs ([#4387](https://github.com/jetstack/cert-manager/pull/4387), [@irbekrm](https://github.com/irbekrm))
+
+## v1.5.1
+
+The CRDs for the cert-manager v1beta1 API were mistakenly changed in cert-manager v1.5.0. If you
+installed the CRDs for v1.5.0, you should upgrade your CRDs to v1.5.1.
+
+The only affected API version is v1beta1, so if you're using the latest version - v1 - you won't
+be affected by the CRD changes. It's worth upgrading to v1 in any case, since v1alpha2, v1alpha3 and
+v1beta1 are all deprecated and will be removed in a future release.
+
+### Changelog since v1.5.0
+
+#### Bug or Regression
+
+- Fix `v1beta1` CRDs which were accidentally changed in cert-manager v1.5.0 ([#4355](https://github.com/jetstack/cert-manager/pull/4355), [@jetstack-bot](https://github.com/jetstack-bot))
+
+## v1.5.0
+
+### Major Themes
+
+#### API Deprecation
 
 The recent Kubernetes 1.22 release has removed a number of deprecated APIs. You
 can read the official blog post [Kubernetes API and Feature Removals In
@@ -34,14 +81,14 @@ These deprecation changes have been implemented in the cert-manager PRs
 [#4225](https://github.com/jetstack/cert-manager/pull/4225) and
 [#4172](https://github.com/jetstack/cert-manager/pull/4172).
 
-## Experimental Features
+### Experimental Features
 
 Features that we are currently working on are included in cert-manager releases
 but disabled by default, as they are likely to change in future. If any of them
 look interesting to you, please try them out and report bugs or quirks in a
 GitHub Issue.
 
-### Gateway API
+#### Gateway API
 
 We have seen many requests from users to support different ways of routing HTTP
 traffic into their clusters for solving ACME HTTP-01 challenges. As the
@@ -67,7 +114,7 @@ Implemented in the cert-manager PRs
 [#4276](https://github.com/jetstack/cert-manager/pull/4276) and
 [#4158](https://github.com/jetstack/cert-manager/pull/4158).
 
-### CertificateSigningRequests
+#### CertificateSigningRequests
 
 CertificateSigningRequest is a built-in Kubernetes resource that was originally
 aimed at requesting X.509 client certificates and serving certificates for
@@ -112,9 +159,9 @@ The above features were implemented in the cert-manager PRs
 [#4106](https://github.com/jetstack/cert-manager/pull/4106), and
 [#4143](https://github.com/jetstack/cert-manager/pull/4143)
 
-## User Experience
+### User Experience
 
-### kubectl plugin
+#### kubectl plugin
 
 cert-manager comes with a kubectl plugin, `kubectl cert-manager`, that comes in
 handy for checking the status of your cert-manager Certificate resources.
@@ -156,7 +203,7 @@ These features were implemented by Tim in the cert-manager PRs
 [#4205](https://github.com/jetstack/cert-manager/pull/4205), and
 [#4138](https://github.com/jetstack/cert-manager/pull/4138).
 
-### Helm chart
+#### Helm chart
 
 While installing cert-manager using Helm, you might have noticed that the
 `--wait` flag does not wait until cert-manager is fully functional.
@@ -168,7 +215,7 @@ ready.
 Implemented in the cert-manager PR
 [#4234](https://github.com/jetstack/cert-manager/pull/4234) by Tim.
 
-### Labels and annotations on generated Secret and CertificateRequest resources
+#### Labels and annotations on generated Secret and CertificateRequest resources
 
 cert-manager now allows you to add custom annotations and labels to the Secret
 containing the TLS key pair using the new Certificate field `secretTemplate`.
@@ -211,7 +258,7 @@ Implemented in the cert-manager PRs
 [#3828](https://github.com/jetstack/cert-manager/pull/3828) and
 [#4251](https://github.com/jetstack/cert-manager/pull/4251).
 
-## Community
+### Community
 
 This is the first time that cert-manager participated in Google Summer of Code.
 Congratulations to [Arsh](https://github.com/RinkiyaKeDad) and
@@ -242,7 +289,7 @@ out on the Slack `#cert-manager` channel; it's a huge help and much appreciated.
 
 ---
 
-### New Features
+#### New Features
 
 - cert-manager now supports using Ed25519 private keys and signatures for
   Certificates. Implemented in the cert-manager PR
@@ -276,7 +323,7 @@ out on the Slack `#cert-manager` channel; it's a huge help and much appreciated.
   service using the Helm value `webhook.serviceLabels`. Implemented in the
   cert-manager PR [#4260](https://github.com/jetstack/cert-manager/pull/4260).
 
-### Bug or Regression
+#### Bug or Regression
 
 - Security: cert-manager now times out after 10 second when performing the
   self-check while solving HTTP-01 challenges. Fixed in the cert-manager PR
@@ -319,7 +366,7 @@ out on the Slack `#cert-manager` channel; it's a huge help and much appreciated.
   Helm-specific labels from the static manifests. Fixed in the cert-manager PR
   [#4190](https://github.com/jetstack/cert-manager/pull/4190).
 
-### Other (Cleanup or Flake)
+#### Other (Cleanup or Flake)
 
 - A conformance end-to-end testing suite was added for the
   CertificateSigningRequest resources

--- a/content/en/docs/release-notes/release-notes-1.6.md
+++ b/content/en/docs/release-notes/release-notes-1.6.md
@@ -134,11 +134,11 @@ and can now be compiled on Apple Silicon ([#4485](https://github.com/jetstack/ce
 
 - Fix a bug in the Vault client that led to a panic after a request to Vault health endpoint failed. ([#4456](https://github.com/jetstack/cert-manager/pull/4456), [@JoshVanL](https://github.com/JoshVanL))
 - Fix CRDs which were accidentally changed in cert-manager `v1.5.0` ([#4353](https://github.com/jetstack/cert-manager/pull/4353), [@SgtCoDFish](https://github.com/SgtCoDFish))
-- Fix regression in Ingress `PathType` introduced in `v1.5.0` ([#4373](https://github.com/jetstack/cert-manager/pull/4373), [@jakexks](https://github.com/jakexks))
+- Fix a regression in Ingress `PathType` introduced in `v1.5.0` ([#4373](https://github.com/jetstack/cert-manager/pull/4373), [@jakexks](https://github.com/jakexks))
 - Fixed the HTTP-01 solver creating `ClusterIP` instead of `NodePort` services by default. ([#4393](https://github.com/jetstack/cert-manager/pull/4393), [@jakexks](https://github.com/jakexks))
-- Fixes renewal time issue for certs with skewed duration period. ([#4399](https://github.com/jetstack/cert-manager/pull/4399), [@irbekrm](https://github.com/irbekrm))
-- Pod Security Policy for startup API check job ([#4364](https://github.com/jetstack/cert-manager/pull/4364), [@ndegory](https://github.com/ndegory))
-- The `startupapicheck` post-install hook in the Helm chart now deletes any post-install hook resources left after a previous failed install allowing helm install to be re-run after a previous failure. ([#4433](https://github.com/jetstack/cert-manager/pull/4433), [@wallrj](https://github.com/wallrj))
+- Fix a bug where a Certificate may not get renewed when the issued Certificate has a one-second skew between `notBefore` and `notAfter` and `spec.duration` is not used. This one-second skew can be observed on certificates issued with Let's Encrypt and caused a mismatch in time precision between the time stored in `status.renewalTime` and the time internally computed by cert-manager. ([#4399](https://github.com/jetstack/cert-manager/pull/4399), [@irbekrm](https://github.com/irbekrm))
+- Helm chart: the post-install hook `startupapicheck` is now compatible with PodSecurityPolicy. ([#4364](https://github.com/jetstack/cert-manager/pull/4364), [@ndegory](https://github.com/ndegory))
+- Helm chart: the post-install hook `startupapicheck` now deletes any post-install hook resources left after a previous failed install allowing `helm install` to be re-run after a failed attempt. ([#4433](https://github.com/jetstack/cert-manager/pull/4433), [@wallrj](https://github.com/wallrj))
 - The defaults for leader election parameters are now consistent across cert-manager and cainjector. ([#4359](https://github.com/jetstack/cert-manager/pull/4359), [@johanfleury](https://github.com/johanfleury))
 - Use `GetAuthorization` instead of `GetChallenge` when querying the current state of an ACME challenge. ([#4430](https://github.com/jetstack/cert-manager/pull/4430), [@JoshVanL](https://github.com/JoshVanL))
 

--- a/content/en/docs/release-notes/release-notes-1.6.md
+++ b/content/en/docs/release-notes/release-notes-1.6.md
@@ -150,6 +150,6 @@ and can now be compiled on Apple Silicon ([#4485](https://github.com/jetstack/ce
 - Fix manually specified `PKCS#10` CSR and X.509 Certificate version numbers (although these were ignored in practice) ([#4392](https://github.com/jetstack/cert-manager/pull/4392), [@SgtCoDFish](https://github.com/SgtCoDFish))
 - Improves logging for 'owner not found' errors for `CertificateRequest`s owning `Order`s. ([#4369](https://github.com/jetstack/cert-manager/pull/4369), [@irbekrm](https://github.com/irbekrm))
 - Refactor: move from `io/ioutil` to `io` and `os` package ([#4402](https://github.com/jetstack/cert-manager/pull/4402), [@Juneezee](https://github.com/Juneezee))
-- Removes status fields from CRD manifests ([#4379](https://github.com/jetstack/cert-manager/pull/4379), [@irbekrm](https://github.com/irbekrm))
+- Helm chart and static manifest: the pointless `status` field is now stripped from the CRD manifests. ([#4379](https://github.com/jetstack/cert-manager/pull/4379), [@irbekrm](https://github.com/irbekrm))
 - Update cert-manager base image versions ([#4474](https://github.com/jetstack/cert-manager/pull/4474), [@SgtCoDFish](https://github.com/SgtCoDFish))
-- Uses Go 1.17 ([#4478](https://github.com/jetstack/cert-manager/pull/4478), [@irbekrm](https://github.com/irbekrm))
+- cert-manager now uses Go 1.17. ([#4478](https://github.com/jetstack/cert-manager/pull/4478), [@irbekrm](https://github.com/irbekrm))

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -46,7 +46,7 @@ This broke many users that either don't use an Ingress controller that supports 
 
 The regression is present in cert-manager v1.5.4, 1.6.0, and 1.6.1. It is only present on Kubernetes 1.19+ and only appears when using an Issuer or ClusterIssuer with an ACME HTTP-01 solver configured.
 
-In 1.7, we have restored the original behavior which is to use the annotation. We will also backport this fix to 1.5.5 and 1.6.2, allowing people to upgrade safely.
+In 1.7, we have restored the original behavior which is to use the annotation. We also backported this fix to 1.5.5 and 1.6.2, allowing people to upgrade safely.
 
 Most people won't have any trouble upgrading from a version that contains the regression to 1.7.0, 1.6.2 or 1.5.5. If you are using Gloo, Contour, Skipper, or kube-ingress-aws-controller, you shouldn't have any issues. If you use the default "class" (e.g., `istio` for Istio) for Traefik, Istio, Ambassador, or ingress-nginx, then these should also continue to work without issue.
 

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -7,6 +7,8 @@ type: "docs"
 
 ## v1.7.0
 
+{{< youtube id="XcAD8Xlj-NE?t=2171s" >}}
+
 ### Breaking Changes (You **MUST** read this before you upgrade!)
 
 #### Removal of Deprecated APIs
@@ -142,7 +144,7 @@ out on the [`#cert-manager` Slack channel]; it's a huge help and much appreciate
 - Added `additionalOutputFormats` parameter to allow `DER` (binary) and `CombinedPEM` (key + cert bundle) formats. ([#4598](https://github.com/jetstack/cert-manager/pull/4598), [@seuf](https://github.com/seuf))
 - Added a makefile based build workflow which doesn't depend on bazel ([#4554](https://github.com/jetstack/cert-manager/pull/4554), [@SgtCoDFish](https://github.com/SgtCoDFish))
 - Added a new Helm chart parameter `prometheus.servicemonitor.honorLabels`, which sets the `honor_labels` field  of the Prometheus scrape config. ([#4608](https://github.com/jetstack/cert-manager/pull/4608), [@thirdeyenick](https://github.com/thirdeyenick))
-- Breaking change: pprof now runs by default on `localhost:6060` on the webhook and the controller, but only if explicitly enabled. Pprof can now be enabled also for cainjector. All three components have `--enable-profiling`, `--profiler-address` CLI flags to configure profiling. Thanks to @bitscuit for help with this! ([#4550](https://github.com/cert-manager/cert-manager/pull/4550), [@irbekrm](https://github.com/irbekrm))
+- Breaking change: pprof now runs by default on `localhost:6060` on the webhook and the controller, but only if explicitly enabled. Pprof can now be enabled also for cainjector. All three components have `--enable-profiling`, `--profiler-address` CLI flags to configure profiling. Thanks to [@bitscuit](https://github.com/bitscuit) for help with this! ([#4550](https://github.com/cert-manager/cert-manager/pull/4550), [@irbekrm](https://github.com/irbekrm))
 - Certificate Secrets are now managed by the APPLY API call, rather than UPDATE/CREATE. The issuing controller actively reconciles Certificate SecretTemplate's against corresponding Secrets, garbage collecting and correcting key/value changes. ([#4638](https://github.com/jetstack/cert-manager/pull/4638), [@JoshVanL](https://github.com/JoshVanL))
 
 #### Bug or Regression

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -129,9 +129,7 @@ out on the [`#cert-manager` Slack channel]; it's a huge help and much appreciate
 
 [`#cert-manager` Slack channel]: ../../contributing/#slack
 
-# Changelog since v1.6.1
-
-## Changes by Kind
+## Changelog since v1.6.0
 
 ### Feature
 

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -140,6 +140,7 @@ out on the [`#cert-manager` Slack channel]; it's a huge help and much appreciate
 - Added `additionalOutputFormats` parameter to allow `DER` (binary) and `CombinedPEM` (key + cert bundle) formats. ([#4598](https://github.com/jetstack/cert-manager/pull/4598), [@seuf](https://github.com/seuf))
 - Added a makefile based build workflow which doesn't depend on bazel ([#4554](https://github.com/jetstack/cert-manager/pull/4554), [@SgtCoDFish](https://github.com/SgtCoDFish))
 - Added a new Helm chart parameter `prometheus.servicemonitor.honorLabels`, which sets the `honor_labels` field  of the Prometheus scrape config. ([#4608](https://github.com/jetstack/cert-manager/pull/4608), [@thirdeyenick](https://github.com/thirdeyenick))
+- Breaking change: pprof now runs by default on `localhost:6060` on the webhook and the controller, but only if explicitly enabled. Pprof can now be enabled also for cainjector. All three components have `--enable-profiling`, `--profiler-address` CLI flags to configure profiling. Thanks to @bitscuit for help with this! ([#4550](https://github.com/cert-manager/cert-manager/pull/4550), [@irbekrm](https://github.com/irbekrm))
 - Certificate Secrets are now managed by the APPLY API call, rather than UPDATE/CREATE. The issuing controller actively reconciles Certificate SecretTemplate's against corresponding Secrets, garbage collecting and correcting key/value changes. ([#4638](https://github.com/jetstack/cert-manager/pull/4638), [@JoshVanL](https://github.com/JoshVanL))
 
 ### Bug or Regression
@@ -148,15 +149,18 @@ out on the [`#cert-manager` Slack channel]; it's a huge help and much appreciate
 - Fix unexpected exit when multiple DNS providers are passed to `RunWebhookServer` ([#4702](https://github.com/jetstack/cert-manager/pull/4702), [@devholic](https://github.com/devholic))
 - Fixed a bug that can cause `cmctl version` to erroneously display the wrong webhook pod versions when older failed pods are present. ([#4615](https://github.com/jetstack/cert-manager/pull/4615), [@johnwchadwick](https://github.com/johnwchadwick))
 - Fixes a bug where a previous failed CertificateRequest was picked up during the next issuance. Thanks to @MattiasGees for raising the issue and help with debugging! ([#4688](https://github.com/jetstack/cert-manager/pull/4688), [@irbekrm](https://github.com/irbekrm))
+- Fixes an issue in `cmctl` that prevented displaying the Order resource with cert-manager 1.6 when running `cmctl status certificate`. ([#4569](https://github.com/cert-manager/cert-manager/pull/4569), [@maelvls](https://github.com/maelvls))
 - Improve checksum validation in makefile based tool installation ([#4680](https://github.com/jetstack/cert-manager/pull/4680), [@SgtCoDFish](https://github.com/SgtCoDFish))
 - The HTTP-01 ACME solver now uses the `kubernetes.io/ingress.class` annotation instead of the `spec.ingressClassName` in created Ingress resources. ([#4762](https://github.com/jetstack/cert-manager/pull/4762), [@jakexks](https://github.com/jakexks))
 - The `cmctl experimental install` command now uses the cert-manager namespace. This fixes a bug which was introduced in release 1.6 that caused cert-manager to be installed in the default namespace. ([#4763](https://github.com/jetstack/cert-manager/pull/4763), [@wallrj](https://github.com/wallrj))
 - Fixed a bug in the way the Helm chart handles service annotations on the controller and webhook services. ([#4329](https://github.com/jetstack/cert-manager/pull/4329), [@jwenz723](https://github.com/jwenz723))
+- Update to latest version of keystore-go to address a backwards incompatible change introduced in v1.6.0 ([#4563](https://github.com/cert-manager/cert-manager/pull/4563), [@SgtCoDFish](https://github.com/SgtCoDFish))
 
 ### Other (Cleanup or Flake)
 
 - Adds `clock_time_seconds_gauge` metric which returns the current clock time, based on seconds since 1970/01/01 UTC ([#4640](https://github.com/jetstack/cert-manager/pull/4640), [@JoshVanL](https://github.com/JoshVanL))
 - Adds an automated script for cert-manager developers to update versions of kind used for development and testing. ([#4574](https://github.com/jetstack/cert-manager/pull/4574), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Breaking change: removes the deprecated `dns01-self-check-nameservers` flag. Use `--dns01-recursive-nameservers` instead. ([#4551](https://github.com/cert-manager/cert-manager/pull/4551), [@irbekrm](https://github.com/irbekrm))
 - Bump kind image versions ([#4593](https://github.com/jetstack/cert-manager/pull/4593), [@SgtCoDFish](https://github.com/SgtCoDFish))
 - Clean up: Remove `v1beta1` form the webhook's `admissionReviewVersions` as cert-manager no longer supports v1.16 ([#4639](https://github.com/jetstack/cert-manager/pull/4639), [@JoshVanL](https://github.com/JoshVanL))
 - Cleanup: Pipe feature gate flag to the e2e binary. Test against shared Feature Gate map for feature enabled and whether they should be tested against. ([#4703](https://github.com/jetstack/cert-manager/pull/4703), [@JoshVanL](https://github.com/JoshVanL))

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -44,8 +44,7 @@ spec:
 
 This broke many users that either don't use an Ingress controller that supports the field (such as ingress-gce and Azure AGIC), as well as people who did not need to create an IngressClass previously (such as with Istio and Traefik).
 
-The regression is present in cert-manager 1.5.4, 1.6.0, and 1.6.1.
-It is only present on Kubernetes 1.19+ and only appears when using an Issuer or ClusterIssuer with an ACME HTTP-01 solver configured.
+The regression is present in cert-manager v1.5.4, 1.6.0, and 1.6.1. It is only present on Kubernetes 1.19+ and only appears when using an Issuer or ClusterIssuer with an ACME HTTP-01 solver configured.
 
 In 1.7, we have restored the original behavior which is to use the annotation. We will also backport this fix to 1.5.5 and 1.6.2, allowing people to upgrade safely.
 

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -5,9 +5,11 @@ weight: 760
 type: "docs"
 ---
 
-## Breaking Changes (You **MUST** read this before you upgrade!)
+## v1.7.0
 
-### Removal of Deprecated APIs
+### Breaking Changes (You **MUST** read this before you upgrade!)
+
+#### Removal of Deprecated APIs
 
 ⚠ Following their deprecation in version 1.5, the cert-manager API versions v1alpha2, v1alpha3, and v1beta1 have been removed.
 You must ensure that all cert-manager custom resources are stored in etcd at version v1
@@ -21,7 +23,7 @@ for full instructions.
 [download `cmctl-v1.7.0`]: https://github.com/jetstack/cert-manager/releases/tag/v1.7.0
 [Migrating Deprecated API Resources]: https://cert-manager.io/docs/installation/upgrading/remove-deprecated-apis/
 
-### Ingress Class Semantics
+#### Ingress Class Semantics
 
 In 1.7, we have reverted a change that caused a regression in the ACME Issuer.
 Before v1.5.4, the Ingress created by cert-manager while solving an HTTP-01 challenge contained the `kubernetes.io/ingress.class` annotation:
@@ -54,9 +56,9 @@ If you are using Traefik, Istio, Ambassador, or ingress-nginx _and_ you are usin
 
 [notes on Ingress v1 compatibility]: https://cert-manager.io/docs/installation/upgrading/ingress-class-compatibility/
 
-## Major Themes
+### Major Themes
 
-### Removal of Deprecated APIs
+#### Removal of Deprecated APIs
 
 In 1.7 the cert-manager API versions v1alpha2, v1alpha3, and v1beta1, that were deprecated in 1.5,
 have been removed from the custom resource definitions (CRDs).
@@ -66,7 +68,7 @@ In this release we have added a new sub-command to the cert-manager CLI (`cmctl 
 which you SHOULD run BEFORE upgrading cert-manager to 1.7.
 Please read [Removing Deprecated API Resources] for full instructions.
 
-### Additional Certificate Output Formats
+#### Additional Certificate Output Formats
 
 `additionalOutputFormats` is a field on the Certificate `spec` that allows
 specifying additional supplementary formats of issued certificates and their
@@ -79,7 +81,7 @@ thanks to [@seuf](https://github.com/seuf) for getting this across the line!
 
 [Additional Certificate Output Formats]: ../../usage/certificate/#additional-certificate-output-formats
 
-### Server-Side Apply
+#### Server-Side Apply
 
 This is the first version of cert-manager which relies on [Server-Side Apply].
 We use it to properly manage the annotations and labels on TLS secrets.
@@ -88,7 +90,7 @@ For this reason cert-manager 1.7 requires at least Kubernetes 1.18 (see
 
 [Server-Side Apply]: https://kubernetes.io/docs/reference/using-api/server-side-apply/
 
-### Configuration Files
+#### Configuration Files
 
 In this release we introduce a new configuration file for the cert-manager-webhook.
 Instead of configuring the webhook using command line flags,
@@ -101,7 +103,7 @@ the controller and the cainjector.
 
 [WebhookConfiguration Schema]: https://cert-manager.io/next-docs/reference/api-docs/#webhook.config.cert-manager.io/v1alpha1.WebhookConfiguration
 
-### Developing cert-manager Without Bazel
+#### Developing cert-manager Without Bazel
 
 In a future release, we'll remove the use of `bazel` for building and testing cert-manager,
 with the aim of making it as easy as possible for anyone to contribute and to get involved
@@ -112,7 +114,7 @@ and that all unit tests can be run with `go test ./cmd/... ./internal/... ./pkg/
 
 [Bazel -> Make Migration Tracker]: https://github.com/jetstack/cert-manager/issues/4712
 
-## Community
+### Community
 
 Thanks again to all open-source contributors with commits in this release, including:
 
@@ -129,9 +131,9 @@ out on the [`#cert-manager` Slack channel]; it's a huge help and much appreciate
 
 [`#cert-manager` Slack channel]: ../../contributing/#slack
 
-## Changelog since v1.6.0
+### Changelog since v1.6.0
 
-### Feature
+#### Feature
 
 - Add `--acme-http01-solver-nameservers` flag to enable custom nameservers usage for ACME HTT01 challenges propagation checks. ([#4287](https://github.com/jetstack/cert-manager/pull/4287), [@Adphi](https://github.com/Adphi))
 - Add `cmctl upgrade migrate-api-version` to ensure all CRD resources are stored at 'v1' prior to upgrading to v1.7 onwards ([#4711](https://github.com/jetstack/cert-manager/pull/4711), [@munnerz](https://github.com/munnerz))
@@ -143,7 +145,7 @@ out on the [`#cert-manager` Slack channel]; it's a huge help and much appreciate
 - Breaking change: pprof now runs by default on `localhost:6060` on the webhook and the controller, but only if explicitly enabled. Pprof can now be enabled also for cainjector. All three components have `--enable-profiling`, `--profiler-address` CLI flags to configure profiling. Thanks to @bitscuit for help with this! ([#4550](https://github.com/cert-manager/cert-manager/pull/4550), [@irbekrm](https://github.com/irbekrm))
 - Certificate Secrets are now managed by the APPLY API call, rather than UPDATE/CREATE. The issuing controller actively reconciles Certificate SecretTemplate's against corresponding Secrets, garbage collecting and correcting key/value changes. ([#4638](https://github.com/jetstack/cert-manager/pull/4638), [@JoshVanL](https://github.com/JoshVanL))
 
-### Bug or Regression
+#### Bug or Regression
 
 - Ensures 1 hour backoff between errored calls for new ACME Orders. ([#4616](https://github.com/jetstack/cert-manager/pull/4616), [@irbekrm](https://github.com/irbekrm))
 - Fix unexpected exit when multiple DNS providers are passed to `RunWebhookServer` ([#4702](https://github.com/jetstack/cert-manager/pull/4702), [@devholic](https://github.com/devholic))
@@ -156,7 +158,7 @@ out on the [`#cert-manager` Slack channel]; it's a huge help and much appreciate
 - Fixed a bug in the way the Helm chart handles service annotations on the controller and webhook services. ([#4329](https://github.com/jetstack/cert-manager/pull/4329), [@jwenz723](https://github.com/jwenz723))
 - Update to latest version of keystore-go to address a backwards incompatible change introduced in v1.6.0 ([#4563](https://github.com/cert-manager/cert-manager/pull/4563), [@SgtCoDFish](https://github.com/SgtCoDFish))
 
-### Other (Cleanup or Flake)
+#### Other (Cleanup or Flake)
 
 - Adds `clock_time_seconds_gauge` metric which returns the current clock time, based on seconds since 1970/01/01 UTC ([#4640](https://github.com/jetstack/cert-manager/pull/4640), [@JoshVanL](https://github.com/JoshVanL))
 - Adds an automated script for cert-manager developers to update versions of kind used for development and testing. ([#4574](https://github.com/jetstack/cert-manager/pull/4574), [@SgtCoDFish](https://github.com/SgtCoDFish))

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -7,8 +7,6 @@ type: "docs"
 
 ## v1.7.0
 
-{{< youtube id="XcAD8Xlj-NE?t=2171s" >}}
-
 ### Breaking Changes (You **MUST** read this before you upgrade!)
 
 #### Removal of Deprecated APIs


### PR DESCRIPTION
- I had to use `##` (section level 2) instead of `#` (section level 1) because the section level 1 is meant for titles and does not show in the table of contents.
- I reviewed all the change log entries and rephrased the ones that I could not understand. I also updated the `release-note` block for those PRs.
