### PR TITLE
Add a Last Verified date to the GKE tutorial

### DIFF
--- a/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
+++ b/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
@@ -3,6 +3,8 @@ title: Deploy cert-manager on Google Kubernetes Engine (GKE) and create SSL cert
 description: Learn how to deploy cert-manager on Google Kubernetes (GKE) Engine and then configure it to sign SSL certificates using Let's Encrypt
 ---
 
+*Last Verified: 15 July 2022*
+
 In this tutorial you will learn how to deploy and configure cert-manager on Google Kubernetes Engine (GKE).
 You will learn how to configure cert-manager to get a signed SSL certificate from Let's Encrypt,
 using an [HTTP-01 challenge](https://letsencrypt.org/docs/challenge-types/#http-01-challenge).


### PR DESCRIPTION
**Preview:** https://deploy-preview-1068--cert-manager-website.netlify.app/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/

So that people can judge whether the content is up-to-date.

As proposed by @inteon during the discussion in cert-manager development meeting on 24 August 2022:
 *  https://docs.google.com/document/d/1Tc5t6ylY9dhXAan1OjOoldeaoys1Yh4Ir710ATfBa5U/edit#bookmark=id.rhtxnoi01ue8

/cc @inteon 