### PR TITLE
Remove enabled from securityContext

### DIFF
--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -247,7 +247,6 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::XXXXXXXXXXX:role/cert-manager
 securityContext:
-  enabled: true
   fsGroup: 1001
 ```
 

--- a/content/next-docs/configuration/acme/dns01/route53.md
+++ b/content/next-docs/configuration/acme/dns01/route53.md
@@ -247,7 +247,6 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::XXXXXXXXXXX:role/cert-manager
 securityContext:
-  enabled: true
   fsGroup: 1001
 ```
 

--- a/content/v1.9-docs/configuration/acme/dns01/route53.md
+++ b/content/v1.9-docs/configuration/acme/dns01/route53.md
@@ -247,7 +247,6 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::XXXXXXXXXXX:role/cert-manager
 securityContext:
-  enabled: true
   fsGroup: 1001
 ```
 


### PR DESCRIPTION
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field "enabled" in io.k8s.api.core.v1.PodSecurityContext
│
│   with helm_release.cert_manager,
│   on certmanager.tf line 1, in resource "helm_release" "cert_manager":
│    1: resource "helm_release" "cert_manager" {

Signed-off-by: Simon Schwichtenberg <33393719+schwichti@users.noreply.github.com>