### PR TITLE
Mark ADCS issuer as not maintained

### DIFF
--- a/content/docs/configuration/external.md
+++ b/content/docs/configuration/external.md
@@ -41,6 +41,7 @@ These external issuers are known to support and honor [approval](https://cert-ma
   certificates signed by [FreeIPA](https://www.freeipa.org).
 - [ADCS Issuer](https://github.com/nokia/adcs-issuer): Requests
   certificates signed by [Microsoft Active Directory Certificate Service](https://docs.microsoft.com/en-us/windows-server/networking/core-network-guide/cncg/server-certs/install-the-certification-authority).
+  [NOT MAINTAINED]
 - [CFSSL Issuer](https://gerrit.wikimedia.org/r/plugins/gitiles/operations/software/cfssl-issuer/): Request certificates signed by a [CFSSL](https://github.com/cloudflare/cfssl) `multirootca` instance.
 - [ncm-issuer](https://github.com/nokia/ncm-issuer): Requests certificates from the [Nokia](https://www.nokia.com/) [Netguard Certificate Manager](https://www.nokia.com/networks/security-portfolio/netguard/certificate-manager)
 - [tcs-issuer](https://github.com/intel/trusted-certificate-issuer) Requests certificates signed securely using [Intel's SGX technology](https://www.intel.com/content/www/us/en/developer/tools/software-guard-extensions/overview.html).


### PR DESCRIPTION
According to their README ADCS issuer is not maintained anymore