### PR TITLE
change header on api-docs to match other files

### DIFF
--- a/content/en/v0.12-docs/reference/api-docs.md
+++ b/content/en/v0.12-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v0.13-docs/reference/api-docs.md
+++ b/content/en/v0.13-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v0.14-docs/reference/api-docs.md
+++ b/content/en/v0.14-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v0.15-docs/reference/api-docs.md
+++ b/content/en/v0.15-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v0.16-docs/reference/api-docs.md
+++ b/content/en/v0.16-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v1.0-docs/reference/api-docs.md
+++ b/content/en/v1.0-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v1.1-docs/reference/api-docs.md
+++ b/content/en/v1.1-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v1.2-docs/reference/api-docs.md
+++ b/content/en/v1.2-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v1.3-docs/reference/api-docs.md
+++ b/content/en/v1.3-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v1.4-docs/reference/api-docs.md
+++ b/content/en/v1.4-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v1.5-docs/reference/api-docs.md
+++ b/content/en/v1.5-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v1.6-docs/reference/api-docs.md
+++ b/content/en/v1.6-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/content/en/v1.7-docs/reference/api-docs.md
+++ b/content/en/v1.7-docs/reference/api-docs.md
@@ -1,7 +1,7 @@
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 <p>Packages:</p>
 <ul>
 <li>

--- a/scripts/gendocs/templates/pkg.tpl
+++ b/scripts/gendocs/templates/pkg.tpl
@@ -1,8 +1,8 @@
 {{ define "packages" }}
-+++
-title = "API reference docs"
-type = "docs"
-+++
+---
+title: "API reference docs"
+type: "docs"
+---
 
 {{ with .packages}}
 <p>Packages:</p>


### PR DESCRIPTION
This was done automatically, though the following command:

```bash
find content/en -name "api-docs.md"  | \
xargs sed -i -e 's/^+++/---/g' -e 's/ = /: /g'
```

The aim of this PR is to make it simpler to programmatically edit these files by unifying headers across all markdown files.

**IMPORTANT**: The netlify preview is broken for API reference docs. It's not related to this PR; if you check this out locally and run locally, you'll see the API docs in the sidebar as normal!