### PR TITLE
Remove a header which previously had autofilled hugo content

### DIFF
--- a/content/docs/configuration/README.md
+++ b/content/docs/configuration/README.md
@@ -17,4 +17,3 @@ When using `ClusterIssuer` resource types, ensure you understand the purpose of 
 [`Cluster Resource Namespace`](../faq/cluster-resource.md); this can be a common source
 of issues for people getting started with cert-manager.
 
-## Supported Issuer Types

--- a/content/next-docs/configuration/README.md
+++ b/content/next-docs/configuration/README.md
@@ -17,4 +17,3 @@ When using `ClusterIssuer` resource types, ensure you understand the purpose of 
 [`Cluster Resource Namespace`](../faq/cluster-resource.md); this can be a common source
 of issues for people getting started with cert-manager.
 
-## Supported Issuer Types

--- a/content/v0.12-docs/configuration/README.md
+++ b/content/v0.12-docs/configuration/README.md
@@ -14,4 +14,3 @@ in the `cert-manager.io` group. cert-manager also supports external issuers than
 can be installed into your cluster that belong to other groups. These external
 issuer types behave no different and are treated equal to in tree issuer types.
 
-## Supported Issuer Types

--- a/content/v0.13-docs/configuration/README.md
+++ b/content/v0.13-docs/configuration/README.md
@@ -14,4 +14,3 @@ in the `cert-manager.io` group. cert-manager also supports external issuers than
 can be installed into your cluster that belong to other groups. These external
 issuer types behave no different and are treated equal to in tree issuer types.
 
-## Supported Issuer Types

--- a/content/v0.14-docs/configuration/README.md
+++ b/content/v0.14-docs/configuration/README.md
@@ -14,4 +14,3 @@ in the `cert-manager.io` group. cert-manager also supports external issuers than
 can be installed into your cluster that belong to other groups. These external
 issuer types behave no different and are treated equal to in tree issuer types.
 
-## Supported Issuer Types

--- a/content/v0.15-docs/configuration/README.md
+++ b/content/v0.15-docs/configuration/README.md
@@ -14,4 +14,3 @@ in the `cert-manager.io` group. cert-manager also supports external issuers than
 can be installed into your cluster that belong to other groups. These external
 issuer types behave no different and are treated equal to in tree issuer types.
 
-## Supported Issuer Types

--- a/content/v0.16-docs/configuration/README.md
+++ b/content/v0.16-docs/configuration/README.md
@@ -18,4 +18,3 @@ When using `ClusterIssuer` resource types, ensure you understand the [`Cluster
 Resource Namespace`](../faq/cluster-resource.md) where other Kubernetes resources
 will be referenced from.
 
-## Supported Issuer Types

--- a/content/v1.0-docs/configuration/README.md
+++ b/content/v1.0-docs/configuration/README.md
@@ -18,4 +18,3 @@ When using `ClusterIssuer` resource types, ensure you understand the [`Cluster
 Resource Namespace`](../faq/cluster-resource.md) where other Kubernetes resources
 will be referenced from.
 
-## Supported Issuer Types

--- a/content/v1.1-docs/configuration/README.md
+++ b/content/v1.1-docs/configuration/README.md
@@ -18,4 +18,3 @@ When using `ClusterIssuer` resource types, ensure you understand the [`Cluster
 Resource Namespace`](../faq/cluster-resource.md) where other Kubernetes resources
 will be referenced from.
 
-## Supported Issuer Types

--- a/content/v1.2-docs/configuration/README.md
+++ b/content/v1.2-docs/configuration/README.md
@@ -18,4 +18,3 @@ When using `ClusterIssuer` resource types, ensure you understand the [`Cluster
 Resource Namespace`](../faq/cluster-resource.md) where other Kubernetes resources
 will be referenced from.
 
-## Supported Issuer Types

--- a/content/v1.3-docs/configuration/README.md
+++ b/content/v1.3-docs/configuration/README.md
@@ -18,4 +18,3 @@ When using `ClusterIssuer` resource types, ensure you understand the [`Cluster
 Resource Namespace`](../faq/cluster-resource.md) where other Kubernetes resources
 will be referenced from.
 
-## Supported Issuer Types

--- a/content/v1.4-docs/configuration/README.md
+++ b/content/v1.4-docs/configuration/README.md
@@ -17,4 +17,3 @@ When using `ClusterIssuer` resource types, ensure you understand the purpose of 
 [`Cluster Resource Namespace`](../faq/cluster-resource.md); this can be a common source
 of issues for people getting started with cert-manager.
 
-## Supported Issuer Types

--- a/content/v1.5-docs/configuration/README.md
+++ b/content/v1.5-docs/configuration/README.md
@@ -17,4 +17,3 @@ When using `ClusterIssuer` resource types, ensure you understand the purpose of 
 [`Cluster Resource Namespace`](../faq/cluster-resource.md); this can be a common source
 of issues for people getting started with cert-manager.
 
-## Supported Issuer Types

--- a/content/v1.6-docs/configuration/README.md
+++ b/content/v1.6-docs/configuration/README.md
@@ -17,4 +17,3 @@ When using `ClusterIssuer` resource types, ensure you understand the purpose of 
 [`Cluster Resource Namespace`](../faq/cluster-resource.md); this can be a common source
 of issues for people getting started with cert-manager.
 
-## Supported Issuer Types

--- a/content/v1.7-docs/configuration/README.md
+++ b/content/v1.7-docs/configuration/README.md
@@ -17,4 +17,3 @@ When using `ClusterIssuer` resource types, ensure you understand the purpose of 
 [`Cluster Resource Namespace`](../faq/cluster-resource.md); this can be a common source
 of issues for people getting started with cert-manager.
 
-## Supported Issuer Types

--- a/content/v1.8-docs/configuration/README.md
+++ b/content/v1.8-docs/configuration/README.md
@@ -17,4 +17,3 @@ When using `ClusterIssuer` resource types, ensure you understand the purpose of 
 [`Cluster Resource Namespace`](../faq/cluster-resource.md); this can be a common source
 of issues for people getting started with cert-manager.
 
-## Supported Issuer Types


### PR DESCRIPTION
We could maintain a hand-rolled list here, but the sidebar already has
all the navigation information. In any case, these headings are
currently pure noise and need to be changed from their current state.