### PR TITLE
Improve the layout of the left-hand menu

### DIFF
--- a/components/docs/Sidebar/Dropdown.jsx
+++ b/components/docs/Sidebar/Dropdown.jsx
@@ -15,7 +15,7 @@ export default function Dropdown({
   })
 
   return (
-    <div className="mt-4">
+    <div className="pt-2 pb-2">
       <button
         tabIndex={parentOpen ? 0 : -1}
         className="relative text-blue-800 text-base font-medium w-full text-left flex items-center justify-between"

--- a/components/docs/Sidebar/index.jsx
+++ b/components/docs/Sidebar/index.jsx
@@ -19,7 +19,7 @@ export default function Sidebar({ router, routes, versions }) {
 
   return (
     <div className="flex-none ">
-      <div className="sticky top-4  overflow-y-auto">
+      <div className="sticky top-4">
         <button
           className="md:hidden mb-4 px-2 border-b border-gray-2 relative text-blue-800 text-base font-medium w-full text-left flex items-center justify-between"
           onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
@@ -31,14 +31,7 @@ export default function Sidebar({ router, routes, versions }) {
         </button>
         <div className={sidebarCollapsed ? 'hidden md:block' : 'block'}>
           <aside className="">
-            <div className="mb-8">
-              <VersionSelect
-                version={version}
-                versions={versions}
-                setSidebarCollapsed={setSidebarCollapsed}
-              />
-            </div>
-            <nav className="flex-1 px-2 space-y-1 mt-6">
+            <nav className="flex-1 px-2 space-y-1">
               {routes &&
                 Object.keys(routes).map((route, idx) => {
                   const obj = routes[route]
@@ -54,6 +47,13 @@ export default function Sidebar({ router, routes, versions }) {
                   )
                 })}
             </nav>
+            <div className="mt-8">
+              <VersionSelect
+                version={version}
+                versions={versions}
+                setSidebarCollapsed={setSidebarCollapsed}
+              />
+            </div>
           </aside>
         </div>
       </div>

--- a/components/docs/VersionSelect.jsx
+++ b/components/docs/VersionSelect.jsx
@@ -3,6 +3,14 @@ import { useState } from 'react'
 import SidebarLink from './Sidebar/SidebarLink'
 import Icon from 'components/Icon'
 
+function labelFromVersion(version) {
+    return (
+        version === 'docs'
+            ? 'latest'
+            : version.replace(/-docs$/, '').replace(/^v/, '')
+    );
+}
+
 export default function VersionSelect({
   version,
   versions,
@@ -11,21 +19,27 @@ export default function VersionSelect({
   const [selectedVersion, setSelectedVersion] = useState(version)
 
   return (
-    <div className="">
+      <div className="bg-gray-1 rounded-md border-2 border-gray-2/50">
       <Listbox value={selectedVersion} onChange={setSelectedVersion}>
-        <Listbox.Button className="flex items-center justify-between px-2 w-full">
-          <span className="block">{selectedVersion}</span>
-          <span className="block h-4 w-4 text-blue-1">
-            <Icon name="chevronDown" />
-          </span>
+        <Listbox.Button className="w-full">
+          <Listbox.Label className="cursor-pointer">version: </Listbox.Label>{labelFromVersion(version)}
         </Listbox.Button>
         <Listbox.Options>
-          {versions.map((version) => (
+          <Listbox.Option key={version} value={version}>
+            <div className="block px-2">
+              <SidebarLink
+                href="docs"
+                caption="latest"
+                setSidebarCollapsed={setSidebarCollapsed}
+              />
+            </div>
+          </Listbox.Option>
+          {versions.reverse().map((version) => (
             <Listbox.Option key={version} value={version}>
               <div className="block px-2">
                 <SidebarLink
                   href={version}
-                  caption={version}
+                  caption={labelFromVersion(version)}
                   setSidebarCollapsed={setSidebarCollapsed}
                 />
               </div>
@@ -34,5 +48,5 @@ export default function VersionSelect({
         </Listbox.Options>
       </Listbox>
     </div>
-  )
+  );
 }

--- a/content/docs/contributing/google-season-of-docs/2022/improve-navigation-and-structure.md
+++ b/content/docs/contributing/google-season-of-docs/2022/improve-navigation-and-structure.md
@@ -12,6 +12,8 @@ On smaller displays the [responsive CSS](https://tailwindcss.com/docs/responsive
 So we've widened it by 1 column on displays `>=1280px`  and reduced the width of the content by 1 column to compensate.
 This makes the menu much easier to read on laptop and desktop computer screens.
 
+We fixed an inconsistency in the vertical spacing between menu items with sub-menus and those without.
+
 ### 3 August 2022: The cert-manager.io Documentation Survey is now closed
 
 Thank you to everyone who participated in our documentation survey.

--- a/content/docs/contributing/google-season-of-docs/2022/improve-navigation-and-structure.md
+++ b/content/docs/contributing/google-season-of-docs/2022/improve-navigation-and-structure.md
@@ -5,7 +5,7 @@ description: Google season of docs 2022 proposal
 
 ## Project Updates
 
-### 12 Aug 2022: Increased the width of the navigation menu
+### 12 Aug 2022: Improved the layout of the navigation menu
 
 On displays `>=1280px` the left-hand menu was too narrow to display the nested menu items clearly,
 On smaller displays the [responsive CSS](https://tailwindcss.com/docs/responsive-design) actually made the menu larger.
@@ -13,6 +13,8 @@ So we've widened it by 1 column on displays `>=1280px`  and reduced the width of
 This makes the menu much easier to read on laptop and desktop computer screens.
 
 We fixed an inconsistency in the vertical spacing between menu items with sub-menus and those without.
+
+And finally, we moved the version selector to the bottom of the side-bar to avoid distracting the reader.
 
 ### 3 August 2022: The cert-manager.io Documentation Survey is now closed
 

--- a/content/docs/contributing/google-season-of-docs/2022/improve-navigation-and-structure.md
+++ b/content/docs/contributing/google-season-of-docs/2022/improve-navigation-and-structure.md
@@ -5,6 +5,13 @@ description: Google season of docs 2022 proposal
 
 ## Project Updates
 
+### 12 Aug 2022: Increased the width of the navigation menu
+
+On displays `>=1280px` the left-hand menu was too narrow to display the nested menu items clearly,
+On smaller displays the [responsive CSS](https://tailwindcss.com/docs/responsive-design) actually made the menu larger.
+So we've widened it by 1 column on displays `>=1280px`  and reduced the width of the content by 1 column to compensate.
+This makes the menu much easier to read on laptop and desktop computer screens.
+
 ### 3 August 2022: The cert-manager.io Documentation Survey is now closed
 
 Thank you to everyone who participated in our documentation survey.

--- a/pages/[...docs].jsx
+++ b/pages/[...docs].jsx
@@ -83,7 +83,7 @@ export async function getStaticProps(ctx) {
 
   // fetch content/*-docs folders as versions
   const dirs = await readdir(join(process.cwd(), 'content'))
-  const docs = dirs.filter((d) => d.endsWith('docs'))
+  const docs = dirs.filter((d) => d.endsWith('docs') && d.startsWith('v'))
   props.versions = docs
 
   return { props }

--- a/pages/[...docs].jsx
+++ b/pages/[...docs].jsx
@@ -37,14 +37,14 @@ const DocumentationPage = ({
       />
       <div className="container mt-6 pb-48">
         <div className="w-full md:grid grid-cols-12 gap-12 xl:gap-16">
-          <div className="col-span-4 lg:col-span-3 xl:col-span-2 md:border-r border-gray-2/50 pr-5">
+          <div className="col-span-4 lg:col-span-3 xl:col-span-3 md:border-r border-gray-2/50 pr-5">
             <Sidebar
               router={router}
               routes={sidebarRoutes}
               versions={versions}
             />
           </div>
-          <main className="col-span-8 lg:col-span-9 xl:col-span-8 docs">
+          <main className="col-span-8 lg:col-span-9 xl:col-span-7 docs">
             <div className="mx-auto md:mx-0 prose max-w-full main-docs-section">
               <h1>{title}</h1>
               <Documentation source={source} theme={theme} />


### PR DESCRIPTION
…and one less for the content


On displays `>=1280px` the left-hand menu was too narrow to display the nested menu items clearly,
On smaller displays the [responsive CSS](https://tailwindcss.com/docs/responsive-design) actually made the menu larger.
So we've widened it by 1 column on displays `>=1280px`  and reduced the width of the content by 1 column to compensate.
This makes the menu much easier to read on laptop and desktop computer screens.

We fixed an inconsistency in the vertical spacing between menu items with sub-menus and those without.

And finally, we moved the version selector to the bottom of the side-bar to avoid distracting the reader.
![Screen Shot 2022-08-12 at 14 52 44](https://user-images.githubusercontent.com/978965/184367777-492b0dac-79ce-4ce7-aca2-39bfd432d599.png)
