### PR TITLE
Ssa installation warning

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -147,6 +147,7 @@ SelfSigned
 SgtCoDFish
 Smallstep
 SubjectAccessReview
+stevehipwell
 TLDs
 TODO
 TPP

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -66,7 +66,7 @@ If you are using Traefik, Istio, Ambassador, or ingress-nginx _and_ you are usin
 
 #### Upgrading with Server Side Apply
 
-As part of the work to [remove deprecated APIs](#removal-of-deprecated-apis) cert-manager `CustomResourceDefinition`s no longer require a conversion webhook. The related change in cert-manager `CustomResourceDefinition` specs results in invalid `CustomResourceDefinition` configs for users who are upgrading to cert-manager 1.7 using `kubectl apply --server-side=true -f <manifests>`. This can be solved either by performing the upgrade with client side apply or by manually patching the [managed fields](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management) of cert-manager `CustomResourceDefinitions`:
+As part of the work to [remove deprecated APIs](#removal-of-deprecated-apis) cert-manager `CustomResourceDefinition`s no longer require a conversion webhook. The related change in cert-manager `CustomResourceDefinition` specs results in invalid `CustomResourceDefinition` configurations for users who are upgrading to cert-manager 1.7 using `kubectl apply --server-side=true -f <manifests>`. This can be solved either by performing the upgrade with client side apply or by manually patching the [managed fields](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management) of cert-manager `CustomResourceDefinitions`:
 
 ```bash
 crds=("certificaterequests.cert-manager.io" "certificates.cert-manager.io" "challenges.acme.cert-manager.io" "clusterissuers.cert-manager.io" "issuers.cert-manager.io" "orders.acme.cert-manager.io")
@@ -78,7 +78,7 @@ done
 ```
 Thanks to [@stevehipwell](https://github.com/stevehipwell) for the above patch commands.
 
-See the original Github issue [cert-manager#](https://github.com/cert-manager/cert-manager/issues/4831)
+See the original GitHub issue [`cert-manager#4831`](https://github.com/cert-manager/cert-manager/issues/4831)
 
 ### Major Themes
 

--- a/content/en/docs/release-notes/release-notes-1.7.md
+++ b/content/en/docs/release-notes/release-notes-1.7.md
@@ -19,7 +19,7 @@ type: "docs"
 
 #### Removal of Deprecated APIs
 
-⚠ Following their deprecation in version 1.5, the cert-manager API versions v1alpha2, v1alpha3, and v1beta1 have been removed.
+⚠ Following their deprecation in version 1.4, the cert-manager API versions v1alpha2, v1alpha3, and v1beta1 have been removed.
 You must ensure that all cert-manager custom resources are stored in etcd at version v1
 and that all cert-manager `CustomResourceDefinition`s have only v1 as the stored version
 **before** upgrading.
@@ -84,7 +84,7 @@ See the original Github issue [cert-manager#](https://github.com/cert-manager/ce
 
 #### Removal of Deprecated APIs
 
-In 1.7 the cert-manager API versions v1alpha2, v1alpha3, and v1beta1, that were deprecated in 1.5,
+In 1.7 the cert-manager API versions v1alpha2, v1alpha3, and v1beta1, that were deprecated in 1.4,
 have been removed from the custom resource definitions (CRDs).
 As a result, you will notice that the YAML manifest files are much smaller.
 


### PR DESCRIPTION
Adds a note about the known issue when upgrading to cert-manaer 1.7 using kubectl server side apply and how to fix it

See https://github.com/cert-manager/cert-manager/issues/4831 for context

If this gets merged, I will sync the update to GitHub release note too.

Also fixes the cert-manager version at which the alpha/beta APIs were deprecated that I fixed on GitHub some time ago, but not here