### PR TITLE
Adding SSA related warnings to the affected versions

### DIFF
--- a/content/docs/installation/supported-releases.md
+++ b/content/docs/installation/supported-releases.md
@@ -16,23 +16,25 @@ release every two months.
 
 | Release  | Release Date |   End of Life   | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |----------|:------------:|:---------------:|:----------------------------------:|:---------------------------------:|
-| [1.10][] | Oct 17, 2022 | Release of 1.12 |            1.20 → 1.25             |             4.7 → 4.11            |
-| [1.9][]  | Jul 22, 2022 | Release of 1.11 |            1.20 → 1.24             |             4.7 → 4.11            |
+| [1.10][] | Oct 17, 2022 | Release of 1.12 |            1.20 → 1.25*            |            4.7 → 4.11             |
+| [1.9][]  | Jul 22, 2022 | Release of 1.11 |            1.20 → 1.24*            |            4.7 → 4.11             |
 
+\*ServerSideApply should be enabled in the cluster
 ## Upcoming releases
 
 | Release  |         Release Date          |  End of life   | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |----------|:-----------------------------:|:--------------:|:----------------------------------:|:---------------------------------:|
-| [1.11][] |   ~Late Dec 22/Early Jan 23   | Mid June, 2023 |            1.20 → 1.25             |             4.7 → 4.11            |
+| [1.11][] |   ~Late Dec 22/Early Jan 23   | Mid June, 2023 |            1.20 → 1.25*            |            4.7 → 4.11             |
 
 Dates in the future are uncertain and might change.
 
+\*ServerSideApply must be enabled in the cluster.
 ## Old releases
 
 | Release  | Release Date |     EOL      | Compatible Kubernetes versions | Compatible OpenShift versions |
 |----------|:------------:|:------------:|:------------------------------:|:-----------------------------:|
-| [1.8][]  | Apr 05, 2022 | Oct 17, 2022 |          1.19 → 1.24           |          4.6 → 4.11           |
-| [1.7][]  | Jan 26, 2021 | Jul 22, 2022 |          1.18 → 1.23           |           4.5 → 4.9           |
+| [1.8][]  | Apr 05, 2022 | Oct 17, 2022 |          1.19 → 1.24*          |          4.6 → 4.11           |
+| [1.7][]  | Jan 26, 2021 | Jul 22, 2022 |          1.18 → 1.23*          |           4.5 → 4.9           |
 | [1.6][]  | Oct 26, 2021 | Apr 05, 2022 |          1.17 → 1.22           |           4.4 → 4.9           |
 | [1.5][]  | Aug 11, 2021 | Jan 26, 2022 |          1.16 → 1.22           |           4.3 → 4.8           |
 | [1.4][]  | Jun 15, 2021 | Oct 26, 2021 |          1.16 → 1.21           |           4.3 → 4.7           |
@@ -72,6 +74,7 @@ and release notes on [cert-manager.io](https://cert-manager.io/docs/release-note
 
 We also maintain detailed [upgrade instructions](https://cert-manager.io/docs/installation/upgrading/).
 
+\*ServerSideApply must be enabled in the cluster.
 ## Support policy
 
 ### What we mean by support

--- a/content/docs/installation/upgrading/upgrading-1.6-1.7.md
+++ b/content/docs/installation/upgrading/upgrading-1.6-1.7.md
@@ -14,6 +14,10 @@ Please read [Migrating Deprecated API Resources] for full instructions.
 If you are currently using HTTP-01 challenges or the Ingress shim annotations, please read the [Ingress class compatibility](./ingress-class-compatibility.md)
 notes to see if your Ingress controller has any known issues with the migration to Ingress v1.
 
+If running Kubernetes versions before `v1.22`, the 
+[`ServerSideApply`](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
+feature gate _must_ be enabled in the cluster. This beta feature is enabled by default
+on supported versions before `v1.22`.
 
 ## Now Follow the Regular Upgrade Process
 

--- a/content/docs/installation/upgrading/upgrading-1.7-1.8.md
+++ b/content/docs/installation/upgrading/upgrading-1.7-1.8.md
@@ -41,6 +41,11 @@ The reason the Challenge resources need to be removed before upgrading to 1.8
 when using the new Server-Side Apply feature is that cert-manager post-1.8 is
 not able to clean up Challenge resources that were created pre-1.8.
 
+If running Kubernetes versions before `v1.22`, the
+[`ServerSideApply`](https://kubernetes.io/docs/reference/using-api/server-side-apply/) 
+feature gate _must_ be enabled in the cluster. This beta feature is enabled by
+default on supported versions before `v1.22`.
+
 #### Migrating from the Gateway API v1alpha1 to v1alpha2
 
 This section only applies to you if you are using the feature gate

--- a/content/docs/installation/upgrading/upgrading-1.8-1.9.md
+++ b/content/docs/installation/upgrading/upgrading-1.8-1.9.md
@@ -3,6 +3,9 @@ title: Upgrading from v1.8 to v1.9
 description: 'cert-manager installation: Upgrading v1.8 to v1.9'
 ---
 
-When upgrading from `v1.8` to `v1.9`, no special upgrade steps are required 🎉
+If running Kubernetes versions before `v1.22`, the
+[`ServerSideApply`](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
+feature gate _must_ be enabled in the cluster. This beta feature is enabled by default
+on supported versions before `v1.22`.
 
 From here on you can follow the [regular upgrade process](./README.md).


### PR DESCRIPTION
Signed-off-by: Sathyanarayanan Saravanamuthu <sathyanarays@.vmware.com>

## Description
- Added notes for versions 1.7, 1.8, 1.9 and 1.10 to enable SSA in the cluster
- Added a line to mandate SSA enabled while upgrading from 1.6 to 1.7
- - I haven't added this line to other upgrades (1.7 -> 1.8,...). These are not required. For example, if any customer is running version 1.7 successfully, that implicitly means SSA is enabled. So, no special instructions are required.