### PR TITLE
Modifications after trying the istio-csr tutorial

### DIFF
--- a/content/docs/tutorials/istio-csr/istio-csr.md
+++ b/content/docs/tutorials/istio-csr/istio-csr.md
@@ -136,6 +136,14 @@ istioctl install -f istio-install-config.yaml
 # istioctl install --set profile=openshift -f istio-install-config.yaml
 ```
 
+You will be prompted for input to confirm your choice of istio profile:
+
+```console
+This will install the Istio 1.14.1 demo profile with ["Istio core" "Istiod" "Ingress gateways" "Egress gateways"] components into the cluster. Proceed? (y/N)
+```
+
+Confirm your selection by entering `y` into the console to proceed with installation.
+
 ## Validating Install
 
 The following steps are option but can be followed to validate everything is hooked correctly:
@@ -265,4 +273,4 @@ namespace or application.
 Assuming your running inside kind, you can simply remove the cluster:
 
 ```shell
-kind delete cluster kind
+kind delete cluster

--- a/content/docs/tutorials/istio-csr/istio-csr.md
+++ b/content/docs/tutorials/istio-csr/istio-csr.md
@@ -136,7 +136,7 @@ istioctl install -f istio-install-config.yaml
 # istioctl install --set profile=openshift -f istio-install-config.yaml
 ```
 
-You will be prompted for input to confirm your choice of istio profile:
+You will be prompted for input to confirm your choice of Istio profile:
 
 ```console
 This will install the Istio 1.14.1 demo profile with ["Istio core" "Istiod" "Ingress gateways" "Egress gateways"] components into the cluster. Proceed? (y/N)


### PR DESCRIPTION
This commit makes two small tweaks to the istio-csr tutorial on the website.

The first is that the final clean up command will fail, following the instructions verbatim
will produce an error, so it has been updated to just `kind delete cluster`, which successfully
deletes the kind cluster. 

```
$ kind delete cluster kind
ERROR: unknown command "kind" for "kind delete cluster"
```

The second change is to add that the `isitoctl install` command will prompt for user input
to confirm the choice of profile. The user should confirm the choice. 

Signed-off-by: David Bond <davidsbond@users.noreply.github.com>