### PR TITLE
Venafi: mention why username & password is not supported on TPP  >= 19.2

### DIFF
--- a/content/docs/configuration/venafi.md
+++ b/content/docs/configuration/venafi.md
@@ -189,10 +189,10 @@ $ kubectl create secret generic \
 
 #### Username / Password Authentication
 
-NOTE: username / password authentication is deprecated and should only be used when connecting to TPP < 19.2.
-It requires the username and password of a TPP user to be stored in the Kubernetes cluster
-and it does not allow scoped access to the API.
-This means that if these credentials are leaked an attacker may gain long term access to the TPP API and web UI.
+NOTE: cert-manager uses a deprecated TPP endpoint for authenticating with a username
+and password. cert-manager has not been updated to use the newer authentication
+endpoint. Because of this limitation in cert-manager, you should only use username
+and password with to TPP < 19.2.
 
 ```bash
 $ kubectl create secret generic \


### PR DESCRIPTION
The cert-manager documentation makes people think that username and password authentication has been dropped entirely in Venafi TPP 19.2. In reality, the username and password will always be supported as an authentication method.

The issue comes from cert-manager itself: cert-manager has not moved yet to the newer `/vedauth/authorize/oauth` because vcert itself doesn't support it yet. vcert [still relies](https://github.com/Venafi/vcert/blob/b89f255872d0253f67902cd9d5f270386a8d9ad6/pkg/venafi/tpp/tpp.go#L343) on the endpoint `/vedsdk/authorize`.

The `/vedsdk/authorize` endpoint itself works fine until TPP 22.1. In TPP 22.2, anyone willing to continue using this endpoint will  have to ask customer service for a license key, which they will then enter in the TPP UI.

I thus propose to remove entirely the phrasing that suggests that username and password is deprecated.