### PR TITLE
Release notes and installation links for for v1.7.1

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -352,6 +352,7 @@ v1.6.1
 v1.6.2
 v1.7
 v1.7.0
+v1.7.1
 v1alpha2
 v1alpha3
 v1beta1

--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -15,7 +15,7 @@ install methods are listed below for each of the situations.
 
 The default static configuration can be installed as follows:
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
 ```
 More information on this install method [can be found here](./kubectl/).
 

--- a/content/en/docs/installation/helm.md
+++ b/content/en/docs/installation/helm.md
@@ -46,7 +46,7 @@ or using the `installCRDs` option when installing the Helm chart.
 
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.0/cert-manager.crds.yaml
+$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -67,7 +67,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.0 \
+  --version v1.7.1 \
   # --set installCRDs=true
 ```
 
@@ -80,7 +80,7 @@ $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.0 \
+  --version v1.7.1 \
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
 ```
@@ -97,7 +97,7 @@ $ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.7.0 \
+  --version v1.7.1 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml
@@ -146,7 +146,7 @@ using the link to the version `vX.Y.Z` you installed:
 > be removed by Kubernetes' garbage collector.
 
 ```bash
-$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
+$ kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.crds.yaml
 ```
 
 ### Namespace Stuck in Terminating State

--- a/content/en/docs/installation/kubectl.md
+++ b/content/en/docs/installation/kubectl.md
@@ -21,7 +21,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`
@@ -75,7 +75,7 @@ Delete the installation manifests using a link to your currently running version
 > be removed by Kubernetes' garbage collector.
 
 ```bash
-$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/vX.Y.Z/cert-manager.yaml
+$ kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.yaml
 ```
 
 ### Namespace Stuck in Terminating State

--- a/content/en/docs/installation/operator-lifecycle-manager.md
+++ b/content/en/docs/installation/operator-lifecycle-manager.md
@@ -69,7 +69,7 @@ spec:
   name: cert-manager
 ...
 status:
-  currentCSV: cert-manager.v1.7.0
+  currentCSV: cert-manager.v1.7.1
   state: AtLatestKnown
 ...
 ```

--- a/content/en/docs/installation/upgrading/ingress-class-compatibility.md
+++ b/content/en/docs/installation/upgrading/ingress-class-compatibility.md
@@ -10,9 +10,9 @@ See [Regression: HTTP-01 challenges fail with Istio, Traefik, ingress-gce and Az
 
 [Regression: HTTP-01 challenges fail with Istio, Traefik, ingress-gce and Azure AGIC]: https://github.com/jetstack/cert-manager/issues/4537
 
-In v1.5.5, v1.6.2 and 1.7.0 we have fixed this problem.
+In v1.5.5, v1.6.2 and 1.7.1 we have fixed this problem.
 
-If you have cert-manager v1.5.3 (or below) you should skip v1.5.4 and upgrade to v1.5.5 then v1.6.2 and then v1.7.0
+If you have cert-manager v1.5.3 (or below) you should skip v1.5.4 and upgrade to v1.5.5 then v1.6.2 and then v1.7.1
 and you can ignore the rest of this document.
 
 The following notes apply to anyone upgrading from cert-manager v1.5.4, v1.6.0, v1.6.1 on Kubernetes v1.19 or later.

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -4,6 +4,14 @@ linkTitle: "v1.7"
 weight: 760
 type: "docs"
 ---
+## v1.7.1
+
+### Changes since v1.7.0
+
+#### Bug or Regression
+
+- Fix: The alpha feature Certificate's `additionalOutputFormats` is now correctly validated at admission time, and no longer _only_ validated if the `privateKey` field of the Certificate is set. The Webhook component now contains a separate feature set.
+  `AdditionalCertificateOutputFormats` feature gate (disabled by default) has been added to the webhook. This gate is required to be enabled on both the controller and webhook components in order to make use of the Certificate's `additionalOutputFormat` feature. ([#4816](https://github.com/cert-manager/cert-manager/pull/4816), [@JoshVanL](https://github.com/JoshVanL))
 
 ## v1.7.0
 

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -25,10 +25,10 @@ and that all cert-manager `CustomResourceDefinition`s have only v1 as the stored
 **before** upgrading.
 
 Since release 1.7, `cmctl` can automatically migrate any deprecated API resources.
-Please [download `cmctl-v1.7.0`] and read [Migrating Deprecated API Resources]
+Please [download `cmctl-v1.7.1`] and read [Migrating Deprecated API Resources]
 for full instructions.
 
-[download `cmctl-v1.7.0`]: https://github.com/jetstack/cert-manager/releases/tag/v1.7.0
+[download `cmctl-v1.7.1`]: https://github.com/cert-manager/cert-manager/releases/tag/v1.7.1
 [Migrating Deprecated API Resources]: https://cert-manager.io/docs/installation/upgrading/remove-deprecated-apis/
 
 #### Ingress Class Semantics

--- a/content/en/docs/usage/cmctl.md
+++ b/content/en/docs/usage/cmctl.md
@@ -23,7 +23,7 @@ Run the following commands to set up the CLI. Replace OS and ARCH with your
 systems equivalents:
 
 ```console
-OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -L -o cmctl.tar.gz https://github.com/jetstack/cert-manager/releases/latest/download/cmctl-$OS-$ARCH.tar.gz
+OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cmctl-$OS-$ARCH.tar.gz
 tar xzf cmctl.tar.gz
 sudo mv cmctl /usr/local/bin
 ```

--- a/content/en/docs/usage/kubectl-plugin.md
+++ b/content/en/docs/usage/kubectl-plugin.md
@@ -22,14 +22,14 @@ In order to use the kubectl plugin you need its binary to be accessible under th
 Run the following commands to set up the plugin:
 
 ```console
-OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -L -o kubectl-cert-manager.tar.gz https://github.com/jetstack/cert-manager/releases/latest/download/kubectl-cert_manager-$OS-$ARCH.tar.gz
+OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o kubectl-cert-manager.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/kubectl-cert_manager-$OS-$ARCH.tar.gz
 tar xzf kubectl-cert-manager.tar.gz
 sudo mv kubectl-cert_manager /usr/local/bin
 ```
 
 ### Windows
 
-1. Download the [latest version](https://github.com/jetstack/cert-manager/releases/latest/download/kubectl-cert_manager-windows-amd64.tar.gz).
+1. Download the [latest version](https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/kubectl-cert_manager-windows-amd64.tar.gz).
 2. Extract the archive.
 3. Add the `.exe` file extension to the extracted `kubectl-cert_manager`.
 4. Copy `kubectl-cert_manager.exe` to a location which is also in your `PATH`.


### PR DESCRIPTION
Release notes and updated installation links for https://github.com/cert-manager/cert-manager/releases/tag/v1.7.1

I've replaced some jetstack/cert-manager with cert-manager/cert-manager, but only where they relate to the download of versioned assets.

We can replace the remaining references in another PR.

I also updated the `cmctl` and `kubectl cet-manager` installation instructions to use a specific version rather than `/latest/`, which may not point to the newest semver version, but simply the last released version.