### PR TITLE
Release process: fix the way we compute "START_REV" when START_TAG is an ancestor of BRANCH.

### DIFF
--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -267,7 +267,7 @@ page if a step is missing or if it is outdated.
         # Must be run from the cert-manger folder.
         export GITHUB_TOKEN=*your-token*
         git fetch origin $BRANCH:$BRANCH
-        export START_SHA="$(git rev-list --reverse --ancestry-path $START_TAG..$BRANCH | head -1)"
+        export START_SHA="$(git rev-list --reverse --ancestry-path $(git merge-base $START_TAG $BRANCH)..$BRANCH | head -1
         release-notes --debug --repo-path cert-manager \
           --org jetstack --repo cert-manager \
           --required-author "jetstack-bot" \

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -267,7 +267,7 @@ page if a step is missing or if it is outdated.
         # Must be run from the cert-manger folder.
         export GITHUB_TOKEN=*your-token*
         git fetch origin $BRANCH:$BRANCH
-        export START_SHA="$(git rev-list --reverse --ancestry-path $(git merge-base $START_TAG $BRANCH)..$BRANCH | head -1
+        export START_SHA="$(git rev-list --reverse --ancestry-path $(git merge-base $START_TAG $BRANCH)..$BRANCH | head -1)"
         release-notes --debug --repo-path cert-manager \
           --org jetstack --repo cert-manager \
           --required-author "jetstack-bot" \


### PR DESCRIPTION


The goal of the command "git rev-list --reverse" was to avoid having to manually remove the changelog entry associated with the commit behind `START_REV`. I wanted to find a command that would find the child commit of `START_REV`.

Later on, we discovered that v1.7.0 does not belong to the ancestry of master, which means that the following command returns no commit hash at all:

```sh
git rev-list --reverse --ancestry-path v1.7.0..release-1.8
```

In order to work around this specific case, we now start with the merge base between the previous tag (e.g., 1.7.1) and the revision that we plan on releasing (e.g. master). With the command

```sh
git rev-list --reverse --ancestry-path $(git merge-base v1.7.0 release-1.8)..release-1.8
```

With this command, the first commit hash returned corresponds to the first commit right after the merge base (the bottom commit inside the below box):

```text
               master
                  ^
                  |
                +---+ release-1.7
                | + |
       these    | | |     + v1.7.0
       commits  | + |     |
       are part | | |     + <----- these commits
       of the   | + |    /         are not
       changelog| | |   /          part of
                | + |  +  <------- the changelog
                +---+ /            for
                  |  +  <--------- 1.8.0
                  | /
                  |-
                  |
                  +
                  |
```
