### PR TITLE
Correct "cloud native" capitalisation

### DIFF
--- a/content/pages/homepage.mdx
+++ b/content/pages/homepage.mdx
@@ -2,7 +2,7 @@ export const meta = {
   title: 'cert-manager',
   description: '',
   hero: {
-    heading: 'Cloud Native certificate management',
+    heading: 'Cloud native certificate management',
     description: 'X.509 certificate management for Kubernetes and OpenShift',
     image: '/images/cert-manager-graphic.svg'
   },


### PR DESCRIPTION
The CNCF style guide [0] defines that the term "cloud native" should follow standard capitlisation rules. As the rest of the headline is in sentance case, the "n" in "cloud native" should also be lowercase.

[0] https://github.com/cncf/foundation/blob/main/style-guide.md