### PR TITLE
Fix broken HTML in API docs; use latest upstream templates for CRD docs

### DIFF
--- a/scripts/gendocs/generate
+++ b/scripts/gendocs/generate
@@ -45,7 +45,7 @@ GOROOT="$(go env GOROOT)"
 export GOROOT
 GOBIN="${tmpdir}/bin"
 export GOBIN
-go get github.com/ahmetb/gen-crd-api-reference-docs@v0.3.0
+go install github.com/ahmetb/gen-crd-api-reference-docs@v0.3.0
 
 mkdir -p "${GOPATH}/src/github.com/jetstack"
 gitdir="${GOPATH}/src/github.com/jetstack/cert-manager"

--- a/scripts/gendocs/templates/members.tpl
+++ b/scripts/gendocs/templates/members.tpl
@@ -4,7 +4,7 @@
 {{ if not (hiddenMember .)}}
 <tr>
     <td>
-        <code>{{ fieldName . }}</code></br>
+        <code>{{ fieldName . }}</code><br/>
         <em>
             {{ if linkForType .Type }}
                 <a href="{{ linkForType .Type}}">

--- a/scripts/gendocs/templates/pkg.tpl
+++ b/scripts/gendocs/templates/pkg.tpl
@@ -22,9 +22,9 @@ type = "docs"
 
     {{ with (index .GoPackages 0 )}}
         {{ with .DocComments }}
-        <p>
+        <div>
             {{ safe (renderComments .) }}
-        </p>
+        </div>
         {{ end }}
     {{ end }}
 

--- a/scripts/gendocs/templates/type.tpl
+++ b/scripts/gendocs/templates/type.tpl
@@ -2,7 +2,7 @@
 
 <h3 id="{{ anchorIDForType . }}">
     {{- .Name.Name }}
-    {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias)</p>{{ end -}}
+    {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias){{ end -}}
 </h3>
 {{ with (typeReferences .) }}
     <p>
@@ -10,17 +10,40 @@
         {{- $prev := "" -}}
         {{- range . -}}
             {{- if $prev -}}, {{ end -}}
-            {{ $prev = . }}
+            {{- $prev = . -}}
             <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
         {{- end -}}
         )
     </p>
 {{ end }}
 
-
-<p>
+<div>
     {{ safe (renderComments .CommentLines) }}
-</p>
+</div>
+
+{{ with (constantsOfType .) }}
+<table>
+    <thead>
+        <tr>
+            <th>Value</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+      {{- range . -}}
+      <tr>
+        {{- /*
+            renderComments implicitly creates a <p> element, so we
+            add one to the display name as well to make the contents
+            of the two cells align evenly.
+        */ -}}
+        <td><p>{{ typeDisplayName . }}</p></td>
+        <td>{{ safe (renderComments .CommentLines) }}</td>
+      </tr>
+      {{- end -}}
+    </tbody>
+</table>
+{{ end }}
 
 {{ if .Members }}
 <table>
@@ -34,7 +57,7 @@
         {{ if isExportedType . }}
         <tr>
             <td>
-                <code>apiVersion</code></br>
+                <code>apiVersion</code><br/>
                 string</td>
             <td>
                 <code>
@@ -44,7 +67,7 @@
         </tr>
         <tr>
             <td>
-                <code>kind</code></br>
+                <code>kind</code><br/>
                 string
             </td>
             <td><code>{{.Name.Name}}</code></td>


### PR DESCRIPTION
This has been incorporated upstream in:

- https://github.com/ahmetb/gen-crd-api-reference-docs/pull/35
- https://github.com/ahmetb/gen-crd-api-reference-docs/pull/31

and possibly other PRs. Before this commit, HTML generated by the script was invalid.

Also uses `go install` for installing a binary.