### PR TITLE
Add key attribute to TOC list items

### DIFF
--- a/components/docs/Toc.jsx
+++ b/components/docs/Toc.jsx
@@ -25,9 +25,9 @@ export default function Toc({ contents, maxHeadingLevel, indentation=2 }) {
             On this page
           </h4>
           <ul>
-            {items.map((item) => {
+            {items.map((item, idx) => {
                 return (
-                    <li className={`pl-${(item.depth - minLevel) * indentation} whitespace-nowrap mb-2`}>
+                    <li className={`pl-${(item.depth - minLevel) * indentation} whitespace-nowrap mb-2`} key={idx}>
                       <a
                         className="text-sm text-blue-900 cursor-pointer no-underline"
                         href={`#${item.slug}`}


### PR DESCRIPTION
See https://reactjs.org/docs/lists-and-keys.html#keys


This fixes the following warning printed by the `./scripts/server-netlify` script:

```console
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <ul>. See https://reactjs.org/link/warning-keys for more information.
    at li
    at Toc (webpack-internal:///./components/docs/Toc.jsx:22:19)
    at div
    at div
    at div
    at DocumentationPage (webpack-internal:///./pages/[...docs].jsx:39:30)
    at WithRouterWrapper (/home/richard/projects/cert-manager/website/node_modules/next/dist/client/with-router.js:11:34)
    at CertManager (webpack-internal:///./pages/_app.js:34:24)
    at StyleRegistry (/home/richard/projects/cert-manager/website/node_modules/styled-jsx/dist/index/index.js:671:34)
    at FlushEffectContainer (/home/richard/projects/cert-manager/website/node_modules/next/dist/server/render.js:406:37)
    at AppContainer (/home/richard/projects/cert-manager/website/node_modules/next/dist/server/render.js:421:29)
    at AppContainerWithIsomorphicFiberStructure (/home/richard/projects/cert-manager/website/node_modules/next/dist/server/render.js:452:57)
    at div
    at Body (/home/richard/projects/cert-manager/website/node_modules/next/dist/server/render.js:715:21)


```

/cc @PatrickHeneise 