### PR TITLE
Improve the table-of-contents 

### DIFF
--- a/components/docs/Toc.jsx
+++ b/components/docs/Toc.jsx
@@ -11,38 +11,30 @@ export default function Toc({ contents }) {
 
   return (
     contents.length > 0 && (
-      <div className="sticky top-4">
-        <div className="flex flex-col flex-grow rounded-lg">
-          <div className="flex items-center flex-shrink-0 px-2 pb-8">
-            <div className="flex-grow flex flex-col">
-              <nav className="flex-1 px-2 space-y-1">
-                <h4 className="text-blue-900 text-xs uppercase font-bold mt-6">
-                  On this page
-                </h4>
-                <ul>
-                  {contents.map((item) => {
-                    return (
-                      <TocMenuItem
-                        key={item.slug}
-                        slug={item.slug}
-                        raw={item.raw}
-                        text={item.text}
-                        isActive={
+        <nav className="sticky top-4">
+          <h4 className="text-blue-900 text-xs uppercase font-bold mb-2">
+            On this page
+          </h4>
+          <ul>
+            {contents.map((item) => {
+                return (
+                    <TocMenuItem
+                      key={item.slug}
+                      slug={item.slug}
+                      raw={item.raw}
+                      text={item.text}
+                      isActive={
                           firstLevelActiveLink === item.slug ||
-                          thirdLevelActiveLink === item.slug ||
-                          secondLevelActiveLink === item.slug
-                        }
-                        onSetActive={onSetActive}
-                        className="truncate"
-                      />
-                    )
-                  })}
-                </ul>
-              </nav>
-            </div>
-          </div>
-        </div>
-      </div>
+                              thirdLevelActiveLink === item.slug ||
+                              secondLevelActiveLink === item.slug
+                      }
+                      onSetActive={onSetActive}
+                      className="whitespace-nowrap mb-2"
+                    />
+                )
+            })}
+          </ul>
+        </nav>
     )
   )
 }

--- a/components/docs/Toc.jsx
+++ b/components/docs/Toc.jsx
@@ -12,7 +12,7 @@ export default function Toc({ contents }) {
   return (
     contents.length > 0 && (
       <div className="sticky top-4">
-        <div className="flex flex-col flex-grow overflow-y-auto rounded-lg">
+        <div className="flex flex-col flex-grow rounded-lg">
           <div className="flex items-center flex-shrink-0 px-2 pb-8">
             <div className="flex-grow flex flex-col">
               <nav className="flex-1 px-2 space-y-1">
@@ -33,6 +33,7 @@ export default function Toc({ contents }) {
                           secondLevelActiveLink === item.slug
                         }
                         onSetActive={onSetActive}
+                        className="truncate"
                       />
                     )
                   })}

--- a/components/docs/Toc.jsx
+++ b/components/docs/Toc.jsx
@@ -1,7 +1,23 @@
 import TocMenuItem from './TocMenuItem'
 import useHighLightLinks from './useHighLightLinks'
 
-export default function Toc({ contents }) {
+/*
+  Toc renders the table-of-contents based on the headings found in the current document (excluding the title heading)
+  It is displayed in the right-hand column when the display is >= 1280.
+
+  This component uses the following tailwind / windicss classes dynamically, so
+  we include the names here so that they can be extracted:
+
+  pl-0 pl-1 pl-2 pl-3 pl-4 pl-5 pl-6 pl-7 pl-8 pl-9 pl-10
+
+  See https://tailwindcss.com/docs/content-configuration#dynamic-class-names
+
+  @maxHeadingLevel: Headings at higher levels than this will be hidden from the TOC
+
+  @indentation: Each item will be indented by this much relative to the lowest heading level found in the TOC content.
+*/
+
+export default function Toc({ contents, maxHeadingLevel, indentation=2 }) {
   const {
     firstLevelActiveLink,
     thirdLevelActiveLink,
@@ -9,14 +25,17 @@ export default function Toc({ contents }) {
     onSetActive
   } = useHighLightLinks()
 
+  const items = contents.filter((item) => item.depth <= maxHeadingLevel)
+  const minLevel = Math.min(...items.map((item) => item.depth))
+
   return (
-    contents.length > 0 && (
+    items.length > 0 && (
         <nav className="sticky top-4">
           <h4 className="text-blue-900 text-xs uppercase font-bold mb-2">
             On this page
           </h4>
           <ul>
-            {contents.map((item) => {
+            {items.map((item) => {
                 return (
                     <TocMenuItem
                       key={item.slug}
@@ -29,7 +48,7 @@ export default function Toc({ contents }) {
                               secondLevelActiveLink === item.slug
                       }
                       onSetActive={onSetActive}
-                      className="whitespace-nowrap mb-2"
+                      className={`pl-${(item.depth - minLevel) * indentation} whitespace-nowrap mb-2`}
                     />
                 )
             })}

--- a/components/docs/TocMenuItem.jsx
+++ b/components/docs/TocMenuItem.jsx
@@ -7,7 +7,7 @@ const TocMenuItem = ({ slug, raw, text, isActive, onSetActive, className }) => {
     <li className={className}>
       <Link
         activeClass={activeClass}
-        className={`text-sm w-full text-blue-900 cursor-pointer inline-flex items-center py-2 leading-4 no-underline ${
+        className={`text-sm text-blue-900 cursor-pointer no-underline ${
           isActive && activeClass
         }`}
         to={slug}
@@ -17,6 +17,7 @@ const TocMenuItem = ({ slug, raw, text, isActive, onSetActive, className }) => {
         duration={500}
         delay={10}
         onSetActive={(to) => onSetActive(to, raw)}
+        title={text}
       >
         {text.replace(/`/g, '')}
       </Link>

--- a/pages/[...docs].jsx
+++ b/pages/[...docs].jsx
@@ -51,7 +51,7 @@ const DocumentationPage = ({
             </div>
           </main>
           <div className="hidden xl:block col-span-2 border-l border-gray-2/50 pl-5">
-            <Toc contents={tocHeadings} />
+            <Toc contents={tocHeadings} maxHeadingLevel={2} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
**Preview**: https://deploy-preview-1057--cert-manager-website.netlify.app/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/

* Made it so that the TOC items do not wrap and overflow the container column (which I think looks neater, given that the right hand column is so narrow).
* Made it possible to filter out the headings above level 2 (including the level-3 headings made the menu look too noisy)
* Removed some (I think) unnecessary HTML wrapper elements and CSS classes.


New:
![image](https://user-images.githubusercontent.com/978965/184502548-7b9ae9a2-a594-4008-b1cf-fd1937375779.png)

Current:
![image](https://user-images.githubusercontent.com/978965/184502632-7c1a5832-2330-440a-965d-a334dbb27466.png)

/cc @PatrickHeneise 