### PR TITLE
Improved the summary on the docs homepage

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -1,14 +1,14 @@
 ---
 title: cert-manager
 description: |
-    cert-manager creates signed TLS / SSL certificates for workloads in your Kubernetes or OpenShift cluster
+    cert-manager creates TLS certificates for workloads in your Kubernetes or OpenShift cluster
     and renews the certificates before they expire.
 ---
 
-cert-manager creates signed TLS / SSL certificates for workloads in your Kubernetes or OpenShift cluster
+cert-manager creates TLS certificates for workloads in your Kubernetes or OpenShift cluster
 and renews the certificates before they expire.
-The private key and signed certificate are stored in Kubernetes secrets and used by applications or ingress controllers. The csi-driver addon instead lets applications mount these certificates in its container directly, ideal for short-lived certificates.
-and used by applications or ingress controllers.
+The private key and certificate are stored in Kubernetes secrets and used by applications or ingress controllers.
+The csi-driver addon instead lets applications mount these certificates in its container directly, ideal for short-lived certificates.
 
 cert-manager can obtain certificates from a variety of certificate authorities, including:
 [Let's Encrypt](configuration/acme/README.md), [HashiCorp Vault](configuration/vault.md),

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -1,23 +1,19 @@
 ---
 title: cert-manager
-description: cert-manager documentation homepage
+description: |
+    cert-manager creates signed TLS / SSL certificates for workloads in your Kubernetes or OpenShift cluster
+    and renews the certificates before they expire.
 ---
 
-cert-manager adds certificates and certificate issuers as resource types in
-Kubernetes clusters, and simplifies the process of obtaining, renewing and
-using those certificates.
+cert-manager creates signed TLS / SSL certificates for workloads in your Kubernetes or OpenShift cluster
+and renews the certificates before they expire.
+Typically, the private key and signed certificate are stored in Kubernetes secrets
+and used by applications or ingress controllers.
 
-It can issue certificates from a variety of supported sources, including
-[Let's Encrypt](https://letsencrypt.org), [HashiCorp Vault](https://www.vaultproject.io),
-and [Venafi](https://www.venafi.com/) as well as private PKI.
+cert-manager can obtain the signed certificates from a variety of certificate authorities, including:
+[Let's Encrypt](configuration/acme/), [HashiCorp Vault](configuration/vault/),
+[Venafi](configuration/venafi/) and [private PKI](configuration/ca/).
 
-It will ensure certificates are valid and up to date, and attempt to
-renew certificates at a configured time before expiry.
-
-It is loosely based upon the work of
-[kube-lego](https://github.com/jetstack/kube-lego) and has borrowed some
-wisdom from other similar projects such as
-[kube-cert-manager](https://github.com/PalmStoneGames/kube-cert-manager).
 
 ![High level overview diagram explaining cert-manager architecture](/images/high-level-overview.svg)
 

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -10,7 +10,7 @@ and renews the certificates before they expire.
 Typically, the private key and signed certificate are stored in Kubernetes secrets
 and used by applications or ingress controllers.
 
-cert-manager can obtain the signed certificates from a variety of certificate authorities, including:
+cert-manager can obtain signed certificates from a variety of certificate authorities, including:
 [Let's Encrypt](configuration/acme/README.md), [HashiCorp Vault](configuration/vault.md),
 [Venafi](configuration/venafi.md) and [private PKI](configuration/ca.md).
 

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -1,8 +1,7 @@
 ---
 title: cert-manager
 description: |
-    cert-manager creates TLS certificates for workloads in your Kubernetes or OpenShift cluster
-    and renews the certificates before they expire.
+    cert-manager creates TLS certificates for workloads in your Kubernetes or OpenShift cluster and renews the certificates before they expire.
 ---
 
 cert-manager creates TLS certificates for workloads in your Kubernetes or OpenShift cluster
@@ -16,7 +15,7 @@ With cert-manager's [Certificate resource](usage/certificate.md), the private ke
 which is mounted by an application Pod or used by an Ingress controller.
 With [csi-driver](usage/csi-driver.md), [csi-driver-spiffe](usage/csi-driver-spiffe.md), or [istio-csr](usage/istio-csr.md) ,
 the private key is generated on-demand, before the application starts up;
-the private key never leaves the node and it is not stored a Kubernetes Secret.
+the private key never leaves the node and it is not stored in a Kubernetes Secret.
 
 ![High level overview diagram explaining cert-manager architecture](/images/high-level-overview.svg)
 

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -11,8 +11,8 @@ Typically, the private key and signed certificate are stored in Kubernetes secre
 and used by applications or ingress controllers.
 
 cert-manager can obtain the signed certificates from a variety of certificate authorities, including:
-[Let's Encrypt](configuration/acme/), [HashiCorp Vault](configuration/vault/),
-[Venafi](configuration/venafi/) and [private PKI](configuration/ca/).
+[Let's Encrypt](configuration/acme/README.md), [HashiCorp Vault](configuration/vault.md),
+[Venafi](configuration/venafi.md) and [private PKI](configuration/ca.md).
 
 
 ![High level overview diagram explaining cert-manager architecture](/images/high-level-overview.svg)

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -7,13 +7,15 @@ description: |
 
 cert-manager creates TLS certificates for workloads in your Kubernetes or OpenShift cluster
 and renews the certificates before they expire.
-The private key and certificate are stored in Kubernetes secrets and used by applications or ingress controllers.
-The csi-driver addon instead lets applications mount these certificates in its container directly, ideal for short-lived certificates.
+The private key and certificate are stored in Kubernetes Secrets and used by applications or ingress controllers.
+
+With the [csi-driver](projects/csi-driver.md), [csi-driver-spiffe](projects/csi-driver-spiffe.md), or [istio-csr](projects/istio-csr.md) addons,
+the private key is generated on-demand, before the application starts up;
+the private key never leaves the node and it is not stored a Kubernetes Secret.
 
 cert-manager can obtain certificates from a variety of certificate authorities, including:
 [Let's Encrypt](configuration/acme/README.md), [HashiCorp Vault](configuration/vault.md),
 [Venafi](configuration/venafi.md) and [private PKI](configuration/ca.md).
-
 
 ![High level overview diagram explaining cert-manager architecture](/images/high-level-overview.svg)
 

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -7,10 +7,10 @@ description: |
 
 cert-manager creates signed TLS / SSL certificates for workloads in your Kubernetes or OpenShift cluster
 and renews the certificates before they expire.
-Typically, the private key and signed certificate are stored in Kubernetes secrets
+The private key and signed certificate are stored in Kubernetes secrets and used by applications or ingress controllers. The csi-driver addon instead lets applications mount these certificates in its container directly, ideal for short-lived certificates.
 and used by applications or ingress controllers.
 
-cert-manager can obtain signed certificates from a variety of certificate authorities, including:
+cert-manager can obtain certificates from a variety of certificate authorities, including:
 [Let's Encrypt](configuration/acme/README.md), [HashiCorp Vault](configuration/vault.md),
 [Venafi](configuration/venafi.md) and [private PKI](configuration/ca.md).
 

--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -7,15 +7,16 @@ description: |
 
 cert-manager creates TLS certificates for workloads in your Kubernetes or OpenShift cluster
 and renews the certificates before they expire.
-The private key and certificate are stored in Kubernetes Secrets and used by applications or ingress controllers.
 
-With the [csi-driver](projects/csi-driver.md), [csi-driver-spiffe](projects/csi-driver-spiffe.md), or [istio-csr](projects/istio-csr.md) addons,
-the private key is generated on-demand, before the application starts up;
-the private key never leaves the node and it is not stored a Kubernetes Secret.
-
-cert-manager can obtain certificates from a variety of certificate authorities, including:
+cert-manager can obtain certificates from a [variety of certificate authorities](configuration/issuers.md), including:
 [Let's Encrypt](configuration/acme/README.md), [HashiCorp Vault](configuration/vault.md),
 [Venafi](configuration/venafi.md) and [private PKI](configuration/ca.md).
+
+With cert-manager's [Certificate resource](usage/certificate.md), the private key and certificate are stored in a Kubernetes Secret
+which is mounted by an application Pod or used by an Ingress controller.
+With [csi-driver](usage/csi-driver.md), [csi-driver-spiffe](usage/csi-driver-spiffe.md), or [istio-csr](usage/istio-csr.md) ,
+the private key is generated on-demand, before the application starts up;
+the private key never leaves the node and it is not stored a Kubernetes Secret.
 
 ![High level overview diagram explaining cert-manager architecture](/images/high-level-overview.svg)
 


### PR DESCRIPTION
**Preview**: https://deploy-preview-1071--cert-manager-website.netlify.app/docs/

The opening paragraph of the `docs/` homepage was a bit waffly, 
so we've tried to get straight to the point and linked to the internal pages about each supported CA rather than sending visitors off to external sites before they've read about the cert-manager integration with each of the CAs.