### PR TITLE
Don't run build script for old crd docs by default

### DIFF
--- a/scripts/gendocs/generate
+++ b/scripts/gendocs/generate
@@ -24,4 +24,9 @@ set -o pipefail
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
 ${REPO_ROOT}/scripts/gendocs/generate-new-import-path-docs
-${REPO_ROOT}/scripts/gendocs/generate-old-import-path-docs
+
+###### WARNING ######
+# If you uncomment the below line to build API docs with the import path "github.com/jetstack/cert-manager",
+# you'll also need to uncomment versions in "${REPO_ROOT}/scripts/gendocs/generate-old-import-path-docs"
+###### WARNING ######
+# ${REPO_ROOT}/scripts/gendocs/generate-old-import-path-docs

--- a/scripts/gendocs/generate-old-import-path-docs
+++ b/scripts/gendocs/generate-old-import-path-docs
@@ -210,6 +210,13 @@ generate_release16() {
     gendocs "v1.6-docs"
 }
 
+###### WARNING ######
+# If you uncomment any of the below lines,
+# you'll also need to uncomment
+# "${REPO_ROOT}/scripts/gendocs/generate-old-import-path-docs" in "scripts/gendocs/generate"
+# for any of the below to be used!
+###### WARNING ######
+
 #genversionwithcli "release-1.7" "v1.7-docs"
 #generate_release16
 #genversionwithcli "release-1.5" "v1.5-docs"
@@ -224,4 +231,4 @@ generate_release16() {
 #genversionwithcli "release-0.13" "v0.13-docs"
 #genversionwithcli "release-0.12" "v0.12-docs"
 
-echo "Generated reference documentation for cert-manager versions with an old github.com/jetstack/cert-manager import path"
+# echo "Generated reference documentation for cert-manager versions with an old github.com/jetstack/cert-manager import path"


### PR DESCRIPTION
This avoids re-running setup steps when the old versions are not being built. since building the old versions is a manual process anyway, we might as well add an extra step to that manual process and save time on our CI