### PR TITLE
Route53 accessKeyIDSecretRef docs

### DIFF
--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -56,7 +56,7 @@ not have to store permanent credentials in a secret.
 
 cert-manager supports two ways of specifying credentials:
 
-- explicit by providing a `accessKeyID` and `secretAccessKey`
+- explicit by providing an `accessKeyID` or an `accessKeyIDSecretRef`, and a `secretAccessKeySecretRef`
 - or implicit (using [metadata
   service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
   or [environment variables or credentials
@@ -168,7 +168,13 @@ spec:
       dns01:
         route53:
           region: eu-central-1
+          # The AWS access key ID can be specified using the literal accessKeyID parameter
+          # or retrieved from a secret using the accessKeyIDSecretRef
+          # If using accessKeyID, omit the accessKeyIDSecretRef parameter and vice-versa
           accessKeyID: AKIAIOSFODNN7EXAMPLE
+          accessKeyIDSecretRef:
+            name: prod-route53-credentials-secret
+            key: access-key-id
           secretAccessKeySecretRef:
             name: prod-route53-credentials-secret
             key: secret-access-key


### PR DESCRIPTION
This adds documentation for the `accessKeyIDSecretRef` dns01.route53 configuration feature as described in https://github.com/cert-manager/cert-manager/issues/3568

This PR is a co-requisite with the core feature implementation PR https://github.com/cert-manager/cert-manager/pull/5194