### PR TITLE
Adds a missing path to 1.10 release notes

### DIFF
--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -512,6 +512,10 @@
               "path": "/docs/release-notes/README.md"
             },
             {
+              "title": "v1.10",
+              "path": "/docs/release-notes/release-notes-1.10.md"
+            },
+            {
               "title": "v1.9",
               "path": "/docs/release-notes/release-notes-1.9.md"
             },


### PR DESCRIPTION
Adds a missing path to 1.10 release notes

Fixes https://github.com/cert-manager/cert-manager/issues/5525


Signed-off-by: irbekrm <irbekrm@gmail.com>