### PR TITLE
don't use indented code blocks inside a quote block

### DIFF
--- a/content/en/docs/configuration/acme/_index.md
+++ b/content/en/docs/configuration/acme/_index.md
@@ -133,12 +133,16 @@ URL string of your external account symmetric MAC key
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/next-docs/configuration/acme/_index.md
+++ b/content/en/next-docs/configuration/acme/_index.md
@@ -132,13 +132,17 @@ URL string of your external account symmetric MAC key
 
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
-> 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+>
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v0.13-docs/configuration/acme/_index.md
+++ b/content/en/v0.13-docs/configuration/acme/_index.md
@@ -90,10 +90,18 @@ string of your external account symmetric MAC key, and finally `keyAlgorithm`,
 the MAC algorithm used to sign the JSON web string containing your External
 Account Binding when registering the account with the ACME server.
 
-> Note: The command `base64` is useful for encoding your MAC key if it is not
-> already `$ echo 'my-secret-key' | base64`, you can then create the Secret
-> resource with: `kubectl create secret generic eab-secret --from-literal
-> secret={base64 encoded secret key}`
+> Note: The `base64` command is useful for encoding your MAC key if it is not
+> already encoded:
+>
+> ```console
+> $ echo 'my-secret-key' | base64
+> ```
+>
+> You can then create the Secret resource with:
+>
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v0.14-docs/configuration/acme/_index.md
+++ b/content/en/v0.14-docs/configuration/acme/_index.md
@@ -90,10 +90,18 @@ string of your external account symmetric MAC key, and finally `keyAlgorithm`,
 the MAC algorithm used to sign the JSON web string containing your External
 Account Binding when registering the account with the ACME server.
 
-> Note: The command `base64` is useful for encoding your MAC key if it is not
-> already `$ echo 'my-secret-key' | base64`, you can then create the Secret
-> resource with: `kubectl create secret generic eab-secret --from-literal
-> secret={base64 encoded secret key}`
+> Note: The `base64` command is useful for encoding your MAC key if it is not
+> already encoded:
+>
+> ```console
+> $ echo 'my-secret-key' | base64
+> ```
+>
+> You can then create the Secret resource with:
+>
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v0.15-docs/configuration/acme/_index.md
+++ b/content/en/v0.15-docs/configuration/acme/_index.md
@@ -90,10 +90,18 @@ string of your external account symmetric MAC key, and finally `keyAlgorithm`,
 the MAC algorithm used to sign the JSON web string containing your External
 Account Binding when registering the account with the ACME server.
 
-> Note: The command `base64` is useful for encoding your MAC key if it is not
-> already `$ echo 'my-secret-key' | base64`, you can then create the Secret
-> resource with: `kubectl create secret generic eab-secret --from-literal
-> secret={base64 encoded secret key}`
+> Note: The `base64` command is useful for encoding your MAC key if it is not
+> already encoded:
+>
+> ```console
+> $ echo 'my-secret-key' | base64
+> ```
+>
+> You can then create the Secret resource with:
+>
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v0.16-docs/configuration/acme/_index.md
+++ b/content/en/v0.16-docs/configuration/acme/_index.md
@@ -90,10 +90,18 @@ string of your external account symmetric MAC key, and finally `keyAlgorithm`,
 the MAC algorithm used to sign the JSON web string containing your External
 Account Binding when registering the account with the ACME server.
 
-> Note: The command `base64` is useful for encoding your MAC key if it is not
-> already `$ echo 'my-secret-key' | base64`, you can then create the Secret
-> resource with: `kubectl create secret generic eab-secret --from-literal
-> secret={base64 encoded secret key}`
+> Note: The `base64` command is useful for encoding your MAC key if it is not
+> already encoded:
+>
+> ```console
+> $ echo 'my-secret-key' | base64
+> ```
+>
+> You can then create the Secret resource with:
+>
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v1.0-docs/configuration/acme/_index.md
+++ b/content/en/v1.0-docs/configuration/acme/_index.md
@@ -136,12 +136,16 @@ ACME server
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 | sed -e 's/+/-/g' -e 's///_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v1.1-docs/configuration/acme/_index.md
+++ b/content/en/v1.1-docs/configuration/acme/_index.md
@@ -136,12 +136,16 @@ ACME server
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v1.2-docs/configuration/acme/_index.md
+++ b/content/en/v1.2-docs/configuration/acme/_index.md
@@ -136,12 +136,16 @@ ACME server
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v1.3-docs/configuration/acme/_index.md
+++ b/content/en/v1.3-docs/configuration/acme/_index.md
@@ -133,12 +133,16 @@ URL string of your external account symmetric MAC key
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v1.4-docs/configuration/acme/_index.md
+++ b/content/en/v1.4-docs/configuration/acme/_index.md
@@ -133,12 +133,16 @@ URL string of your external account symmetric MAC key
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v1.5-docs/configuration/acme/_index.md
+++ b/content/en/v1.5-docs/configuration/acme/_index.md
@@ -133,12 +133,16 @@ URL string of your external account symmetric MAC key
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v1.6-docs/configuration/acme/_index.md
+++ b/content/en/v1.6-docs/configuration/acme/_index.md
@@ -133,12 +133,16 @@ URL string of your external account symmetric MAC key
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 

--- a/content/en/v1.7-docs/configuration/acme/_index.md
+++ b/content/en/v1.7-docs/configuration/acme/_index.md
@@ -133,12 +133,16 @@ URL string of your external account symmetric MAC key
 > Note: In _most_ cases, the MAC key must be encoded in `base64URL`. The 
 > following command will base64-encode a key and convert it to `base64URL`:
 > 
->     $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```console
+> $ echo 'my-secret-key' | base64 -w0 | sed -e 's/+/-/g' -e 's/\//_/g' -e 's/=//g'
+> ```
 > 
 > You can then create the Secret resource with: 
 > 
->     $ kubectl create secret generic eab-secret --from-literal \
->       secret={base64 encoded secret key}
+> ```console
+> $ kubectl create secret generic eab-secret --from-literal \
+>   secret={base64 encoded secret key}
+> ```
 
 An example of an ACME issuer with an External Account Binding is as follows.
 


### PR DESCRIPTION
This messes with MDX; this change is backwards compatible so should be totally safe to make, while it makes the website refresh a _tonne_ easier.

This is also an improvement since we can specify the type of code block (`console`)!