### PR TITLE
Changed Github org from jetstack to cert-manager

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,5 @@
 
 Security is the number one priority for cert-manager. If you think you've
 found a vulnerability in the cert-manager website, or in any cert-manager
-project, please follow the [vulnerability reporting process](https://github.com/jetstack/cert-manager/blob/master/SECURITY.md)
+project, please follow the [vulnerability reporting process](https://github.com/cert-manager/cert-manager/blob/master/SECURITY.md)
 documented in the main cert-manager repository.

--- a/content/docs/configuration/acme/dns01/acme-dns.md
+++ b/content/docs/configuration/acme/dns01/acme-dns.md
@@ -124,7 +124,7 @@ Information about setting up and configuring ACMEDNS is available on the
 ## Limitation of the `acme-dns` server
 
 The [`acme-dns`](https://github.com/joohoi/acme-dns) server has a [known
-limitation](https://github.com/jetstack/cert-manager/issues/3610#issuecomment-849792721):
+limitation](https://github.com/cert-manager/cert-manager/issues/3610#issuecomment-849792721):
 when a set of credentials is used with more than 2 domains, cert-manager
 will fail solving the DNS01 challenges.
 

--- a/content/docs/configuration/selfsigned.md
+++ b/content/docs/configuration/selfsigned.md
@@ -157,6 +157,6 @@ To avoid this, be sure to set a Subject for `SelfSigned` certs. This can be
 done by setting the `spec.subject` on a cert-manager `Certificate` object
 which will be issued by a `SelfSigned` issuer.
 
-Starting in version 1.3, cert-manager will emit a Kubernetes [warning event](https://github.com/jetstack/cert-manager/blob/45befd86966c563663d18848943a1066d9681bf8/pkg/controller/certificaterequests/selfsigned/selfsigned.go#L140)
+Starting in version 1.3, cert-manager will emit a Kubernetes [warning event](https://github.com/cert-manager/cert-manager/blob/45befd86966c563663d18848943a1066d9681bf8/pkg/controller/certificaterequests/selfsigned/selfsigned.go#L140)
 of type `BadConfig` if it detects that a certificate is being created
 by a `SelfSigned` issuer which has an empty Issuer DN.

--- a/content/docs/contributing/building.md
+++ b/content/docs/contributing/building.md
@@ -122,4 +122,4 @@ cert-manager has 3 kinds of tests, which can each be invoked separately to give 
 ## But... I like Makefiles more
 
 We got you covered! The root of the repo has a `Makefile` which you can use for quick actions. Which will use Bazel in the background.
-We recommend [looking at the file](https://github.com/jetstack/cert-manager/blob/master/Makefile) to learn all possible options.
+We recommend [looking at the file](https://github.com/cert-manager/cert-manager/blob/master/Makefile) to learn all possible options.

--- a/content/docs/contributing/coding-conventions.md
+++ b/content/docs/contributing/coding-conventions.md
@@ -26,7 +26,7 @@ import (
 ```
 
 An example might be the following, taken from
-[`pkg/acme/accounts/client.go`](https://github.com/jetstack/cert-manager/blob/0c71fe7795858b96cabcddabf706d997cd2fba3f/pkg/acme/accounts/client.go):
+[`pkg/acme/accounts/client.go`](https://github.com/cert-manager/cert-manager/blob/0c71fe7795858b96cabcddabf706d997cd2fba3f/pkg/acme/accounts/client.go):
 
 ```go
 import (
@@ -38,11 +38,11 @@ import (
 
 	acmeapi "golang.org/x/crypto/acme"
 
-	acmecl "github.com/jetstack/cert-manager/pkg/acme/client"
-	acmeutil "github.com/jetstack/cert-manager/pkg/acme/util"
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
-	"github.com/jetstack/cert-manager/pkg/metrics"
-	"github.com/jetstack/cert-manager/pkg/util"
+	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
+	acmeutil "github.com/cert-manager/cert-manager/pkg/acme/util"
+	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	"github.com/cert-manager/cert-manager/pkg/metrics"
+	"github.com/cert-manager/cert-manager/pkg/util"
 )
 ```
 

--- a/content/docs/contributing/contributing-flow.md
+++ b/content/docs/contributing/contributing-flow.md
@@ -4,7 +4,7 @@ description: 'cert-manager contributing guide: Contribution flow'
 ---
 
 All of cert-manager's development is done via
-[GitHub](https://github.com/jetstack/cert-manager) which contains code, issues and pull
+[GitHub](https://github.com/cert-manager/cert-manager) which contains code, issues and pull
 requests.
 
 All code for the documentation and cert-manager.io can be found at [the cert-manager/website repo](https://github.com/cert-manager/website/).
@@ -20,7 +20,7 @@ Prow will also run all tests and assign certain labels on PRs.
 ## Bugs
 
 All bugs should be tracked as issues inside the
-[GitHub](https://github.com/jetstack/cert-manager/issues) repository. Issues should then be
+[GitHub](https://github.com/cert-manager/cert-manager/issues) repository. Issues should then be
 attached with the `kind/bug` tag. To do this add `/kind bug` to your issue description.
 This may then be assigned a priority and milestone to be addressed in a future release.
 
@@ -43,7 +43,7 @@ Prow can assist you to reopen or close issues you file, you can trigger it using
 ## Features
 
 Feature requests should be created as
-[GitHub](https://github.com/jetstack/cert-manager/issues) issues. They should contain
+[GitHub](https://github.com/cert-manager/cert-manager/issues) issues. They should contain
 clear motivation for the feature you wish to see as well as some possible
 solutions for how it can be implemented.
 Issues should then be tagged with `kind/feature`. To do this add `/kind feature` to your issue description.
@@ -56,7 +56,7 @@ Issues should then be tagged with `kind/feature`. To do this add `/kind feature`
 ## Creating Pull Requests
 
 Changes to the cert-manager code base is done via [pull
-requests](https://github.com/jetstack/cert-manager/pulls). Each pull request
+requests](https://github.com/cert-manager/cert-manager/pulls). Each pull request
 should ideally have a corresponding issue attached that is to be fixed by this
 pull request. It is valid for multiple pull requests to resolve a single issue
 in the interest of keeping code changes self contained and simpler to review.
@@ -99,7 +99,7 @@ Most of cert-manager's project management is done on GitHub, with the help of Pr
 
 ### When will something be released?
 
-Our team works using [GitHub milestones](https://github.com/jetstack/cert-manager/milestones).
+Our team works using [GitHub milestones](https://github.com/cert-manager/cert-manager/milestones).
 When a milestone is set on an Issue it is generally an indication of when we plan to address this.
 Prow will apply milestones on merged PRs, this will tell you in which version that PR will land.
 

--- a/content/docs/contributing/dns-providers.md
+++ b/content/docs/contributing/dns-providers.md
@@ -12,7 +12,7 @@ DNS providers via way of an external webhook.
 
 To implement an external DNS provider webhook, it is recommended to base your
 implementation on the [example
-repository](https://github.com/jetstack/cert-manager-webhook-example). Please
+repository](https://github.com/cert-manager/webhook-example). Please
 reach out on the `cert-manager-dev` channel on the [community
 slack](https://slack.k8s.io) for advise and guidance on getting a DNS webhook
 running and released.

--- a/content/docs/contributing/e2e.md
+++ b/content/docs/contributing/e2e.md
@@ -119,4 +119,4 @@ terraform apply -var="cert_manager_version=v1.3.3" -auto-approve
 
 To see a list of all configurable variables present for a particular infrastructure you can see the `variables.tf` file for that cloud provider's [infrastructure](https://github.com/cert-manager/test-infra).
 
-> Please note that the cloud provider tests run the e2e tests present in the **master** branch of cert-manager on a predefined version of cert-manager (can be changed in the prow job). Currently, they do **not** test code in a PR, but we have an [issue](https://github.com/jetstack/cert-manager/issues/4349) tracking that request.
+> Please note that the cloud provider tests run the e2e tests present in the **master** branch of cert-manager on a predefined version of cert-manager (can be changed in the prow job). Currently, they do **not** test code in a PR, but we have an [issue](https://github.com/cert-manager/cert-manager/issues/4349) tracking that request.

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -30,7 +30,7 @@ following conditions:
     ```sh
     brew install gh
     gh auth login
-    gh api /repos/jetstack/cert-manager/collaborators/$(gh api /user | jq -r .login)/permission | jq .permission
+    gh api /repos/cert-manager/cert-manager/collaborators/$(gh api /user | jq -r .login)/permission | jq .permission
     ```
 
     If your permission is `admin`, then you are good to go. To request the
@@ -188,7 +188,7 @@ page if a step is missing or if it is outdated.
 
     1. Check that the `origin` remote is correct. To do that, run the following
         command and make sure it returns
-        the upstream `https://github.com/jetstack/cert-manager.git`:
+        the upstream `https://github.com/cert-manager/cert-manager.git`:
 
         ```sh
         # Must be run from the cert-manager repo folder.
@@ -288,12 +288,12 @@ page if a step is missing or if it is outdated.
         - Add additional blurb, notable items and characterize change log.
 
         You can see the commits that will go into this release by using the
-        [GitHub compare](https://github.com/jetstack/cert-manager/compare). For
+        [GitHub compare](https://github.com/cert-manager/cert-manager/compare). For
         example, while releasing `v1.0.0`, you want to compare it with the
         latest pre-released version `v1.0.0-beta.1`:
 
         ```text
-        https://github.com/jetstack/cert-manager/compare/v1.0.0-beta.1...master
+        https://github.com/cert-manager/cert-manager/compare/v1.0.0-beta.1...master
         ```
 
     4. **(final release only)** Check the release notes include all changes
@@ -434,7 +434,7 @@ page if a step is missing or if it is outdated.
    visible. Also cross-post the message on `#cert-manager`.
 
     <div className="pageinfo pageinfo-primary"><p>
-    https://github.com/jetstack/cert-manager/releases/tag/v1.0.0 🎉
+    https://github.com/cert-manager/cert-manager/releases/tag/v1.0.0 🎉
     </p></div>
 
 12. **(final release only)** Show the release to the world:
@@ -503,7 +503,7 @@ page if a step is missing or if it is outdated.
        example](https://github.com/jetstack/testing/pull/397/files).
 
     6. **(final release only)** Push a new release branch to
-       [`jetstack/cert-manager`](https://github.com/jetstack/cert-manager). If the
+       [`cert-manager/cert-manager`](https://github.com/cert-manager/cert-manager). If the
        final release is `v1.0.0`, then push the new branch `release-1.1`:
 
         ```bash

--- a/content/docs/contributing/security.md
+++ b/content/docs/contributing/security.md
@@ -5,9 +5,9 @@ description: 'cert-manager contributing: Security policy'
 
 Security is the number one priority for cert-manager. If you think you've
 found a vulnerability in any cert-manager project, please follow the
-[vulnerability reporting process](https://github.com/jetstack/cert-manager/blob/master/SECURITY.md)
+[vulnerability reporting process](https://github.com/cert-manager/cert-manager/blob/master/SECURITY.md)
 documented in the main cert-manager repository.
 
 The reporting process is the same for all repositories under the
 cert-manager organization. The process is documented in one place to ensure
-a single source of truth and a single list of [security contacts](https://github.com/jetstack/cert-manager/blob/master/SECURITY_CONTACTS.md).
+a single source of truth and a single list of [security contacts](https://github.com/cert-manager/cert-manager/blob/master/SECURITY_CONTACTS.md).

--- a/content/docs/contributing/third-party-code-donation.md
+++ b/content/docs/contributing/third-party-code-donation.md
@@ -23,7 +23,7 @@ and containerd.
 
 1.  Code must be licensed appropriately, including any dependencies   
     We'd prefer [Apache 2.0](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)) since that's
-    what cert-manager [uses](https://github.com/jetstack/cert-manager/blob/master/LICENSE), but the
+    what cert-manager [uses](https://github.com/cert-manager/cert-manager/blob/master/LICENSE), but the
     license must be [OSI approved](https://opensource.org/licenses).
 2.  Code must conform to CNCF standards and due diligence requirements   
     You don't need to go over this with a fine-toothed comb; the intent here is that no code donation
@@ -34,7 +34,7 @@ and containerd.
     donation. This ensures that there's a single point of contact for the party donating the code.
 4.  Must pass cert-manager conformance tests   
     This might not apply to all donations, but where conformance tests exist any donated code must
-    pass them. E.g. for [external issuers](https://github.com/jetstack/cert-manager/blob/dffbf391dbb0fc6c1cfea62e561a9c6f54362ab0/test/e2e/suite/conformance/certificates/external/external.go#L41-L62)
+    pass them. E.g. for [external issuers](https://github.com/cert-manager/cert-manager/blob/dffbf391dbb0fc6c1cfea62e561a9c6f54362ab0/test/e2e/suite/conformance/certificates/external/external.go#L41-L62)
 5.  Must provide a point-of-contact for questions about the project for at least 3 months after acceptance
     We don't anticipate that we'd need to reach out often after the donation has been accepted,
     but it's important to have someone we can reach out to if we need to.
@@ -65,7 +65,7 @@ These items are not absolutely necessary but they definitely help if a code dona
 As a method of ensuring that the donator has permission to donate the code, we require DCO sign-offs -
 or something equivalent - to be in place at the time of the donation.
 
-The cert-manager [DCO signoff process](https://github.com/jetstack/cert-manager/blob/master/CONTRIBUTING.md#dco-sign-off)
+The cert-manager [DCO signoff process](https://cert-manager.io/docs/contributing/sign-off/)
 would be appropriate. Existing contributors could bootstrap this process by creating an empty signed-off
 with a note that previous code should be considered signed off as of that commit:
 
@@ -76,4 +76,4 @@ git commit --allow-empty --signoff --message="bootstrapping DCO signoff for past
 ## After Donation
 
 Code files in the donated repository must be updated to include the relevant 
-[cert-manger boilerplate](https://github.com/jetstack/cert-manager/blob/master/hack/boilerplate/boilerplate.go.txt)
+[cert-manger boilerplate](https://github.com/cert-manager/cert-manager/blob/master/hack/boilerplate/boilerplate.go.txt)

--- a/content/docs/faq/README.md
+++ b/content/docs/faq/README.md
@@ -85,7 +85,7 @@ spec:
 
 ### If `renewBefore` or `duration` is not defined, what will be the default value?
 
-Default `duration` is [90 days](https://github.com/jetstack/cert-manager/blob/v1.2.0/pkg/apis/certmanager/v1/const.go#L26). If `renewBefore` has not been set, `Certificate` will be renewed 2/3 through its _actual_ duration.
+Default `duration` is [90 days](https://github.com/cert-manager/cert-manager/blob/v1.2.0/pkg/apis/certmanager/v1/const.go#L26). If `renewBefore` has not been set, `Certificate` will be renewed 2/3 through its _actual_ duration.
 
 ## Miscellaneous
 

--- a/content/docs/installation/compatibility.md
+++ b/content/docs/installation/compatibility.md
@@ -20,7 +20,7 @@ when installing cert-manager either using a command line flag or an entry in
 your `values.yaml` file.
 
 If you have a port clash, you could see confusing error messages regarding
-untrusted certs. See [#3237](https://github.com/jetstack/cert-manager/issues/3237)
+untrusted certs. See [#3237](https://github.com/cert-manager/cert-manager/issues/3237)
 for more details.
 </div>
 
@@ -48,7 +48,7 @@ docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#ad
 ### GKE Autopilot
 
 GKE Autopilot mode with Kubernetes < 1.21 does not support cert-manager,
-due to a [restriction on mutating admission webhooks](https://github.com/jetstack/cert-manager/issues/3717).
+due to a [restriction on mutating admission webhooks](https://github.com/cert-manager/cert-manager/issues/3717).
 
 As of October 2021, only the "rapid" Autopilot release channel has rolled
 out version 1.21 for Kubernetes masters. Installation via the helm chart
@@ -73,7 +73,7 @@ port; see the warning at the top of the page for details.
 
 It's worth noting that using AWS Fargate doesn't allow much network configuration and
 will cause the webhook's port to clash with the kubelet running on port 10250, as seen
-in [#3237](https://github.com/jetstack/cert-manager/issues/3237).
+in [#3237](https://github.com/cert-manager/cert-manager/issues/3237).
 
 When deploying cert-manager on Fargate, you _must_ change the port on which
 the webhook listens. See the warning at the top of this page for more details.

--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -103,7 +103,7 @@ The `Certificate` will be issued using the issuer named `ca-issuer` in the
 > using `s`, `m`, and `h` suffixes instead. Failing to do so without installing
 > the [`webhook component`](../concepts/webhook.md) can prevent cert-manager
 > from functioning correctly
-> [`#1269`](https://github.com/jetstack/cert-manager/issues/1269).
+> [`#1269`](https://github.com/cert-manager/cert-manager/issues/1269).
 
 > Note: Take care when setting the `renewBefore` field to be very close to the
 > `duration` as this can lead to a renewal loop, where the `Certificate` is always
@@ -143,7 +143,7 @@ ingress controller, `ingress-gce`
 [required](https://github.com/kubernetes/ingress-gce/pull/388) a temporary
 certificate must be present while waiting for the issuance of a signed
 certificate. Note that this issue was
-[solved](https://github.com/jetstack/cert-manager/issues/606#issuecomment-424397233)
+[solved](https://github.com/cert-manager/cert-manager/issues/606#issuecomment-424397233)
 in `1.10.7-gke.2`.
 
 ```yaml

--- a/content/docs/usage/cmctl.md
+++ b/content/docs/usage/cmctl.md
@@ -14,7 +14,7 @@ to use as a stand alone binary as this allows the use of command
 
 You need the `cmctl.tar.gz` file for the platform you're using, these can be
 found on our
-[GitHub releases page](https://github.com/jetstack/cert-manager/releases).
+[GitHub releases page](https://github.com/cert-manager/cert-manager/releases).
 In order to use `cmctl` you need its binary to be accessible under
 the name `cmctl` in your `$PATH`.
 Run the following commands to set up the CLI. Replace OS and ARCH with your

--- a/content/docs/usage/csi.md
+++ b/content/docs/usage/csi.md
@@ -155,7 +155,7 @@ certificate is available from the Pods file system at `/tls/key.pem` and
 Below is a full list of the available volume attributes to configure resulting
 key certificate pairs.
 
-The full list of usage keys is available [from code](https://github.com/jetstack/cert-manager/blob/57034dc1e47d0231d781cb8fe1ab58375fab5faf/pkg/apis/certmanager/v1/types.go#L167-L191).
+The full list of usage keys is available [from code](https://github.com/cert-manager/cert-manager/blob/57034dc1e47d0231d781cb8fe1ab58375fab5faf/pkg/apis/certmanager/v1/types.go#L167-L191).
 
 | Attribute                                | Description                                                                                           | Default                              | Example                          |
 |------------------------------------------|-------------------------------------------------------------------------------------------------------|--------------------------------------|----------------------------------|

--- a/content/docs/usage/kubectl-plugin.md
+++ b/content/docs/usage/kubectl-plugin.md
@@ -12,7 +12,7 @@ While the kubectl plugin is supported, it is recommended to use
 
 ## Installation
 
-You need the `kubectl-cert-manager.tar.gz` file for the platform you're using, these can be found on our [GitHub releases page](https://github.com/jetstack/cert-manager/releases).
+You need the `kubectl-cert-manager.tar.gz` file for the platform you're using, these can be found on our [GitHub releases page](https://github.com/cert-manager/cert-manager/releases).
 In order to use the kubectl plugin you need its binary to be accessible under the name `kubectl-cert_manager` in your `$PATH`.
 
 ### macOS/Linux

--- a/content/docs/usage/prometheus-metrics.md
+++ b/content/docs/usage/prometheus-metrics.md
@@ -11,7 +11,7 @@ How metrics are scraped will depend how you're operating your Prometheus server(
 
 ### Helm
 
-If you're deploying cert-manager with helm, a `ServiceMonitor` resource can be configured. This configuration should enable metric scraping, and the configuration can be further tweaked as described in the [Helm configuration documentation](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#configuration).
+If you're deploying cert-manager with helm, a `ServiceMonitor` resource can be configured. This configuration should enable metric scraping, and the configuration can be further tweaked as described in the [Helm configuration documentation](https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#configuration).
 
 ```yaml
 prometheus:

--- a/content/pages/homepage.mdx
+++ b/content/pages/homepage.mdx
@@ -24,7 +24,7 @@ export const meta = {
     ctas: [
       {
         icon: 'github',
-        href: 'https://github.com/jetstack/cert-manager',
+        href: 'https://github.com/cert-manager/cert-manager',
         caption: 'Github Repository',
         target: '_blank'
       },


### PR DESCRIPTION
(This PR only changes the current docs and leaves all the release notes untouched)

This PR changes a lot of references from jetstack/cert-manager to cert-manager/cert-manager. While there are redirects in Github so the links are not broken, this could be slightly confusing.

/kind cleanup