### PR TITLE
Use NEXT_PUBLIC_URL to configure the site base URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,10 @@
 NEXT_PUBLIC_DOCS_SEARCH_APP_ID=18N9PEKHUC
 NEXT_PUBLIC_DOCS_SEARCH_INDEX_NAME=cert-manager-latest
 NEXT_PUBLIC_DOCS_SEARCH_API_KEY=
+
+# All environment variables that are prefixed with NEXT_PUBLIC_ can be
+# referenced using process.env.NEXT_PUBLIC_<VARIABLE_NAME> and be accessible
+# from the browser (i.e., not just during the webpack build). See:
+# https://docs.netlify.com/configure-builds/environment-variables.
+
+NEXT_PUBLIC_URL=http://localhost:3000

--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,14 +1,12 @@
-const deployUrl = 'https://cert-manager.io'
-
 export default {
   openGraph: {
     type: 'website',
     locale: 'en_EN',
-    url: `${deployUrl}`,
+    url: `${process.env.NEXT_PUBLIC_URL}`,
     site_name: 'cert-manager',
     images: [
       {
-        url: `${deployUrl}/images/og1.png`,
+        url: `${process.env.NEXT_PUBLIC_URL}/images/og1.png`,
         width: 1200,
         height: 630,
         alt: 'cert-manager — automated Kubernetes X.509 certificates'

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,5 +1,5 @@
 module.exports = {
-  siteUrl: 'https://cert-manager-io',
+  siteUrl: process.env.NEXT_PUBLIC_URL,
   generateRobotsTxt: true,
   changefreq: 'daily',
   priority: 0.7,


### PR DESCRIPTION
This fixes the sitemap.xml that is currently totally broken, as well as the og:image tag on deploy builds that didn't have the correct URL.

The http://cert-manager.io/sitemap.xml looks like this currently:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<sitemap><loc>https://cert-manager-io/sitemap-0.xml</loc></sitemap>
</sitemapindex>% 
```

and https://cert-manager.io/sitemap-0.xml looks like this:

```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
<url><loc>https://cert-manager-io/</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-05T10:49:36.025Z</lastmod></url>
<url><loc>https://cert-manager-io/support/</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-05T10:49:36.025Z</lastmod></url>
<url><loc>https://cert-manager-io/docs/</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-05T10:49:36.025Z</lastmod></url>
<url><loc>https://cert-manager-io/docs/README/</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-05T10:49:36.025Z</lastmod></url>
<url><loc>https://cert-manager-io/docs/installation/</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-05T10:49:36.025Z</lastmod></url>
...
```

Also, the `og:image` tag is off on deploy builds, for example:

```html
<meta property="og:url" content="https://deploy-preview-963--cert-manager.netlify.app/">
<meta property="og:type" content="website">
<meta property="og:title" content="cert-manager">
<meta property="og:description" content="Cloud native X.509 certificate management for Kubernetes and OpenShift">
<meta property="og:image" content="https://cert-manager.io/images/og1.png">
<!--                               ^^^^^^^^^^^^^^^^^^^^^^^                 -->
```

I would expect the following:

```html
<meta property="og:image" content="https://deploy-preview-963--cert-manager.netlify.app/images/og1.png">
<!--                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                 -->
```

With this change, the URL should be correct in all cases:
- set to `https://localhost:3000` when running `npm run dev` and `npm run build` (aka local dev),
- set to `$NEXT_PUBLIC_URL` if you need to `npm run build && npm run export` with an actual site URL,
- set to whatever $URL points to on Netlify (for both master and deploy builds).


