### PR TITLE
Update docs to remove subchart warning

### DIFF
--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -7,9 +7,6 @@ description: 'cert-manager installation: Using Helm'
 
 cert-manager provides Helm charts as a first-class method of installation on both Kubernetes and OpenShift.
 
-Be sure never to embed cert-manager as a sub-chart of other Helm charts; cert-manager manages
-non-namespaced resources in your cluster and care must be taken to ensure that it is installed exactly once.
-
 ### Prerequisites
 
 - [Install Helm version 3 or later](https://helm.sh/docs/intro/install/).

--- a/content/next-docs/installation/helm.md
+++ b/content/next-docs/installation/helm.md
@@ -7,9 +7,6 @@ description: 'cert-manager installation: Using Helm'
 
 cert-manager provides Helm charts as a first-class method of installation on both Kubernetes and OpenShift.
 
-Be sure never to embed cert-manager as a sub-chart of other Helm charts; cert-manager manages
-non-namespaced resources in your cluster and care must be taken to ensure that it is installed exactly once.
-
 ### Prerequisites
 
 - [Install Helm version 3 or later](https://helm.sh/docs/intro/install/).

--- a/content/v1.9-docs/installation/helm.md
+++ b/content/v1.9-docs/installation/helm.md
@@ -6,10 +6,6 @@ description: 'cert-manager installation: Using Helm'
 ## Installing with Helm
 
 cert-manager provides Helm charts as a first-class method of installation on both Kubernetes and OpenShift.
-
-Be sure never to embed cert-manager as a sub-chart of other Helm charts; cert-manager manages
-non-namespaced resources in your cluster and care must be taken to ensure that it is installed exactly once.
-
 ### Prerequisites
 
 - [Install Helm version 3 or later](https://helm.sh/docs/intro/install/).


### PR DESCRIPTION
Since it appears that this is supported since v 1.9 and support is documented below the warning on the same page, this removes the warning for users to not use cert-manager as a sub chart.

Resolves https://github.com/cert-manager/cert-manager/issues/5503