### PR TITLE
Add a top-level Reference section

### DIFF
--- a/content/docs/faq/README.md
+++ b/content/docs/faq/README.md
@@ -1,12 +1,19 @@
 ---
-title: FAQ
-description: 'cert-manager FAQ: Overview / General Questions'
+title: Frequently Asked Questions (FAQ)
+description: Find answers to some frequently asked questions about cert-manager
 ---
 
-Below is an aggregation of solutions to some issues that cert-manager users may
-face:
+On this page you will find answers to some frequently asked questions about cert-manager.
 
-- [TLS Terminology, including commonly misused terms](./terminology.md)
+## Terminology
+
+### What does `publicly trusted` and `self-signed` mean?
+
+These terms are defined in the [TLS Terminology page](../reference/tls-terminology.md).
+
+### What do the terms `root`, `intermediate` and `leaf` _certificate_ mean?
+
+These terms are defined in the [TLS Terminology page](../reference/tls-terminology.md).
 
 ## Certificates
 

--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -423,16 +423,7 @@
         },
         {
           "title": "FAQ",
-          "routes": [
-            {
-              "title": "Introduction",
-              "path": "/docs/faq/README.md"
-            },
-            {
-              "title": "TLS Terminology",
-              "path": "/docs/faq/terminology.md"
-            }
-          ]
+          "path": "/docs/faq/README.md"
         },
         {
           "title": "Contributing",
@@ -671,38 +662,48 @@
             }
           ]
         },
-        {
-          "title": "CLI reference",
-          "routes": [
-            {
-              "title": "Introduction",
-              "path": "/docs/cli/README.md"
+          {
+            "title": "Reference",
+            "routes": [
+                {
+                "title": "TLS Terminology",
+                "path": "/docs/reference/tls-terminology.md"
             },
-            {
-              "title": "acmesolver",
-              "path": "/docs/cli/acmesolver.md"
+
+                {
+                "title": "Components",
+                "routes": [
+                    {
+                    "title": "Introduction",
+                    "path": "/docs/cli/README.md"
+                },
+                    {
+                    "title": "acmesolver",
+                    "path": "/docs/cli/acmesolver.md"
+                },
+                    {
+                    "title": "cainjector",
+                    "path": "/docs/cli/cainjector.md"
+                },
+                    {
+                    "title": "cmctl",
+                    "path": "/docs/cli/cmctl.md"
+                },
+                    {
+                    "title": "controller",
+                    "path": "/docs/cli/controller.md"
+                },
+                    {
+                    "title": "webhook",
+                    "path": "/docs/cli/webhook.md"
+                }
+                ]
             },
-            {
-              "title": "cainjector",
-              "path": "/docs/cli/cainjector.md"
-            },
-            {
-              "title": "cmctl",
-              "path": "/docs/cli/cmctl.md"
-            },
-            {
-              "title": "controller",
-              "path": "/docs/cli/controller.md"
-            },
-            {
-              "title": "webhook",
-              "path": "/docs/cli/webhook.md"
+                {
+                "title": "API",
+                "path": "/docs/reference/api-docs.md"
             }
-          ]
-        },
-        {
-          "title": "API reference",
-          "path": "/docs/reference/api-docs.md"
+            ]
         }
       ]
     }

--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -665,13 +665,17 @@
           {
             "title": "Reference",
             "routes": [
+            {
+                "title": "Introduction",
+                "path": "/docs/reference/README.md"
+            },
                 {
                 "title": "TLS Terminology",
                 "path": "/docs/reference/tls-terminology.md"
             },
 
                 {
-                "title": "Components",
+                "title": "Components / Docker Images",
                 "routes": [
                     {
                     "title": "Introduction",
@@ -700,7 +704,7 @@
                 ]
             },
                 {
-                "title": "API",
+                "title": "API Reference",
                 "path": "/docs/reference/api-docs.md"
             }
             ]

--- a/content/docs/reference/README.md
+++ b/content/docs/reference/README.md
@@ -1,0 +1,15 @@
+---
+title: Reference
+description: Reference material including TLS terminology, API documentation, and information about the command line flags of the cert-manager components.
+---
+
+This section contains reference material including TLS terminology, API documentation, and information about the command line flags of the cert-manager components.
+
+* [TLS Terminology](./tls-terminology.md):
+  Learn about the TLS terminology used in the cert-manager documentation such as `publicly trusted`, `self-signed`, `root`, `intermediate` and `leaf` _certificate_.
+
+* [Components / Docker Images](../cli/README.md):
+  Learn about the command line flags of the cert-manager Docker images: `controller`, `webhook`, `cainjector`, `acmesolver`, which run in containers in your cluster.
+
+* [API Reference](./api-docs.md):
+  Learn about the cert-manager API which includes Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.

--- a/content/docs/reference/api-docs.md
+++ b/content/docs/reference/api-docs.md
@@ -4,7 +4,7 @@ description: >-
   Learn about the cert-manager API which includes Custom Resources such as
   Certificate, CertificateRequest, Issuer and ClusterIssuer.
 ---
-Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
+Learn about the cert-manager API which includes Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>
 <ul>
   <li>

--- a/content/docs/reference/api-docs.md
+++ b/content/docs/reference/api-docs.md
@@ -1,7 +1,10 @@
 ---
-title: API reference docs
-description: cert-manager API reference documentation
+title: API Reference
+description: >-
+  Learn about the cert-manager API which comprises Custom Resources such as
+  Certificate, CertificateRequest, Issuer and ClusterIssuer
 ---
+Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>
 <ul>
   <li>
@@ -5642,5 +5645,5 @@ Resource Types:
 </table>
 <hr />
 <p>
-  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>feb7979cb</code>. </em>
+  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>4486c01f7</code>. </em>
 </p>

--- a/content/docs/reference/api-docs.md
+++ b/content/docs/reference/api-docs.md
@@ -1,8 +1,8 @@
 ---
 title: API Reference
 description: >-
-  Learn about the cert-manager API which comprises Custom Resources such as
-  Certificate, CertificateRequest, Issuer and ClusterIssuer
+  Learn about the cert-manager API which includes Custom Resources such as
+  Certificate, CertificateRequest, Issuer and ClusterIssuer.
 ---
 Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>

--- a/content/docs/reference/tls-terminology.md
+++ b/content/docs/reference/tls-terminology.md
@@ -1,7 +1,12 @@
 ---
 title: TLS Terminology
-description: 'cert-manager FAQ: TLS terminology'
+description: |
+    Learn about the TLS terminology used in the cert-manager documentation such as publicly trusted, self-signed, root, intermediate and leaf certificate
 ---
+
+Learn about the TLS terminology used in the cert-manager documentation such as publicly trusted, self-signed, root, intermediate and leaf certificate.
+
+## Overview
 
 With TLS being so widely deployed, terminology can sometimes get confused or be used to mean different things, and that reality
 combined with the complexity of TLS can lead to serious misunderstandings and confusion.
@@ -11,6 +16,8 @@ For further reference, you might want to check out some relevant RFCs:
 - [RFC 5246: TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246)
 - [RFC 8446: TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446)
 - [RFC 5280: X.509](https://datatracker.ietf.org/doc/html/rfc5280)
+
+## Definitions
 
 ### What does "publicly trusted" mean?
 

--- a/content/docs/reference/tls-terminology.md
+++ b/content/docs/reference/tls-terminology.md
@@ -4,7 +4,7 @@ description: |
     Learn about the TLS terminology used in the cert-manager documentation such as publicly trusted, self-signed, root, intermediate and leaf certificate
 ---
 
-Learn about the TLS terminology used in the cert-manager documentation such as publicly trusted, self-signed, root, intermediate and leaf certificate.
+Learn about the TLS terminology used in the cert-manager documentation such as `publicly trusted`, `self-signed`, `root`, `intermediate` and `leaf` _certificate_.
 
 ## Overview
 
@@ -19,7 +19,9 @@ For further reference, you might want to check out some relevant RFCs:
 
 ## Definitions
 
-### What does "publicly trusted" mean?
+### `publicly trusted`
+
+What does "publicly trusted" mean?
 
 Broadly speaking, a "publicly trusted" certificate is one that you can use on the Internet and expect
 that most reasonably up-to-date computers will be able to verify it using their system trust store.

--- a/content/next-docs/reference/api-docs.md
+++ b/content/next-docs/reference/api-docs.md
@@ -4,7 +4,7 @@ description: >-
   Learn about the cert-manager API which includes Custom Resources such as
   Certificate, CertificateRequest, Issuer and ClusterIssuer.
 ---
-Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
+Learn about the cert-manager API which includes Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>
 <ul>
   <li>

--- a/content/next-docs/reference/api-docs.md
+++ b/content/next-docs/reference/api-docs.md
@@ -1,7 +1,10 @@
 ---
-title: API reference docs
-description: cert-manager API reference documentation
+title: API Reference
+description: >-
+  Learn about the cert-manager API which comprises Custom Resources such as
+  Certificate, CertificateRequest, Issuer and ClusterIssuer
 ---
+Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>
 <ul>
   <li>
@@ -5642,5 +5645,5 @@ Resource Types:
 </table>
 <hr />
 <p>
-  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>feb7979cb</code>. </em>
+  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>4486c01f7</code>. </em>
 </p>

--- a/content/next-docs/reference/api-docs.md
+++ b/content/next-docs/reference/api-docs.md
@@ -1,8 +1,8 @@
 ---
 title: API Reference
 description: >-
-  Learn about the cert-manager API which comprises Custom Resources such as
-  Certificate, CertificateRequest, Issuer and ClusterIssuer
+  Learn about the cert-manager API which includes Custom Resources such as
+  Certificate, CertificateRequest, Issuer and ClusterIssuer.
 ---
 Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>

--- a/content/v1.9-docs/reference/api-docs.md
+++ b/content/v1.9-docs/reference/api-docs.md
@@ -4,7 +4,7 @@ description: >-
   Learn about the cert-manager API which includes Custom Resources such as
   Certificate, CertificateRequest, Issuer and ClusterIssuer.
 ---
-Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
+Learn about the cert-manager API which includes Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>
 <ul>
   <li>

--- a/content/v1.9-docs/reference/api-docs.md
+++ b/content/v1.9-docs/reference/api-docs.md
@@ -1,7 +1,10 @@
 ---
-title: API reference docs
-description: cert-manager API reference documentation
+title: API Reference
+description: >-
+  Learn about the cert-manager API which comprises Custom Resources such as
+  Certificate, CertificateRequest, Issuer and ClusterIssuer
 ---
+Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>
 <ul>
   <li>
@@ -5642,5 +5645,5 @@ Resource Types:
 </table>
 <hr />
 <p>
-  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>feb7979cb</code>. </em>
+  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>4486c01f7</code>. </em>
 </p>

--- a/content/v1.9-docs/reference/api-docs.md
+++ b/content/v1.9-docs/reference/api-docs.md
@@ -1,8 +1,8 @@
 ---
 title: API Reference
 description: >-
-  Learn about the cert-manager API which comprises Custom Resources such as
-  Certificate, CertificateRequest, Issuer and ClusterIssuer
+  Learn about the cert-manager API which includes Custom Resources such as
+  Certificate, CertificateRequest, Issuer and ClusterIssuer.
 ---
 Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 <p>Packages:</p>

--- a/public/_redirects
+++ b/public/_redirects
@@ -169,3 +169,6 @@ https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 302!
 /docs/faq/troubleshooting/ /docs/troubleshooting/ 301!
 /docs/faq/webhook/ /docs/troubleshooting/webhook/ 301!
 /docs/faq/acme/ /docs/troubleshooting/acme/ 301!
+
+# Moved FAQ terminology page to a new reference section
+/docs/faq/terminology/ /docs/reference/tls-terminology/ 301!

--- a/scripts/gendocs/templates/pkg.tpl
+++ b/scripts/gendocs/templates/pkg.tpl
@@ -1,8 +1,10 @@
 {{ define "packages" }}
 ---
-title: "API reference docs"
-description: "cert-manager API reference documentation"
+title: "API Reference"
+description: "Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer"
 ---
+
+Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 
 {{ with .packages}}
 <p>Packages:</p>

--- a/scripts/gendocs/templates/pkg.tpl
+++ b/scripts/gendocs/templates/pkg.tpl
@@ -4,7 +4,7 @@ title: "API Reference"
 description: "Learn about the cert-manager API which includes Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer."
 ---
 
-Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
+Learn about the cert-manager API which includes Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.
 
 {{ with .packages}}
 <p>Packages:</p>

--- a/scripts/gendocs/templates/pkg.tpl
+++ b/scripts/gendocs/templates/pkg.tpl
@@ -1,7 +1,7 @@
 {{ define "packages" }}
 ---
 title: "API Reference"
-description: "Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer"
+description: "Learn about the cert-manager API which includes Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer."
 ---
 
 Learn about the cert-manager API which comprises Custom Resources such as Certificate, CertificateRequest, Issuer and ClusterIssuer.


### PR DESCRIPTION
**Preview**: https://deploy-preview-1066--cert-manager-website.netlify.app/docs/

This is another step towards implementing the changes that we presented in 
 * https://github.com/cert-manager/website/pull/1048

- Moved `FAQ / TLS Terminology` to `Reference / TLS Terminology`
- Moved `API Reference` to `Reference / API`
- Moved `CLI Reference` to `Reference / Components` (but decided not to change the URLs for now, since I'm not sure how to do the redirects for those generated pages)

Additionally, we've tried to add more descriptive page titles and metadata descriptions  for each of the pages that we've moved.

/cc @mehak151 @maelvls @jsoref 