### PR TITLE
Fix broken links across the site

### DIFF
--- a/content/docs/installation/kubectl.md
+++ b/content/docs/installation/kubectl.md
@@ -7,7 +7,7 @@ description: 'cert-manager installation: Using static manifests'
 
 ### Prerequisites
 
-- [Install `kubectl` version `>= v1.19.0`](https://kubernetes.io/docs/tasks/tools/). (otherwise, you'll have issues updating the CRDs - see [v0.16 upgrade notes](../../../installation/upgrading/upgrading-0.15-0.16/#issue-with-older-versions-of-kubectl))
+- [Install `kubectl` version `>= v1.19.0`](https://kubernetes.io/docs/tasks/tools/). (otherwise, you'll have issues updating the CRDs - see [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl))
 - Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
@@ -57,15 +57,15 @@ following command:
 ```bash
 kubectl get Issuers,ClusterIssuers,Certificates,CertificateRequests,Orders,Challenges --all-namespaces
 ```
-It is recommended that you delete all these resources before uninstalling cert-manager. 
-If plan on reinstalling later and don't want to lose some custom resources, you can keep them. 
-However, this can potentially lead to problems with finalizers. Some resources, like 
-`Challenges`, should be deleted to avoid [getting stuck in a pending state](#namespace-stuck-in-terminating-state). 
+It is recommended that you delete all these resources before uninstalling cert-manager.
+If plan on reinstalling later and don't want to lose some custom resources, you can keep them.
+However, this can potentially lead to problems with finalizers. Some resources, like
+`Challenges`, should be deleted to avoid [getting stuck in a pending state](#namespace-stuck-in-terminating-state).
 
 Once the unneeded resources have been deleted, you are ready to uninstall
 cert-manager using the procedure determined by how you installed.
 
-> **Warning**: Uninstalling cert-manager or simply deleting a `Certificate` resource can result in 
+> **Warning**: Uninstalling cert-manager or simply deleting a `Certificate` resource can result in
 > TLS `Secret`s being deleted if they have `metadata.ownerReferences` set by cert-manager.
 > You can control whether owner references are added to `Secret`s using the `--enable-certificate-owner-ref` controller flag. 
 > By default, this flag is set to false, which means that no owner references are added. 
@@ -105,11 +105,11 @@ kubectl delete apiservice v1beta1.webhook.cert-manager.io
 
 #### Deleting pending challenges
 
-`Challenge`s can get stuck in a pending state when the finalizer is unable to complete 
-and Kubernetes is waiting for the cert-manager controller to finish. 
-This happens when the controller is no longer running to remove the flag, 
+`Challenge`s can get stuck in a pending state when the finalizer is unable to complete
+and Kubernetes is waiting for the cert-manager controller to finish.
+This happens when the controller is no longer running to remove the flag,
 and the resources are defined as needing to wait.
-You can fix this problem by doing what the controller does manually. 
+You can fix this problem by doing what the controller does manually.
 
 First, delete existing cert-manager webhook configurations, if any:
 

--- a/content/docs/installation/upgrading/README.md
+++ b/content/docs/installation/upgrading/README.md
@@ -88,7 +88,7 @@ number you want to install:
 $ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<version>/cert-manager.yaml
 ```
 
-Once you have deployed the new version of cert-manager, you can [verify](../../verify.md) the installation.
+Once you have deployed the new version of cert-manager, you can [verify](../verify.md) the installation.
 
 ## Reinstalling cert-manager
 

--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -340,7 +340,7 @@ spec:
 ## Supported Annotations
 
 If you are migrating to Gateway resources from Ingress resources, be aware that
-there are some differences between [the annotations for Ingress resources](ingress.md#supported-annotations)
+there are some differences between [the annotations for Ingress resources](./ingress.md#supported-annotations)
 versus the annotations for Gateway resources.
 
 The Gateway resource supports the following annotations for generating

--- a/content/next-docs/installation/upgrading/README.md
+++ b/content/next-docs/installation/upgrading/README.md
@@ -10,7 +10,7 @@ versions, and information on things to look out for when upgrading.
 > Note: Before performing upgrades of cert-manager, it is advised to take a
 > backup of all your cert-manager resources just in case an issue occurs whilst
 > upgrading. You can read how to backup and restore cert-manager in the [backup
-> and restore](../tutorials/backup.md) guide.
+> and restore](../../tutorials/backup.md) guide.
 
 We recommend that you upgrade cert-manager one minor version at a time, always
 choosing the latest patch version for the minor version. You should always read

--- a/content/next-docs/installation/upgrading/upgrading-0.10-0.11.md
+++ b/content/next-docs/installation/upgrading/upgrading-0.10-0.11.md
@@ -20,7 +20,7 @@ resources, will need to be updated to reflect these changes.
 This upgrade should be performed in a few steps:
 
 1. Back up existing cert-manager resources, as per the
-   [backup and restore guide](../../../tutorials/backup.md).
+   [backup and restore guide](../../tutorials/backup.md).
 
 2. [Uninstall cert-manager](../uninstall.md).
 

--- a/content/next-docs/manifest.json
+++ b/content/next-docs/manifest.json
@@ -610,8 +610,32 @@
             {
               "title": "Introduction",
               "path": "/next-docs/cli/README.md"
+            },
+            {
+              "title": "acmesolver",
+              "path": "/next-docs/cli/acmesolver.md"
+            },
+            {
+              "title": "cainjector",
+              "path": "/next-docs/cli/cainjector.md"
+            },
+            {
+              "title": "cmctl",
+              "path": "/next-docs/cli/cmctl.md"
+            },
+            {
+              "title": "controller",
+              "path": "/next-docs/cli/controller.md"
+            },
+            {
+              "title": "webhook",
+              "path": "/next-docs/cli/webhook.md"
             }
           ]
+        },
+        {
+          "title": "API reference",
+          "path": "/next-docs/reference/api-docs.md"
         }
       ]
     }

--- a/content/v0.12-docs/configuration/acme/dns01/README.md
+++ b/content/v0.12-docs/configuration/acme/dns01/README.md
@@ -128,4 +128,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v0.12-docs/configuration/acme/dns01/webhook.md
+++ b/content/v0.12-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v0.12-docs/configuration/external.md
+++ b/content/v0.12-docs/configuration/external.md
@@ -24,4 +24,4 @@ authors are as follows:
   Authority server](https://github.com/smallstep/certificates).
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v0.12-docs/installation/openshift.md
+++ b/content/v0.12-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v0.13-docs/configuration/acme/dns01/README.md
+++ b/content/v0.13-docs/configuration/acme/dns01/README.md
@@ -132,4 +132,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v0.13-docs/configuration/acme/dns01/webhook.md
+++ b/content/v0.13-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v0.13-docs/configuration/external.md
+++ b/content/v0.13-docs/configuration/external.md
@@ -24,4 +24,4 @@ authors are as follows:
   Authority server](https://github.com/smallstep/certificates).
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v0.13-docs/installation/openshift.md
+++ b/content/v0.13-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v0.14-docs/configuration/acme/dns01/README.md
+++ b/content/v0.14-docs/configuration/acme/dns01/README.md
@@ -161,4 +161,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v0.14-docs/configuration/acme/dns01/webhook.md
+++ b/content/v0.14-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v0.14-docs/configuration/external.md
+++ b/content/v0.14-docs/configuration/external.md
@@ -24,4 +24,4 @@ authors are as follows:
   Authority server](https://github.com/smallstep/certificates).
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v0.14-docs/installation/openshift.md
+++ b/content/v0.14-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v0.15-docs/configuration/acme/dns01/README.md
+++ b/content/v0.15-docs/configuration/acme/dns01/README.md
@@ -173,4 +173,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v0.15-docs/configuration/acme/dns01/webhook.md
+++ b/content/v0.15-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v0.15-docs/configuration/external.md
+++ b/content/v0.15-docs/configuration/external.md
@@ -24,4 +24,4 @@ authors are as follows:
   Authority server](https://github.com/smallstep/certificates).
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v0.15-docs/installation/openshift.md
+++ b/content/v0.15-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v0.16-docs/configuration/acme/dns01/README.md
+++ b/content/v0.16-docs/configuration/acme/dns01/README.md
@@ -173,4 +173,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v0.16-docs/configuration/acme/dns01/webhook.md
+++ b/content/v0.16-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v0.16-docs/configuration/external.md
+++ b/content/v0.16-docs/configuration/external.md
@@ -29,4 +29,4 @@ authors are as follows:
   for cloud native/hybrid environments.
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v0.16-docs/installation/kubernetes.md
+++ b/content/v0.16-docs/installation/kubernetes.md
@@ -31,7 +31,7 @@ All resources (the `CustomResourceDefinitions`, cert-manager, namespace, and the
 are included in a single YAML manifest file:
 
 > **Note**: If you're using a `kubectl` version below `v1.19.0-rc.1` you will have issues updating the CRDs.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
 
 
 Install the `CustomResourceDefinitions` and cert-manager itself:
@@ -138,7 +138,7 @@ This can either be done manually, using `kubectl`, or using the `installCRDs`
 option when installing the Helm chart.
 
 > **Note**: If you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`) `installCRDs` will not work with cert-manager `v0.16`.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#helm)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#helm)
 
 **Option 1: installing CRDs with `kubectl`**
 

--- a/content/v0.16-docs/installation/openshift.md
+++ b/content/v0.16-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v1.0-docs/configuration/acme/dns01/README.md
+++ b/content/v1.0-docs/configuration/acme/dns01/README.md
@@ -175,4 +175,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.0-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.0-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.0-docs/configuration/external.md
+++ b/content/v1.0-docs/configuration/external.md
@@ -37,4 +37,4 @@ authors are as follows:
   to enable TLS between Cloudflare edge and your Kubernetes workloads.
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.0-docs/installation/kubernetes.md
+++ b/content/v1.0-docs/installation/kubernetes.md
@@ -31,7 +31,7 @@ All resources (the `CustomResourceDefinitions`, cert-manager, namespace, and the
 are included in a single YAML manifest file:
 
 > **Note**: If you're using a `kubectl` version below `v1.19.0-rc.1` you will have issues updating the CRDs.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
+> For more info see the [v0.16 upgrade notes](../../docs/installation//upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
 
 
 Install the `CustomResourceDefinitions` and cert-manager itself:
@@ -138,7 +138,7 @@ This can either be done manually, using `kubectl`, or using the `installCRDs`
 option when installing the Helm chart.
 
 > **Note**: If you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`) `installCRDs` will not work with cert-manager `v0.16`.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#helm)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#helm)
 
 **Option 1: installing CRDs with `kubectl`**
 

--- a/content/v1.0-docs/installation/openshift.md
+++ b/content/v1.0-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v1.1-docs/configuration/acme/dns01/README.md
+++ b/content/v1.1-docs/configuration/acme/dns01/README.md
@@ -176,4 +176,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.1-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.1-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.1-docs/configuration/external.md
+++ b/content/v1.1-docs/configuration/external.md
@@ -49,4 +49,4 @@ authors are as follows:
 
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.1-docs/installation/kubernetes.md
+++ b/content/v1.1-docs/installation/kubernetes.md
@@ -31,7 +31,7 @@ All resources (the `CustomResourceDefinitions`, cert-manager, namespace, and the
 are included in a single YAML manifest file:
 
 > **Note**: If you're using a `kubectl` version below `v1.19.0-rc.1` you will have issues updating the CRDs.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
 
 
 Install the `CustomResourceDefinitions` and cert-manager itself:
@@ -120,7 +120,7 @@ This can either be done manually, using `kubectl`, or using the `installCRDs`
 option when installing the Helm chart.
 
 > **Note**: If you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`) `installCRDs` will not work with cert-manager `v0.16`.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#helm)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#helm)
 
 **Option 1: installing CRDs with `kubectl`**
 

--- a/content/v1.1-docs/installation/openshift.md
+++ b/content/v1.1-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v1.2-docs/configuration/acme/dns01/README.md
+++ b/content/v1.2-docs/configuration/acme/dns01/README.md
@@ -178,4 +178,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.2-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.2-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.2-docs/configuration/external.md
+++ b/content/v1.2-docs/configuration/external.md
@@ -49,4 +49,4 @@ authors are as follows:
 
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.2-docs/installation/kubernetes.md
+++ b/content/v1.2-docs/installation/kubernetes.md
@@ -31,7 +31,7 @@ All resources (the `CustomResourceDefinitions`, cert-manager, namespace, and the
 are included in a single YAML manifest file:
 
 > **Note**: If you're using a `kubectl` version below `v1.19.0-rc.1` you will have issues updating the CRDs.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
 
 
 Install the `CustomResourceDefinitions` and cert-manager itself:
@@ -105,7 +105,7 @@ This can either be done manually, using `kubectl`, or using the `installCRDs`
 option when installing the Helm chart.
 
 > **Note**: If you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`) `installCRDs` will not work with cert-manager `v0.16`.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#helm)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#helm)
 
 #### Option 1: installing CRDs with `kubectl`
 

--- a/content/v1.2-docs/installation/openshift.md
+++ b/content/v1.2-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v1.3-docs/configuration/acme/dns01/README.md
+++ b/content/v1.3-docs/configuration/acme/dns01/README.md
@@ -178,4 +178,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.3-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.3-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.3-docs/configuration/external.md
+++ b/content/v1.3-docs/configuration/external.md
@@ -57,4 +57,4 @@ are as follows. These issuers do _not_ honour
 
 
 To create your own external issuer type, please follow the guidance in the
-[development documentation](../contributing/external-issuers.md).
+[development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.3-docs/configuration/venafi.md
+++ b/content/v1.3-docs/configuration/venafi.md
@@ -34,7 +34,7 @@ resources, read the [Namespaces](../concepts/issuer.md#namespaces) section.
 With this update, the zone format changes from a UUID to a string of the form `<Application Name>\<Issuing Template Alias>`.
 Please read [cert-manager 1.2 to 1.3 upgrade notes][] and [Venafi Cloud Prerequisites][] for further information.
 
-[cert-manager 1.2 to 1.3 upgrade notes]: /docs/installation/upgrading/upgrading-1.2-1.3/
+[cert-manager 1.2 to 1.3 upgrade notes]: ../../docs/installation/upgrading/upgrading-1.2-1.3.md
 [Venafi Cloud Prerequisites]: https://github.com/Venafi/vcert/blob/v4.13.1/README-CLI-CLOUD.md#prerequisites
 
 In order to set up a Venafi Cloud `Issuer`, you must first create a Kubernetes

--- a/content/v1.3-docs/installation/kubernetes.md
+++ b/content/v1.3-docs/installation/kubernetes.md
@@ -31,7 +31,7 @@ All resources (the `CustomResourceDefinitions`, cert-manager, namespace, and the
 are included in a single YAML manifest file:
 
 > **Note**: If you're using a `kubectl` version below `v1.19.0-rc.1` you will have issues updating the CRDs.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl)
 
 
 Install the `CustomResourceDefinitions` and cert-manager itself:
@@ -105,7 +105,7 @@ This can either be done manually, using `kubectl`, or using the `installCRDs`
 option when installing the Helm chart.
 
 > **Note**: If you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`) `installCRDs` will not work with cert-manager `v0.16`.
-> For more info see the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#helm)
+> For more info see the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#helm)
 
 #### Option 1: installing CRDs with `kubectl`
 

--- a/content/v1.3-docs/installation/openshift.md
+++ b/content/v1.3-docs/installation/openshift.md
@@ -4,7 +4,7 @@ description: 'cert-manager installation: OpenShift'
 ---
 
 cert-manager supports running on OpenShift in a similar manner to [Running on
-Kubernetes](.kubernetes.md).  It runs within your OpenShift cluster as a series
+Kubernetes](./kubernetes.md).  It runs within your OpenShift cluster as a series
 of deployment resources. It utilizes
 [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources)
 to configure Certificate Authorities and request certificates.
@@ -51,7 +51,7 @@ resource is deployed to validate cert-manager resources we will create after
 installation.  No mutating webhooks are currently implemented.
 
 You can read more about the webhook on the [webhook
-document](../../concepts/webhook.md).
+document](../concepts/webhook.md).
 
 We can now go ahead and install cert-manager. All resources
 (the `CustomResourceDefinitions`, cert-manager, and the webhook component)

--- a/content/v1.4-docs/configuration/acme/dns01/README.md
+++ b/content/v1.4-docs/configuration/acme/dns01/README.md
@@ -179,4 +179,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.4-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.4-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.4-docs/configuration/external.md
+++ b/content/v1.4-docs/configuration/external.md
@@ -44,4 +44,4 @@ These external issuers are known to support and honor [approval](https://cert-ma
 
 ## Building New External Issuers
 
-If you're interested in building a new external issuer, check the [development documentation](../contributing/external-issuers.md).
+If you're interested in building a new external issuer, check the [development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.4-docs/installation/helm.md
+++ b/content/v1.4-docs/installation/helm.md
@@ -13,7 +13,7 @@ non-namespaced resources in your cluster and care must be taken to ensure that i
 ### Prerequisites
 
 - Helm version 3 or later
-- A Kubernetes or OpenShift cluster running a [supported version](./supported-releases.md)
+- A Kubernetes or OpenShift cluster running a [supported version](../../docs/installation/supported-releases.md)
 - cert-manager not already installed on the cluster
 - [Prerequisites specific to your cloud provider](./compatibility.md)
 
@@ -55,7 +55,7 @@ must add the `--set installCRDs=true` flag to your Helm installation command.
 
 Uncomment the relevant line in the next steps to enable this.
 
-Note that if you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`), `installCRDs` will not work with cert-manager `v0.16`. See the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#helm) for more details.
+Note that if you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`), `installCRDs` will not work with cert-manager `v0.16`. See the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#helm) for more details.
 
 #### 4. Install cert-manager
 

--- a/content/v1.4-docs/installation/kubectl.md
+++ b/content/v1.4-docs/installation/kubectl.md
@@ -7,8 +7,8 @@ description: 'cert-manager installation: Using static manifests'
 
 ### Prerequisites
 
-- `kubectl` version `>= v1.19.0-rc.1` (otherwise, you will have issues updating the CRDs. see [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl))
-- A Kubernetes or OpenShift cluster running a [supported version](./supported-releases.md)
+- `kubectl` version `>= v1.19.0-rc.1` (otherwise, you will have issues updating the CRDs. see [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl))
+- A Kubernetes or OpenShift cluster running a [supported version](../../docs/installation/supported-releases.md)
 - cert-manager not already installed on the cluster
 - [Prerequisites specific to your cloud provider](./compatibility.md)
 

--- a/content/v1.4-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.4-docs/installation/operator-lifecycle-manager.md
@@ -7,7 +7,7 @@ description: 'cert-manager installation: Using OLM'
 
 ### Prerequisites
 
-- A Kubernetes or OpenShift cluster running a [supported version](./supported-releases.md)
+- A Kubernetes or OpenShift cluster running a [supported version](../../docs/installation/supported-releases.md)
 - cert-manager not already installed on the cluster
 - [Prerequisites specific to your cloud provider](./compatibility.md)
 

--- a/content/v1.5-docs/configuration/acme/dns01/README.md
+++ b/content/v1.5-docs/configuration/acme/dns01/README.md
@@ -179,4 +179,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.5-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.5-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.5-docs/configuration/external.md
+++ b/content/v1.5-docs/configuration/external.md
@@ -44,4 +44,4 @@ These external issuers are known to support and honor [approval](https://cert-ma
 
 ## Building New External Issuers
 
-If you're interested in building a new external issuer, check the [development documentation](../contributing/external-issuers.md).
+If you're interested in building a new external issuer, check the [development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.5-docs/installation/helm.md
+++ b/content/v1.5-docs/installation/helm.md
@@ -13,7 +13,7 @@ non-namespaced resources in your cluster and care must be taken to ensure that i
 ### Prerequisites
 
 - [Install Helm version 3 or later](https://helm.sh/docs/intro/install/).
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps
@@ -54,7 +54,7 @@ must add the `--set installCRDs=true` flag to your Helm installation command.
 
 Uncomment the relevant line in the next steps to enable this.
 
-Note that if you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`), `installCRDs` will not work with cert-manager `v0.16`. See the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#helm) for more details.
+Note that if you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`), `installCRDs` will not work with cert-manager `v0.16`. See the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#helm) for more details.
 
 #### 4. Install cert-manager
 

--- a/content/v1.5-docs/installation/kubectl-plugin.md
+++ b/content/v1.5-docs/installation/kubectl-plugin.md
@@ -8,7 +8,7 @@ description: 'cert-manger installation: Using kubectl'
 ### Prerequisites
 
 - [Install the kubectl cert-manager plugin](../usage/kubectl-plugin.md#installation).
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.5-docs/installation/kubectl.md
+++ b/content/v1.5-docs/installation/kubectl.md
@@ -7,8 +7,8 @@ description: 'cert-manager installation: Using static manifests'
 
 ### Prerequisites
 
-- [Install `kubectl` version `>= v1.19.0-rc.1`](https://kubernetes.io/docs/tasks/tools/). (otherwise, you will have issues updating the CRDs - see [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl))
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- [Install `kubectl` version `>= v1.19.0-rc.1`](https://kubernetes.io/docs/tasks/tools/). (otherwise, you will have issues updating the CRDs - see [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl))
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.5-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.5-docs/installation/operator-lifecycle-manager.md
@@ -7,7 +7,7 @@ description: 'cert-manager installation: Using OLM'
 
 ### Prerequisites
 
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Option 1: Installing from OperatorHub Web Console on OpenShift

--- a/content/v1.6-docs/configuration/acme/dns01/README.md
+++ b/content/v1.6-docs/configuration/acme/dns01/README.md
@@ -182,4 +182,4 @@ You can find more information on how to configure webhook providers
 [here](./webhook.md).
 
 To create a new unsupported DNS provider, follow the development documentation
-[here](../../../../contributing/dns-providers.md).
+[here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.6-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.6-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../contributing/dns-providers.md).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.6-docs/configuration/external.md
+++ b/content/v1.6-docs/configuration/external.md
@@ -45,4 +45,4 @@ These external issuers are known to support and honor [approval](https://cert-ma
 
 ## Building New External Issuers
 
-If you're interested in building a new external issuer, check the [development documentation](../contributing/external-issuers.md).
+If you're interested in building a new external issuer, check the [development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.6-docs/installation/cmctl.md
+++ b/content/v1.6-docs/installation/cmctl.md
@@ -8,7 +8,7 @@ description: 'cert-manager installation: cmctl'
 ### Prerequisites
 
 - [Install the cert-manager CLI cmctl](../usage/cmctl.md#installation).
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.6-docs/installation/helm.md
+++ b/content/v1.6-docs/installation/helm.md
@@ -13,7 +13,7 @@ non-namespaced resources in your cluster and care must be taken to ensure that i
 ### Prerequisites
 
 - [Install Helm version 3 or later](https://helm.sh/docs/intro/install/).
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps
@@ -54,7 +54,7 @@ must add the `--set installCRDs=true` flag to your Helm installation command.
 
 Uncomment the relevant line in the next steps to enable this.
 
-Note that if you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`), `installCRDs` will not work with cert-manager `v0.16`. See the [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#helm) for more details.
+Note that if you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`), `installCRDs` will not work with cert-manager `v0.16`. See the [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#helm) for more details.
 
 #### 4. Install cert-manager
 

--- a/content/v1.6-docs/installation/kubectl-plugin.md
+++ b/content/v1.6-docs/installation/kubectl-plugin.md
@@ -8,7 +8,7 @@ description: 'cert-manger installation: Using kubectl'
 ### Prerequisites
 
 - [Install the kubectl cert-manager plugin](../usage/kubectl-plugin.md#installation).
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.6-docs/installation/kubectl.md
+++ b/content/v1.6-docs/installation/kubectl.md
@@ -7,8 +7,8 @@ description: 'cert-manager installation: Using static manifests'
 
 ### Prerequisites
 
-- [Install `kubectl` version `>= v1.19.0-rc.1`](https://kubernetes.io/docs/tasks/tools/). (otherwise, you will have issues updating the CRDs - see [v0.16 upgrade notes](./upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl))
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- [Install `kubectl` version `>= v1.19.0-rc.1`](https://kubernetes.io/docs/tasks/tools/). (otherwise, you will have issues updating the CRDs - see [v0.16 upgrade notes](../../docs/installation/upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl))
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.6-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.6-docs/installation/operator-lifecycle-manager.md
@@ -7,7 +7,7 @@ description: 'cert-manager installation: Using OLM'
 
 ### Prerequisites
 
-- Install a [supported version of Kubernetes or OpenShift](./supported-releases.md).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Option 1: Installing from OperatorHub Web Console on OpenShift

--- a/content/v1.7-docs/configuration/acme/dns01/README.md
+++ b/content/v1.7-docs/configuration/acme/dns01/README.md
@@ -181,4 +181,4 @@ Links to these supported providers along with their documentation are below:
 
 You can find more information on how to configure webhook providers [here](./webhook.md).
 
-To create a new unsupported DNS provider, follow the development documentation [here](../../../contributing/dns-providers/).
+To create a new unsupported DNS provider, follow the development documentation [here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.7-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.7-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../../contributing/dns-providers/).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.7-docs/configuration/external.md
+++ b/content/v1.7-docs/configuration/external.md
@@ -45,4 +45,4 @@ These external issuers are known to support and honor [approval](https://cert-ma
 
 ## Building New External Issuers
 
-If you're interested in building a new external issuer, check the [development documentation](../../contributing/external-issuers/).
+If you're interested in building a new external issuer, check the [development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.7-docs/installation/cmctl.md
+++ b/content/v1.7-docs/installation/cmctl.md
@@ -8,7 +8,7 @@ description: 'cert-manager installation: cmctl'
 ### Prerequisites
 
 - [Install the cert-manager CLI cmctl](../usage/cmctl.md#installation).
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.7-docs/installation/helm.md
+++ b/content/v1.7-docs/installation/helm.md
@@ -13,7 +13,7 @@ non-namespaced resources in your cluster and care must be taken to ensure that i
 ### Prerequisites
 
 - [Install Helm version 3 or later](https://helm.sh/docs/intro/install/).
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.7-docs/installation/kubectl-plugin.md
+++ b/content/v1.7-docs/installation/kubectl-plugin.md
@@ -8,7 +8,7 @@ description: 'cert-manger installation: Using kubectl'
 ### Prerequisites
 
 - [Install the kubectl cert-manager plugin](../usage/kubectl-plugin.md#installation).
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.7-docs/installation/kubectl.md
+++ b/content/v1.7-docs/installation/kubectl.md
@@ -8,7 +8,7 @@ description: 'cert-manager installation: Using static manifests'
 ### Prerequisites
 
 - [Install `kubectl` version `>= v1.19.0-rc.1`](https://kubernetes.io/docs/tasks/tools/). (otherwise, you will have issues updating the CRDs - see [v0.16 upgrade notes](../../../../docs/installation/upgrading/upgrading-0.15-0.16.md#issue-with-older-versions-of-kubectl))
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.7-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.7-docs/installation/operator-lifecycle-manager.md
@@ -7,7 +7,7 @@ description: 'cert-manager installation: Using OLM'
 
 ### Prerequisites
 
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Option 1: Installing from OperatorHub Web Console on OpenShift

--- a/content/v1.8-docs/configuration/acme/dns01/README.md
+++ b/content/v1.8-docs/configuration/acme/dns01/README.md
@@ -181,4 +181,4 @@ Links to these supported providers along with their documentation are below:
 
 You can find more information on how to configure webhook providers [here](./webhook.md).
 
-To create a new unsupported DNS provider, follow the development documentation [here](../../../contributing/dns-providers/).
+To create a new unsupported DNS provider, follow the development documentation [here](../../../../docs/contributing/dns-providers.md).

--- a/content/v1.8-docs/configuration/acme/dns01/webhook.md
+++ b/content/v1.8-docs/configuration/acme/dns01/webhook.md
@@ -5,7 +5,7 @@ description: 'cert-manager configuration: ACME DNS-01 challenges using External 
 
 The webhook `Issuer` is a generic ACME solver. The actual work is done by an
 external service. Look at the respective documentation of
-[`dns-providers`](../../../../contributing/dns-providers/).
+[`dns-providers`](../../../../docs/contributing/dns-providers.md).
 
 View more webhook solvers at https://github.com/topics/cert-manager-webhook.
 

--- a/content/v1.8-docs/configuration/external.md
+++ b/content/v1.8-docs/configuration/external.md
@@ -45,4 +45,4 @@ These external issuers are known to support and honor [approval](https://cert-ma
 
 ## Building New External Issuers
 
-If you're interested in building a new external issuer, check the [development documentation](../../contributing/external-issuers/).
+If you're interested in building a new external issuer, check the [development documentation](../../docs/contributing/external-issuers.md).

--- a/content/v1.8-docs/installation/cmctl.md
+++ b/content/v1.8-docs/installation/cmctl.md
@@ -8,7 +8,7 @@ description: 'cert-manager installation: cmctl'
 ### Prerequisites
 
 - [Install the cert-manager CLI cmctl](../usage/cmctl.md#installation).
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.8-docs/installation/helm.md
+++ b/content/v1.8-docs/installation/helm.md
@@ -13,7 +13,7 @@ non-namespaced resources in your cluster and care must be taken to ensure that i
 ### Prerequisites
 
 - [Install Helm version 3 or later](https://helm.sh/docs/intro/install/).
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.8-docs/installation/kubectl-plugin.md
+++ b/content/v1.8-docs/installation/kubectl-plugin.md
@@ -8,7 +8,7 @@ description: 'cert-manger installation: Using kubectl'
 ### Prerequisites
 
 - [Install the kubectl cert-manager plugin](../usage/kubectl-plugin.md#installation).
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.8-docs/installation/kubectl.md
+++ b/content/v1.8-docs/installation/kubectl.md
@@ -8,7 +8,7 @@ description: 'cert-manager installation: Using static manifests'
 ### Prerequisites
 
 - [Install `kubectl` version `>= v1.19.0`](https://kubernetes.io/docs/tasks/tools/). (otherwise, you will have issues updating the CRDs - see [v0.16 upgrade notes](../../../docs/installation/upgrading/upgrading-0.15-0.16/#issue-with-older-versions-of-kubectl))
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Steps

--- a/content/v1.8-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.8-docs/installation/operator-lifecycle-manager.md
@@ -7,7 +7,7 @@ description: 'cert-manager installation: Using OLM'
 
 ### Prerequisites
 
-- Install a [supported version of Kubernetes or OpenShift](../../installation/supported-releases/).
+- Install a [supported version of Kubernetes or OpenShift](../../docs/installation/supported-releases.md).
 - Read [Compatibility with Kubernetes Platform Providers](./compatibility.md) if you are using Kubernetes on a cloud platform.
 
 ### Option 1: Installing from OperatorHub Web Console on OpenShift

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@headlessui/react": "^1.5.0",
-        "@zentered/next-product-docs": "^0.0.126",
+        "@zentered/next-product-docs": "^0.0.127",
         "classnames": "^2.3.1",
         "next": "12.1.4",
         "next-seo": "^5.4.0",
@@ -1731,9 +1731,9 @@
       "peer": true
     },
     "node_modules/@zentered/next-product-docs": {
-      "version": "0.0.126",
-      "resolved": "https://registry.npmjs.org/@zentered/next-product-docs/-/next-product-docs-0.0.126.tgz",
-      "integrity": "sha512-sVKw2av2O2HLFIwsa+2hnnc0mD9GHtThxw0JKmq/TzvfiZC7svi8yCqfuZNv6Wzl2LSbrL5M4cqo96udZI1kgw==",
+      "version": "0.0.127",
+      "resolved": "https://registry.npmjs.org/@zentered/next-product-docs/-/next-product-docs-0.0.127.tgz",
+      "integrity": "sha512-3CnXOWEuHkyQ287K0sp8hxiMaK7asSnw374YDjSnKWqiOJC1cRtCmQSHETbGBwEIBYJOXPWc0QdioswxEa1nIA==",
       "dependencies": {
         "@next/mdx": "^12.1.0",
         "github-slugger": "^1.4.0",
@@ -18979,9 +18979,9 @@
       "peer": true
     },
     "@zentered/next-product-docs": {
-      "version": "0.0.126",
-      "resolved": "https://registry.npmjs.org/@zentered/next-product-docs/-/next-product-docs-0.0.126.tgz",
-      "integrity": "sha512-sVKw2av2O2HLFIwsa+2hnnc0mD9GHtThxw0JKmq/TzvfiZC7svi8yCqfuZNv6Wzl2LSbrL5M4cqo96udZI1kgw==",
+      "version": "0.0.127",
+      "resolved": "https://registry.npmjs.org/@zentered/next-product-docs/-/next-product-docs-0.0.127.tgz",
+      "integrity": "sha512-3CnXOWEuHkyQ287K0sp8hxiMaK7asSnw374YDjSnKWqiOJC1cRtCmQSHETbGBwEIBYJOXPWc0QdioswxEa1nIA==",
       "requires": {
         "@next/mdx": "^12.1.0",
         "github-slugger": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@docsearch/react": "^3.0.0",
     "@headlessui/react": "^1.5.0",
-    "@zentered/next-product-docs": "^0.0.126",
+    "@zentered/next-product-docs": "^0.0.127",
     "classnames": "^2.3.1",
     "next": "12.1.4",
     "next-seo": "^5.4.0",


### PR DESCRIPTION
Some of these are relics from before the migration, some happened during the migration. This PR fixes every broken link currently on the site, bumps next-product-docs to fix a bug causing broken links in that tool, and fixes reference docs which were broken in `next-docs`

Everything in this PR was done by hand :sleeping: 

I checked every docs version for broken links using muffet, as here: https://github.com/SgtCoDFish/rutte/blob/7f04ee3c60702661cde4a86bee96d4a0ccd474d3/Makefile#L24-L31