### PR TITLE
Add public docssearch variables to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,5 @@
 
 [context.production.environment]
 	NEXT_PUBLIC_ENABLE_ANALYTICS = "true"
+	NEXT_PUBLIC_DOCS_SEARCH_APP_ID = "18N9PEKHUC"
+	NEXT_PUBLIC_DOCS_SEARCH_INDEX_NAME = "cert-manager-latest"


### PR DESCRIPTION
Taken from an old config file on the site [here](https://github.com/cert-manager/website/blob/5156d36f802dca01ad406b2734bb22cad05d45ed/config/_default/config.toml#L95-L97)

We also want to set `NEXT_PUBLIC_DOCS_SEARCH_API_KEY` in netlify config but that's:

1. Private and can't be checked into source
2. Not something we currently know :grin: 