### PR TITLE
Add a paragraph about releasing OLM packages

### DIFF
--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -536,10 +536,9 @@ page if a step is missing or if it is outdated.
 
     11. Create a new OLM package and publish to OperatorHub
 
-        [cert-manager can be installed using Operator Lifecycle Manager (OLM)](https://cert-manager.io/docs/installation/operator-lifecycle-manager/)
-        so we need to create OLM packages for each cert-manager version,
-        and publish them to [operatorhub.io]https://operatorhub.io/operator/cert-manager
-        and to the equivalent package index for RedHat OpenShift.
+        cert-manager can be [installed](https://cert-manager.io/docs/installation/operator-lifecycle-manager/) using Operator Lifecycle Manager (OLM)
+        so we need to create OLM packages for each cert-manager version and publish them to both
+        [operatorhub.io](https://operatorhub.io/operator/cert-manager) and the equivalent package index for RedHat OpenShift.
 
-        Follow [the cert-manager OLM release process](https://github.com/jetstack/cert-manager-olm#release-process) and once published
+        Follow [the cert-manager OLM release process](https://github.com/jetstack/cert-manager-olm#release-process) and, once published,
         [verify that the cert-manager OLM installation instructions](https://cert-manager.io/docs/installation/operator-lifecycle-manager/) still work.

--- a/content/en/docs/contributing/release-process.md
+++ b/content/en/docs/contributing/release-process.md
@@ -533,3 +533,13 @@ page if a step is missing or if it is outdated.
 
     10. Open a PR against the Krew index such as [this one](https://github.com/kubernetes-sigs/krew-index/pull/1724),
         bumping the versions of our kubectl plugins.
+
+    11. Create a new OLM package and publish to OperatorHub
+
+        [cert-manager can be installed using Operator Lifecycle Manager (OLM)](https://cert-manager.io/docs/installation/operator-lifecycle-manager/)
+        so we need to create OLM packages for each cert-manager version,
+        and publish them to [operatorhub.io]https://operatorhub.io/operator/cert-manager
+        and to the equivalent package index for RedHat OpenShift.
+
+        Follow [the cert-manager OLM release process](https://github.com/jetstack/cert-manager-olm#release-process) and once published
+        [verify that the cert-manager OLM installation instructions](https://cert-manager.io/docs/installation/operator-lifecycle-manager/) still work.


### PR DESCRIPTION
Eventually I should probably move all the OLM release documentation into a page here, but for now I explain the motivation for this release step and link to the README in the cert-manager-olm repo.