### PR TITLE
style: fix active style for docs in nav

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -146,6 +146,7 @@ function closeMenu(setOpen) {
 }
 
 function NavItem({ active, item, setOpen = null }) {
+  active = active === '/[...docs]' ? '/docs' : active
   const isActive = active === item.href
   return (
     <li key={item.href}>

--- a/content/docs/installation/supported-releases.md
+++ b/content/docs/installation/supported-releases.md
@@ -3,9 +3,7 @@ title: Supported Releases
 description: cert-manager supported releases, supported Kubernetes versions and release timeline
 ---
 
-/*
-Inspired by https://istio.io/latest/about/supported-releases/
-*/
+{/* Inspired by https://istio.io/latest/about/supported-releases/ */}
 
 This page lists the status, timeline and policy for currently supported
 releases.


### PR DESCRIPTION
Active styling for docs in navigation
![image](https://user-images.githubusercontent.com/39129161/161771679-86628ac2-6ffb-476b-bd42-b957e0564535.png)

Correctly comment out using `{/* ... */}`
Before
![image](https://user-images.githubusercontent.com/39129161/161771818-bc04f103-6d3a-45ad-ba09-b2384f472dc5.png)

After
![image](https://user-images.githubusercontent.com/39129161/161771946-3dcfb95a-5363-4cd5-8552-b46d9d5a1522.png)
