### PR TITLE
Use the correct spelling of GitHub on the homepage

### DIFF
--- a/content/pages/homepage.mdx
+++ b/content/pages/homepage.mdx
@@ -10,7 +10,7 @@ export const meta = {
   stats: [
     {
       icon: 'github',
-      description: '9000+ Github Stars'
+      description: '9000+ GitHub Stars'
     },
     {
       icon: 'slack',
@@ -26,7 +26,7 @@ export const meta = {
       {
         icon: 'github',
         href: 'https://github.com/cert-manager/cert-manager',
-        caption: 'Github Repository',
+        caption: 'GitHub Repository',
         target: '_blank'
       },
       {
@@ -88,7 +88,7 @@ export const meta = {
       {
         icon: 'github',
         href: 'https://github.com/cert-manager/cert-manager',
-        caption: 'Github Repository',
+        caption: 'GitHub Repository',
         target: '_blank'
       },
       {


### PR DESCRIPTION
I checked for other misspellings such as `github` and `Github` as follows:

```terminal
$ git grep '\s[Gg]ithub\s'
```  
...but found none.


/cc @jsoref 