### PR TITLE
Move the meetings and slack information to a separate page

### DIFF
--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -27,24 +27,6 @@ external cert-manager components:
 
 Hello new or existing contributor!
 Welcome to our contributors documentation, this is the place where we document all our processes
-as well as how to compile, run and test cert-manager and all it's components.
+as well as how to compile, run and test cert-manager and all its components.
 This document sometimes can get out of date due to changes in the code and/or tooling. PRs to this part are
 also very welcome if you happen to find an out of date part.
-
-## Meetings
-
-All cert-manager meetings are open for everyone to join.
-
-To get invites you can subscribe to [our mailing list](https://groups.google.com/forum/#!forum/cert-manager-dev).
-
-We have 2 regular repeating meetings:
-
-* daily stand-up meetings [on Google Meet](https://meet.google.com/eum-fyvt-xpa) at [10:30 London time](http://www.thetimezoneconverter.com/?t=10:30&tz=Europe/London) every weekday
-* bi-weekly developer meetings [on Google Meet](https://meet.google.com/abp-bwhk-wxc) at [17:00 London time](http://www.thetimezoneconverter.com/?t=17:00&tz=Europe/London) (for dates, check calendar invites or [meeting notes](https://docs.google.com/document/d/1Tc5t6ylY9dhXAan1OjOoldeaoys1Yh4Ir710ATfBa5U))
-
-## Slack
-
-We have two cert-manager channels on [the Kubernetes Slack](https://slack.k8s.io) which we use to communicate:
-
-* `cert-manager`: a general channel for all users of cert-manager; use this one for any usage related questions.
-* `cert-manager-dev`: a channel for collaboration between cert-manager contributors and maintainers; please only use this for code related questions

--- a/content/en/docs/contributing/talk-to-us.md
+++ b/content/en/docs/contributing/talk-to-us.md
@@ -1,0 +1,24 @@
+---
+title: "Meet the maintainers"
+linkTitle: "talk-to-us"
+weight: 70
+type: "docs"
+---
+
+## Meetings
+
+All cert-manager meetings are open for everyone to join.
+
+To get invites you can subscribe to [our mailing list](https://groups.google.com/forum/#!forum/cert-manager-dev).
+
+We have 2 regular repeating meetings:
+
+* daily stand-up meetings [on Google Meet](https://meet.google.com/eum-fyvt-xpa) at [10:30 London time](http://www.thetimezoneconverter.com/?t=10:30&tz=Europe/London) every weekday
+* bi-weekly developer meetings [on Google Meet](https://meet.google.com/abp-bwhk-wxc) at [17:00 London time](http://www.thetimezoneconverter.com/?t=17:00&tz=Europe/London) (for dates, check calendar invites or [meeting notes](https://docs.google.com/document/d/1Tc5t6ylY9dhXAan1OjOoldeaoys1Yh4Ir710ATfBa5U))
+
+## Slack
+
+We have two cert-manager channels on [the Kubernetes Slack](https://slack.k8s.io) which we use to communicate:
+
+* `cert-manager`: a general channel for all users of cert-manager; use this one for any usage related questions.
+* `cert-manager-dev`: a channel for collaboration between cert-manager contributors and maintainers; please only use this for code related questions


### PR DESCRIPTION
We've been reviewing the contributing guide and agreed that having the meetings and slack information as the main content of the contributing guide is distracting.
New contributors first concern is how to check out and build the code.