### PR TITLE
Updating the policy on website around subcharts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ public/feed.*
 
 # ignore netlify-cli tmp dir
 .netlify/
+
+# IntelliJ
+.idea

--- a/.spelling
+++ b/.spelling
@@ -594,3 +594,4 @@ x509
 x509
  - content/v0.16-docs/usage/kubectl-plugin.md
 x509
+subchart

--- a/.spelling
+++ b/.spelling
@@ -448,6 +448,7 @@ Nokia
 Netguard
 ZeroSSL
 Sectigo
+subchart
 
 # TEMPORARY
 # these are temporarily ignored because the spellchecker
@@ -594,4 +595,3 @@ x509
 x509
  - content/v0.16-docs/usage/kubectl-plugin.md
 x509
-subchart

--- a/content/docs/contributing/policy.md
+++ b/content/docs/contributing/policy.md
@@ -89,7 +89,7 @@ cert-manager works around this limitation by shipping CRDs in the templates.
 
 ### Helm Subchart capabilities
 
-cert-manager now has the capability to be [installed as a subchart](./helm.md#installing-cert-manager-as-subchart)
+cert-manager now has the capability to be [installed as a subchart](../installation/helm.md#installing-cert-manager-as-subchart)
 
 But you need to be careful when adding it to your umbrella chart.
 

--- a/content/docs/contributing/policy.md
+++ b/content/docs/contributing/policy.md
@@ -89,15 +89,15 @@ cert-manager works around this limitation by shipping CRDs in the templates.
 
 ### Helm Subchart capabilities
 
-cert-manager now has the capability to be [installed as a subchart](../installation/helm.md#installing-cert-manager-as-subchart)
+cert-manager now has the capability to be [installed as a subchart](../installation/helm.md#installing-cert-manager-as-subchart).
 
 But you need to be careful when adding it to your umbrella chart.
 
 This is because the cert-manager installation creates cluster scoped resources like admission webhooks and custom resource definitions. cert-manager should be seen as part of your cluster and should be treated as such for being installed. An apt comparison
-to other Kubernetes components would be a LoadBalancer controller or a PV provisioner
+to other Kubernetes components would be a LoadBalancer controller or a PV provisioner.
 
 It is your responsibility to ensure that cert-manager is only installed once in your cluster.
-This can be managed via the `condition` parameter of the dependency in your Chart.yaml, which allows users to disable the installation of a subchart. The condition parameter must be added when using cert-manager as a subchart to allow users to disable your dependency
+This can be managed via the `condition` parameter of the dependency in your `Chart.yaml`, which allows users to disable the installation of a subchart. The condition parameter must be added when using cert-manager as a subchart to allow users to disable your dependency.
 
 ```yaml
 apiVersion: v2

--- a/content/docs/contributing/policy.md
+++ b/content/docs/contributing/policy.md
@@ -89,13 +89,30 @@ cert-manager works around this limitation by shipping CRDs in the templates.
 
 ### Helm Subchart capabilities
 
-cert-manager should not be used as a sub-chart in Helm deployments.
+cert-manager now has the capability to install it as a subchart [link]
 
-Helm deployments are namespaced by design and do not support a dependency model that would support cert-manager being operated at cluster scope; nor is it possible using this method to prevent cert-manager being installed twice (with conflicting versions)
-or being upgraded independently from the application.
+But you need to be careful when adding it to your umbrella chart.
 
-The cert-manager installation creates cluster scoped resources like admission webhooks and custom resource definitions. cert-manager should be seen as part of your cluster and should be treated as such for being installed. An apt comparison
+This is because the cert-manager installation creates cluster scoped resources like admission webhooks and custom resource definitions. cert-manager should be seen as part of your cluster and should be treated as such for being installed. An apt comparison
 to other Kubernetes components would be a LoadBalancer controller or a PV provisioner
+
+It is your responsibility to ensure that cert-manager is only installed once in your cluster.
+This can be managed via the `condition` parameter of the dependency in your Chart.yaml, which allows users to disable the installation of a subchart. The condition parameter must be added when using cert-manager as a subchart to allow users to disable your dependency
+
+```yaml
+apiVersion: v2
+name: example_chart
+description: A Helm chart with cert-manager as subchart
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+dependencies:
+  - name: cert-manager
+    version: v1.8.0
+    repository: https://charts.jetstack.io
+    alias: cert-manager
+    condition: cert-manager.enabled
+```
 
 ### Secret injection or copying
 

--- a/content/docs/contributing/policy.md
+++ b/content/docs/contributing/policy.md
@@ -89,7 +89,7 @@ cert-manager works around this limitation by shipping CRDs in the templates.
 
 ### Helm Subchart capabilities
 
-cert-manager now has the capability to install it as a subchart [link]
+cert-manager now has the capability to be [installed as a subchart](./helm.md#installing-cert-manager-as-subchart)
 
 But you need to be careful when adding it to your umbrella chart.
 


### PR DESCRIPTION
Updating the policy section of the website around the policy on using cert-manager as a subchart

Signed-off-by: Andrew Kew <andrew@quadcorps.co.uk>