### PR TITLE
Document new and old release processes

### DIFF
--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -311,7 +311,7 @@ page if a step is missing or if it is outdated.
         cmrel makestage --ref=v1.8.0-beta.0
         ```
 
-        This step takes ~5 minutes. It will build all Docker images and create
+        This step takes ~5 minutes. It will build all container images and create
         all the manifest files, sign Helm charts and upload everything to a storage
         bucket on Google Cloud. These artifacts will then be published and released
         in the next steps.
@@ -505,10 +505,9 @@ page if a step is missing or if it is outdated.
        patch releases as we want to encourage users to always install the latest
        patch.
 
-    9. Open a PR against our
-       [Algolia indexing configuration](https://github.com/algolia/docsearch-configs/blob/master/configs/cert-manager.json#L7-L13)
-       including the new version for search indexing, as in
-       [this PR](https://github.com/algolia/docsearch-configs/pull/2278).
+    9. Future: check that our Algolia search indexing is up-to-date for the website - i.e. that the new version of the docs
+       is being indexed correctly. This is listed here as it's a step we should be checking after a release of a major version
+       but at the time of writing we don't know how to do it!
 
     10. Open a PR against the Krew index such as [this one](https://github.com/kubernetes-sigs/krew-index/pull/1724),
         bumping the versions of our kubectl plugins.

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -73,8 +73,11 @@ following conditions:
 
 </div>
 
-First, ensure that you have all the tools required to perform a cert-manager
-release:
+This guide applies for versions of cert-manager released using `make`, which should be every version from cert-manger 1.8 and later.
+
+**If you need to release a version of cert-manager 1.7 or earlier** see [older releases](#older-releases).
+
+First, ensure that you have all the tools required to perform a cert-manager release:
 
 1. Install the [`release-notes`](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md) CLI:
 
@@ -313,10 +316,6 @@ page if a step is missing or if it is outdated.
         bucket on Google Cloud. These artifacts will then be published and released
         in the next steps.
 
-        <div className="pageinfo pageinfo-info"><p>
-        🔰 Remember to keep open the terminal where you run <code>cmrel stage</code>. Its output will be used in the next step.
-        </p></div>
-
     2. While the build is running, send a first Slack message to
        `#cert-manager-dev`:
 
@@ -340,46 +339,29 @@ page if a step is missing or if it is outdated.
 
 7. Run `cmrel publish`:
 
-    1. Set the `CMREL_RELEASE_NAME` variable in your shell. The value for the
-       `CMREL_RELEASE_NAME` variable is found in the output of the previous command,
-       `cmrel stage`. Look for the line that contains the `gs://` link:
-
-        ```sh
-        gs://cert-manager-release/stage/gcb/release/v1.3.0-alpha.1-c2c0fdd78131493707050ffa4a7454885d041b08
-        #                                           <---------- CMREL_RELEASE_NAME ----------------------->
-        ```
-
-        Copy that part into a variable in your shell (no need to export it):
-
-        ```sh
-        CMREL_RELEASE_NAME=v1.3.0-alpha.0-77b045d159bd20ce0ec454cd79a5edce9187bdd9
-        ```
-
-    2. Do a `cmrel publish` dry-run to ensure that all the staged resources are
+    1. Do a `cmrel publish` dry-run to ensure that all the staged resources are
        valid. Run the following command:
 
         ```sh
         # Must be run from the "cert-manager/release" repo folder.
-        cmrel publish --release-name "$CMREL_RELEASE_NAME"
+        cmrel publish --release-name "$RELEASE_VERSION"
         ```
 
         You can view the progress by clicking the Google Cloud Build URL in the
         output of this command.
 
-    3. While the build is running, send a third Slack message in reply to
-       the first message:
+    2. While the build is running, send a third Slack message in reply to the first message:
 
         <div className="pageinfo pageinfo-primary"><p>
         Follow the `cmrel publish` dry-run build: https://console.cloud.google.com/cloud-build/builds16f6f875-0a23-4fff-b24d-3de0af207463?project=1021342095237
         </p></div>
 
-    4. Next publish the release artifacts for real. The following command will
-       publish "for real" the artifacts to GitHub, `Quay.io`, to our
-       [ChartMuseum](https://charts.jetstack.io) instance:
+    3. Now publish the release artifacts for real. The following command will publish the artifacts to GitHub, `Quay.io` and to our
+       [helm chart repository](https://charts.jetstack.io):
 
         ```bash
         # Must be run from the "cert-manager/release" repo folder.
-        cmrel publish --nomock --release-name "$CMREL_RELEASE_NAME"
+        cmrel publish --nomock --release-name "$RELEASE_VERSION"
         ```
 
       <div className="info">
@@ -394,8 +376,7 @@ page if a step is missing or if it is outdated.
          </ol>
       </div>
 
-    5. While the build is running, send a fourth Slack message in reply to
-       the first message:
+    4. While the build is running, send a fourth Slack message in reply to the first message:
 
         <div className="pageinfo pageinfo-primary"><p>
         Follow the <code>cmrel publish</code> build: https://console.cloud.google.com/cloud-build/builds/b6fef12b-2e81-4486-9f1f-d00592351789?project=1021342095237
@@ -540,3 +521,40 @@ page if a step is missing or if it is outdated.
 
         Follow [the cert-manager OLM release process](https://github.com/jetstack/cert-manager-olm#release-process) and, once published,
         [verify that the cert-manager OLM installation instructions](https://cert-manager.io/docs/installation/operator-lifecycle-manager/) still work.
+
+
+## Older Releases
+
+The above guide only applies for versions of cert-manager from v1.8 onwards.
+
+Older versions were built using Bazel and this difference in build process is reflected in the release process.
+
+### cert-manager 1.6 and 1.7
+
+Follow [this older version][older-release-process] of the release process on GitHub, rather than the guide on this website.
+
+The most notable difference is you'll call `cmrel stage` rather than `cmrel makestage`. You should be fine to use the latest
+version of `cmrel` to do the release.
+
+### cert-manager 1.5 and earlier
+
+If you're releasing version 1.5 or earlier you must also be sure to install a different version of `cmrel`.
+
+In the step where you install `cmrel`, you'll want to run the following instead:
+
+```bash
+go install github.com/cert-manager/release/cmd/cmrel@cert-manager-pre-1.6
+```
+
+This will ensure that the version of `cmrel` you're using is compatible with the version of cert-manager you're releasing.
+
+In addition, when you check out the `cert-manager/release` repository you should be sure to check out the `cert-manager-pre-1.6` tag in that repo:
+
+```bash
+git checkout cert-manager-pre-1.6
+```
+
+Other than the different `cert-manager/release` tag and `cmrel` version, you can follow the [same older release documentation][older-release-process] as
+is used for 1.6 and 1.7 - just remember to change the version of `cmrel` you install!
+
+[older-release-process]: https://github.com/cert-manager/website/blob/6fa0db74de0ae17d7be638a08155d1b4e036aaa9/content/en/docs/contributing/release-process.md?plain=1


### PR DESCRIPTION
[During the release of v1.8.1](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1655221978315829) it was discovered that the path to which we write staged artifacts was unintentionally changed by using `make publish-release` rather than our old `cmrel` magic which constructed a longer path.

This change actually simplifies our release process and will simplify `cmrel makestage` too. This PR documents that, and also documents how _older_ versions of cert-manager (1.7 and before) should be released, in case we find a reason to do that!

This also removes the step where we're instructed to do something with algolia, because we don't actually know how to do that.

Each commit has more details in its full commit message.