### PR TITLE
Vault: document the new field "serviceAccountRef"

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -553,6 +553,10 @@ NetworkPolicy
 mjudeikis
 rgl
 1password
+secretless
+TokenRequest
+v1.12.0
+v1.12.0.
 
 # TEMPORARY
 # these are temporarily ignored because the spellchecker

--- a/content/docs/configuration/vault.md
+++ b/content/docs/configuration/vault.md
@@ -163,7 +163,7 @@ Kubernetes service account token can be provided in two ways:
 
 With the secretless authentication with a service account, cert-manager creates
 an ephemeral service account token using the TokenRequest API and uses it to
-authenticates with Vault. These tokens are short-lived (10 minutes) and are
+authenticate with Vault. These tokens are short-lived (10 minutes) and are
 never stored to disk.
 
 This is the recommended authentication method because it does not rely on the

--- a/content/docs/configuration/vault.md
+++ b/content/docs/configuration/vault.md
@@ -230,7 +230,7 @@ spec:
 > **Issuer vs. ClusterIssuer:** With an Issuer resource, you can only refer to a
 > service account located in the same namespace as the Issuer. With a
 > ClusterIssuer, the service account must be located in the namespace that is
-> configured by the flag `--cluster-scoped namespace`.
+> configured by the flag `--cluster-resource-namespace`.
 
 To create the role in Vault, you can use the following command:
 
@@ -249,7 +249,7 @@ Issuer or ClusterIssuer. The syntax is the following:
 
 ```yaml
 "vault://<namespace>/<issuer-name>"   # For an Issuer.
-"vault://<issuer-name>"               # For a ClusterIssuer.
+"vault://<cluster-issuer-name>"       # For a ClusterIssuer.
 ```
 
 The expiration duration for the Kubernetes tokens that are requested is

--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -8,8 +8,8 @@
           "path": "/docs/README.md"
         },
         {
-            "title": "Getting Started",
-            "path": "/docs/getting-started/README.md"
+          "title": "Getting Started",
+          "path": "/docs/getting-started/README.md"
         },
         {
           "title": "Installation",
@@ -70,8 +70,8 @@
                   "path": "/docs/installation/upgrading/upgrading-1.10-1.11.md"
                 },
                 {
-                    "title": "v1.9 to v1.10",
-                    "path": "/docs/installation/upgrading/upgrading-1.9-1.10.md"
+                  "title": "v1.9 to v1.10",
+                  "path": "/docs/installation/upgrading/upgrading-1.9-1.10.md"
                 },
                 {
                   "title": "v1.8 to v1.9",
@@ -353,12 +353,12 @@
               "title": "trust-manager",
               "routes": [
                 {
-                    "title": "Introduction",
-                    "path": "/docs/projects/trust-manager/README.md"
+                  "title": "Introduction",
+                  "path": "/docs/projects/trust-manager/README.md"
                 },
                 {
-                    "title": "API Reference",
-                    "path": "/docs/projects/trust-manager/api-reference.md"
+                  "title": "API Reference",
+                  "path": "/docs/projects/trust-manager/api-reference.md"
                 }
               ]
             }
@@ -372,20 +372,20 @@
               "path": "/docs/tutorials/README.md"
             },
             {
-                "title": "Securing NGINX-ingress",
-                "path": "/docs/tutorials/acme/nginx-ingress.md"
+              "title": "Securing NGINX-ingress",
+              "path": "/docs/tutorials/acme/nginx-ingress.md"
             },
             {
-                "title": "GKE + Ingress + Let's Encrypt",
-                "path": "/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md"
+              "title": "GKE + Ingress + Let's Encrypt",
+              "path": "/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md"
             },
             {
-                "title": "AKS + LoadBalancer + Let's Encrypt",
-                "path": "/docs/tutorials/getting-started-aks-letsencrypt/README.md"
+              "title": "AKS + LoadBalancer + Let's Encrypt",
+              "path": "/docs/tutorials/getting-started-aks-letsencrypt/README.md"
             },
             {
-                "title": "Migrating from Kube-LEGO",
-                "path": "/docs/tutorials/acme/migrating-from-kube-lego.md"
+              "title": "Migrating from Kube-LEGO",
+              "path": "/docs/tutorials/acme/migrating-from-kube-lego.md"
             },
             {
               "title": "Backup and Restore Resources",
@@ -421,22 +421,22 @@
             }
           ]
         },
-          {
-            "title": "Troubleshooting",
-            "routes": [
-                {
-                "title": "Introduction",
-                "path": "/docs/troubleshooting/README.md"
+        {
+          "title": "Troubleshooting",
+          "routes": [
+            {
+              "title": "Introduction",
+              "path": "/docs/troubleshooting/README.md"
             },
             {
-                "title": "Troubleshooting ACME / Let's Encrypt Certificates",
-                "path": "/docs/troubleshooting/acme.md"
+              "title": "Troubleshooting ACME / Let's Encrypt Certificates",
+              "path": "/docs/troubleshooting/acme.md"
             },
             {
-                "title": "Troubleshooting webhook",
-                "path": "/docs/troubleshooting/webhook.md"
+              "title": "Troubleshooting webhook",
+              "path": "/docs/troubleshooting/webhook.md"
             }
-            ]
+          ]
         },
         {
           "title": "FAQ",
@@ -545,12 +545,16 @@
               "path": "/docs/release-notes/README.md"
             },
             {
+              "title": "v1.12",
+              "path": "/docs/release-notes/release-notes-1.12.md"
+            },
+            {
               "title": "v1.11",
               "path": "/docs/release-notes/release-notes-1.11.md"
             },
             {
-                "title": "v1.10",
-                "path": "/docs/release-notes/release-notes-1.10.md"
+              "title": "v1.10",
+              "path": "/docs/release-notes/release-notes-1.10.md"
             },
             {
               "title": "v1.9",
@@ -691,56 +695,56 @@
             }
           ]
         },
-          {
-            "title": "Reference",
-            "routes": [
+        {
+          "title": "Reference",
+          "routes": [
             {
-                "title": "Introduction",
-                "path": "/docs/reference/README.md"
+              "title": "Introduction",
+              "path": "/docs/reference/README.md"
             },
             {
-                "title": "Command Line Tool (cmctl)",
-                "path": "/docs/reference/cmctl.md"
+              "title": "Command Line Tool (cmctl)",
+              "path": "/docs/reference/cmctl.md"
             },
-                {
-                "title": "TLS Terminology",
-                "path": "/docs/reference/tls-terminology.md"
+            {
+              "title": "TLS Terminology",
+              "path": "/docs/reference/tls-terminology.md"
             },
 
+            {
+              "title": "Components / Docker Images",
+              "routes": [
                 {
-                "title": "Components / Docker Images",
-                "routes": [
-                    {
-                    "title": "Introduction",
-                    "path": "/docs/cli/README.md"
+                  "title": "Introduction",
+                  "path": "/docs/cli/README.md"
                 },
-                    {
-                    "title": "acmesolver",
-                    "path": "/docs/cli/acmesolver.md"
+                {
+                  "title": "acmesolver",
+                  "path": "/docs/cli/acmesolver.md"
                 },
-                    {
-                    "title": "cainjector",
-                    "path": "/docs/cli/cainjector.md"
+                {
+                  "title": "cainjector",
+                  "path": "/docs/cli/cainjector.md"
                 },
-                    {
-                    "title": "cmctl",
-                    "path": "/docs/cli/cmctl.md"
+                {
+                  "title": "cmctl",
+                  "path": "/docs/cli/cmctl.md"
                 },
-                    {
-                    "title": "controller",
-                    "path": "/docs/cli/controller.md"
+                {
+                  "title": "controller",
+                  "path": "/docs/cli/controller.md"
                 },
-                    {
-                    "title": "webhook",
-                    "path": "/docs/cli/webhook.md"
+                {
+                  "title": "webhook",
+                  "path": "/docs/cli/webhook.md"
                 }
-                ]
+              ]
             },
-                {
-                "title": "API Reference",
-                "path": "/docs/reference/api-docs.md"
+            {
+              "title": "API Reference",
+              "path": "/docs/reference/api-docs.md"
             }
-            ]
+          ]
         }
       ]
     }

--- a/content/docs/release-notes/README.md
+++ b/content/docs/release-notes/README.md
@@ -3,6 +3,7 @@ title: Release Notes
 description: 'cert-manager release notes: Overview'
 ---
 
+- [`v1.12`](./release-notes-1.12.md)
 - [`v1.11`](./release-notes-1.11.md)
 - [`v1.10`](./release-notes-1.10.md)
 - [`v1.9`](./release-notes-1.9.md)

--- a/content/docs/release-notes/release-notes-1.12.md
+++ b/content/docs/release-notes/release-notes-1.12.md
@@ -1,0 +1,19 @@
+---
+title: Release 1.12
+description: 'cert-manager release notes: cert-manager 1.12'
+---
+
+## Major Themes
+
+### Support for ephemeral service account tokens in Vault
+
+cert-manager can now authenticate to Vault using ephemeral service account
+tokens. cert-manager already knew to authenticate to Vault using the [Vault
+Kubernetes Auth
+Method](https://developer.hashicorp.com/vault/docs/auth/kubernetes) but relied
+on insecure service account tokens stored in Secrets. You can now configure
+cert-manager in a secretless manner. With this new feature, cert-manager will
+create an ephemeral service account token on your behalf and use that to
+authenticate to Vault.
+
+> 📖 Read about [Secretless Authentication with a Service Account](../configuration/vault#secretless-authentication-with-a-service-account).

--- a/content/docs/release-notes/release-notes-1.12.md
+++ b/content/docs/release-notes/release-notes-1.12.md
@@ -16,4 +16,4 @@ cert-manager in a secretless manner. With this new feature, cert-manager will
 create an ephemeral service account token on your behalf and use that to
 authenticate to Vault.
 
-> 📖 Read about [Secretless Authentication with a Service Account](../configuration/vault#secretless-authentication-with-a-service-account).
+> 📖 Read about [Secretless Authentication with a Service Account](../configuration/vault.md#secretless-authentication-with-a-service-account).

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate:sitemap": "next-sitemap",
     "export": "next export",
     "start": "next start",
-    "check": "concurrently --group --timings npm:check:* # Run all the npm check:* scripts in parallel",
+    "check": "npm exec concurrently -y -- --group --timings npm:check:* # Run all the npm check:* scripts in parallel",
     "check:next-lint": "next lint",
     "check:links": "find content/docs -type f -name '*.md' | xargs markdown-link-check --quiet --config markdown-link-check.json 2>&1 | awk -v RS=FILE: '/ERROR/{f=1; print RS $0} END{exit f}' # Split into records based on the word FILE and print only records containing word ERROR",
     "check:spelling": "FORCE_COLOR=1 mdspell --report --en-us --ignore-numbers --ignore-acronyms 'content/**/*.md' 'content/**/*.html' '_layouts/*.html' '_includes/*.html' '*.html' '!**/api-docs.md' # Force color output in mdspell. # See https://github.com/lukeapage/node-markdown-spellcheck/issues/36#issuecomment-482649408 ",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate:sitemap": "next-sitemap",
     "export": "next export",
     "start": "next start",
-    "check": "npm exec concurrently -y -- --group --timings npm:check:* # Run all the npm check:* scripts in parallel",
+    "check": "concurrently --group --timings npm:check:* # Run all the npm check:* scripts in parallel",
     "check:next-lint": "next lint",
     "check:links": "find content/docs -type f -name '*.md' | xargs markdown-link-check --quiet --config markdown-link-check.json 2>&1 | awk -v RS=FILE: '/ERROR/{f=1; print RS $0} END{exit f}' # Split into records based on the word FILE and print only records containing word ERROR",
     "check:spelling": "FORCE_COLOR=1 mdspell --report --en-us --ignore-numbers --ignore-acronyms 'content/**/*.md' 'content/**/*.html' '_layouts/*.html' '_includes/*.html' '*.html' '!**/api-docs.md' # Force color output in mdspell. # See https://github.com/lukeapage/node-markdown-spellcheck/issues/36#issuecomment-482649408 ",


### PR DESCRIPTION
| Preview: https://deploy-preview-1081--cert-manager-website.netlify.app/docs/configuration/vault/#authenticating-with-a-kubernetes-service-account-without-a-secret |
|:--|

The feature itself is being developed in ~https://github.com/cert-manager/cert-manager/pull/4524~ https://github.com/cert-manager/cert-manager/pull/5502.