### PR TITLE
gateway-api: update the docs for v1alpha2

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -384,6 +384,7 @@ v1.7.1
 v1.7.2
 v1.8
 v1.8.0
+v1alpha1
 v1alpha2
 v1alpha3
 v1beta1

--- a/content/en/docs/configuration/acme/http01/_index.md
+++ b/content/en/docs/configuration/acme/http01/_index.md
@@ -227,9 +227,11 @@ kubectl rollout restart deployment cert-manager -n cert-manager
 Gateway API. The version v1alpha1 was supported in cert-manager 1.5, 1.6, and
 1.7.
 
-You can read [Upgrading from v1.7 to v1.8](<!-- TODO: -->) to know more about
+You can read [Upgrading from v1.7 to v1.8][upgrading-1.7-1.8] to know more about
 migrating your Issuer and ClusterIssuer resources that use `gatewayHTTPRoute`
 from v1alpha1 to v1alpha2.
+
+[upgrading-1.7-1.8]: /docs/installation/upgrading/upgrading-1.6-1.7/
 
 {{% /pageinfo %}}
 

--- a/content/en/docs/installation/upgrading/upgrading-1.7-1.8.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.7-1.8.md
@@ -1,12 +1,9 @@
 ---
 title: "Upgrading from v1.7 to v1.8"
 linkTitle: "v1.7 to v1.8"
-weight: 750
+weight: 740
 type: "docs"
 ---
-
-When upgrading from 1.7 to 1.8, no special upgrade steps are required 🎉. From
-here on you can follow the [regular upgrade process](../).
 
 #### Validation of the `rotationPolicy` field
 

--- a/content/en/docs/installation/upgrading/upgrading-1.7-1.8.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.7-1.8.md
@@ -49,9 +49,11 @@ not able to clean up Challenge resources that were created pre-1.8.
 
 #### Migrating from the Gateway API v1alpha1 to v1alpha2
 
+This section only applies to you if you are using the feature gate
+`ExperimentalGatewayAPISupport`.
+
 cert-manager 1.8 drops support for the Gateway API v1alpha1, and now only
-supports v1alpha2. You should read this section if you are using the feature
-flag `ExperimentalGatewayAPISupport`.
+supports v1alpha2.
 
 Before upgrading cert-manager, you will need to:
 

--- a/content/en/docs/installation/upgrading/upgrading-1.7-1.8.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.7-1.8.md
@@ -46,3 +46,45 @@ state.
 The reason the Challenge resources need to be removed before upgrading to 1.8
 when using the new Server-Side Apply feature is that cert-manager post-1.8 is
 not able to clean up Challenge resources that were created pre-1.8.
+
+#### Migrating from the Gateway API v1alpha1 to v1alpha2
+
+cert-manager 1.8 drops support for the Gateway API v1alpha1, and now only
+supports v1alpha2. You should read this section if you are using the feature
+flag `ExperimentalGatewayAPISupport`.
+
+Before upgrading cert-manager, you will need to:
+
+1. remove all existing Gateway API v1alpha1 resources,
+2. upgrade the Gateway API CRDs to v1alpha2,
+3. re-create the Gateway API resources with the v1alpha2.
+
+This manual intervention is needed because the Gateway API project does not
+come with a conversion webhook that would allow an easier migration from
+v1alpha1 to v1alpha2.
+
+After upgrading cert-manager to 1.8, you will need to remove the `labels` field,
+and add the `parentRefs`:
+
+```diff
+ apiVersion: cert-manager.io/v1
+ kind: Issuer
+ metadata:
+   name: letsencrypt
+   namespace: default
+ spec:
+   acme:
+     solvers:
+       - http01:
+           gatewayHTTPRoute:
+-            labels:
+-              gateway: traefik
++            parentRefs:
++              - name: traefik
++                namespace: traefik
++                kind: Gateway
+```
+
+## Now, Follow the Regular Upgrade Process
+
+From here on you can follow the [regular upgrade process](../).

--- a/content/en/docs/installation/upgrading/upgrading-1.7-1.8.md
+++ b/content/en/docs/installation/upgrading/upgrading-1.7-1.8.md
@@ -28,8 +28,7 @@ smoketest-cert in namespace default has rotationPolicy=Foo
 #### Server-Side Apply
 
 Server-Side Apply is an alpha feature of cert-manager introduced in 1.8. By
-default, the feature is disabled, in which case you do not need to do any
-upgrade steps.
+default, the feature is disabled, in which case you can skip this section.
 
 If you are using Server-Side Apply, i.e., you are running the cert-manager
 controller with the flag

--- a/content/en/docs/usage/gateway.md
+++ b/content/en/docs/usage/gateway.md
@@ -22,9 +22,11 @@ HTTP-01](/docs/configuration/acme/http01/).
 Gateway API. The version v1alpha1 was supported in cert-manager 1.5, 1.6, and
 1.7.
 
-You can read [Upgrading from v1.7 to v1.8](<!-- TODO: -->) to know more about
+You can read [Upgrading from v1.7 to v1.8][upgrading-1.7-1.8] to know more about
 migrating your Issuer and ClusterIssuer resources that use `gatewayHTTPRoute`
 from v1alpha1 to v1alpha2.
+
+[upgrading-1.7-1.8]: /docs/installation/upgrading/upgrading-1.6-1.7/
 
 {{% /pageinfo %}}
 

--- a/content/en/docs/usage/gateway.md
+++ b/content/en/docs/usage/gateway.md
@@ -16,6 +16,18 @@ HTTP-01](/docs/configuration/acme/http01/).
 
 {{% /pageinfo %}}
 
+{{% pageinfo color="info" %}}
+
+🚧  Since cert-manager 1.8, v1alpha2 is the only supported version of the
+Gateway API. The version v1alpha1 was supported in cert-manager 1.5, 1.6, and
+1.7.
+
+You can read [Upgrading from v1.7 to v1.8](<!-- TODO: -->) to know more about
+migrating your Issuer and ClusterIssuer resources that use `gatewayHTTPRoute`
+from v1alpha1 to v1alpha2.
+
+{{% /pageinfo %}}
+
 cert-manager can generate TLS certificates for Gateway resources. This is
 configured by adding annotations to a Gateway and is similar to the process for
 [Securing Ingress Resources](/docs/usage/ingress/).
@@ -43,7 +55,6 @@ HTTPRoute for Istio][istio#31747]).
 [istio#31747]: https://github.com/istio/istio/issues/31747
 [gateway-api#577]: https://github.com/kubernetes-sigs/gateway-api/issues/577
 
-
 {{% pageinfo color="info" %}}
 
 📌  This feature requires the installation of the Gateway API CRDs and passing a
@@ -52,7 +63,7 @@ feature flag to the cert-manager controller.
 To install the Gateway API CRDs, run the following command:
 
 ```sh
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0" | kubectl apply -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.1" | kubectl apply -f -
 ```
 
 To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
@@ -90,7 +101,7 @@ following Gateway will trigger the creation of a Certificate with the name
 `example-com-tls`:
 
 ```yaml
-apiVersion: networking.x-k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
   name: example
@@ -99,20 +110,17 @@ metadata:
 spec:
   gatewayClassName: foo
   listeners:
-    - hostname: example.com
+    - name: http
+      hostname: example.com
       port: 443
       protocol: HTTPS
-      routes:
-        kind: HTTPRoute
-        selector:
-          matchLabels:
-            app: foo
+      allowedRoutes:
+        namespaces:
+          from: All
       tls:
         mode: Terminate
-        certificateRef:
-          name: example-com-tls
-          kind: Secret
-          group: core
+        certificateRefs:
+          - name: example-com-tls
 ```
 
 A few moments later, cert-manager will create a Certificate. The Certificate is
@@ -154,7 +162,7 @@ In the following example, the first three listener blocks will not be used to
 generate Certificate resources:
 
 ```yaml
-apiVersion: networking.x-k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
   annotations:
@@ -166,35 +174,33 @@ spec:
 
     # ❌  Missing "hostname", the following listener is skipped.
     - tls:
-        certificateRef:
-          name: example-com-tls
-          kind: Secret"
-          group: core
+        certificateRefs:
+          - name: example-com-tls
+            kind: Secret"
+            group: core
 
     # ❌  "mode: Passthrough" is not supported, the following listener is skipped.
     - hostname: example.com
       tls:
         mode: Passthrough
-        certificateRef:
-          name: example-com-tls
-          kind: Secret
-          group: core
+        certificateRefs:
+          - name: example-com-tls
+            kind: Secret
+            group: core
 
     # ✅  The following listener is valid.
     - hostname: foo.example.com # ✅ Required.
       port: 443
       protocol: HTTPS
-      routes:
-        kind: HTTPRoute
-        selector:
-          matchLabels:
-            app: foo
+      allowedRoutes:
+        namespaces:
+          from: All
       tls:
         mode: Terminate # ✅ Required. "Terminate" is the only supported mode.
-        certificateRef:
-          name: example-com-tls # ✅ Required.
-          kind: Secret  # ✅ Required. "Secret" is the only valid value.
-          group: core # ✅ Required. "core" is the only valid value.
+        certificateRefs:
+          - name: example-com-tls # ✅ Required.
+            kind: Secret  # ✅ Required. "Secret" is the only valid value.
+            group: core # ✅ Required. "core" is the only valid value.
 ```
 
 cert-manager has skipped over the first three listener blocks and has created a
@@ -221,7 +227,7 @@ The same Secret name can be re-used in multiple TLS blocks, regardless of the
 hostname. Let us imagine that you have these two listeners:
 
 ```yaml
-apiVersion: networking.x-k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
   name: example
@@ -236,15 +242,15 @@ spec:
       protocol: HTTPS
       routes:
         kind: HTTPRoute
-        selector:
-          matchLabels:
-            app: foo
+        parentRefs:
+          - name: example
+            kind: Gateway
       tls:
         mode: Terminate
-        certificateRef:
-          name: example-com-tls
-          kind: Secret
-          group: core
+        certificateRefs:
+          - name: example-com-tls
+            kind: Secret
+            group: core
 
     # Listener 2: Same Secret name as Listener 1, with a different hostname.
     - hostname: *.example.com
@@ -252,15 +258,15 @@ spec:
       protocol: HTTPS
       routes:
         kind: HTTPRoute
-        selector:
-          matchLabels:
-            app: foo
+        parentRefs:
+          - name: example
+            kind: Gateway
       tls:
         mode: Terminate
-        certificateRef:
-          name: example-com-tls
-          kind: Secret
-          group: core
+        certificateRefs:
+          - name: example-com-tls
+            kind: Secret
+            group: core
 
     # Listener 3: also same Secret name, except the hostname is also the same.
     - hostname: *.example.com
@@ -268,15 +274,15 @@ spec:
       protocol: HTTPS
       routes:
         kind: HTTPRoute
-        selector:
-          matchLabels:
-            app: foo
+        parentRefs:
+          - name: example
+            kind: Gateway
       tls:
         mode: Terminate
-        certificateRef:
-          name: example-com-tls
-          kind: Secret
-          group: core
+        certificateRefs:
+          - name: example-com-tls
+            kind: Secret
+            group: core
 
    # Listener 4: different Secret name.
     - hostname: site.org
@@ -284,15 +290,15 @@ spec:
       protocol: HTTPS
       routes:
         kind: HTTPRoute
-        selector:
-          matchLabels:
-            app: foo
+        parentRefs:
+          - name: example
+            kind: Gateway
       tls:
         mode: Terminate
-        certificateRef:
-          name: site-org-tls
-          kind: Secret
-          group: core
+        certificateRefs:
+          - name: site-org-tls
+            kind: Secret
+            group: core
 ```
 
 cert-manager will create two Certificates since two Secret names are used:


### PR DESCRIPTION
I updated the documentation for the Gateway API for v1alpha2.

While writing this documentation, I realize that no one should ever be using the Gateway API; it is way too experimental, and upgrading from v1alpha1 to v1alpha2 is a massive pain.

~⚠️ Right now, this PR targets `master`, but it should rather target the next release. Does `release-next` still exist @SgtCoDFish?~

cc @jakexks 