### PR TITLE
add external link to Netcup ACME webhook

### DIFF
--- a/content/v1.7-docs/configuration/acme/dns01/README.md
+++ b/content/v1.7-docs/configuration/acme/dns01/README.md
@@ -178,6 +178,7 @@ Links to these supported providers along with their documentation are below:
 - [`bizflycloud-certmanager-dns-webhook`](https://github.com/bizflycloud/bizflycloud-certmanager-dns-webhook)
 - [`cert-manager-webhook-hetzner`](https://github.com/vadimkim/cert-manager-webhook-hetzner)
 - [`cert-manager-webhook-yandex-cloud`](https://github.com/malinink/cert-manager-webhook-yandex-cloud)
+- [`cert-manager-webhook-netcup`](https://github.com/aellwein/cert-manager-webhook-netcup)
 
 You can find more information on how to configure webhook providers [here](./webhook.md).
 

--- a/content/v1.8-docs/configuration/acme/dns01/README.md
+++ b/content/v1.8-docs/configuration/acme/dns01/README.md
@@ -178,6 +178,7 @@ Links to these supported providers along with their documentation are below:
 - [`bizflycloud-certmanager-dns-webhook`](https://github.com/bizflycloud/bizflycloud-certmanager-dns-webhook)
 - [`cert-manager-webhook-hetzner`](https://github.com/vadimkim/cert-manager-webhook-hetzner)
 - [`cert-manager-webhook-yandex-cloud`](https://github.com/malinink/cert-manager-webhook-yandex-cloud)
+- [`cert-manager-webhook-netcup`](https://github.com/aellwein/cert-manager-webhook-netcup)
 
 You can find more information on how to configure webhook providers [here](./webhook.md).
 


### PR DESCRIPTION
Add external link to Netcup ACME webhook for 1.7/1.8 docs.

Fixes cert-manager/cert-manager#5079.

Signed-off-by: Alex Ellwein <alex.ellwein@gmail.com>