### PR TITLE
fix(doc): adjust name of container for monitoring

### DIFF
--- a/content/docs/usage/prometheus-metrics.md
+++ b/content/docs/usage/prometheus-metrics.md
@@ -31,7 +31,7 @@ spec:
   template:
     spec:
       containers:
-        - name: cert-manager
+        - name: cert-manager-controller
           ports:
             - containerPort: 9402
               name: http

--- a/content/next-docs/usage/prometheus-metrics.md
+++ b/content/next-docs/usage/prometheus-metrics.md
@@ -31,7 +31,7 @@ spec:
   template:
     spec:
       containers:
-        - name: cert-manager
+        - name: cert-manager-controller
           ports:
             - containerPort: 9402
               name: http

--- a/content/v1.10-docs/usage/prometheus-metrics.md
+++ b/content/v1.10-docs/usage/prometheus-metrics.md
@@ -31,7 +31,7 @@ spec:
   template:
     spec:
       containers:
-        - name: cert-manager
+        - name: cert-manager-controller
           ports:
             - containerPort: 9402
               name: http


### PR DESCRIPTION
After release of 1.10, the container name has been changed and the patch wasn't relevant anymore


New deployment manifest in v1.10:
<img width="653" alt="image" src="https://user-images.githubusercontent.com/1970922/198537486-22284ef4-fd0f-4692-ab78-dd047e1b6931.png">


Signed-off-by: Davin Kevin <davin.kevin@gmail.com>