### PR TITLE
Rename trust to trust-manager

### DIFF
--- a/content/docs/configuration/ca.md
+++ b/content/docs/configuration/ca.md
@@ -13,7 +13,7 @@ The CA issuer represents a Certificate Authority whose certificate and
 private key are stored inside the cluster as a Kubernetes `Secret`.
 
 Certificates issued by a CA issuer will not be publicly trusted and so are unlikely to be trusted
-by your applications without further configuration work. Consider the [cert-manager/trust](../projects/trust.md)
+by your applications without further configuration work. Consider the [trust-manager](../projects/trust-manager.md)
 project for distributing trust stores.
 
 ## Deployment

--- a/content/docs/configuration/selfsigned.md
+++ b/content/docs/configuration/selfsigned.md
@@ -138,7 +138,7 @@ spec:
 Clients consuming `SelfSigned` certificates have _no way_ to trust them
 without already having the certificates beforehand. This becomes hard to
 manage when the client of the server using the certificate exists in a
-different namespace. This limitation can be tackled by using [trust](../projects/trust.md)
+different namespace. This limitation can be tackled by using [trust-manager](../projects/trust-manager.md)
 to distribute the `ca.crt` to other namespaces. The alternative is to use
 "TOFU" (trust on first use), which has security implications in the event
 of a man-in-the-middle attack.

--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -339,7 +339,7 @@
             },
             {
               "title": "trust",
-              "path": "/docs/projects/trust.md"
+              "path": "/docs/projects/trust-manager.md"
             }
           ]
         },

--- a/content/docs/projects/README.md
+++ b/content/docs/projects/README.md
@@ -28,6 +28,6 @@ These tools help with security, compliance and control.
   in the form of X.509 certificate key pairs to mounting Kubernetes Pods. The
   end result is all and any Pod running in Kubernetes can securely request their
   SPIFFE identity document from a Trust Domain with minimal configuration.
-- [trust](./trust.md): an
+- [trust-manager](./trust-manager.md): an
   operator to distribute trust bundles, like CA certificates, across a
   Kubernetes cluster.

--- a/content/docs/projects/trust-manager.md
+++ b/content/docs/projects/trust-manager.md
@@ -1,12 +1,12 @@
 ---
-title: Trust
+title: trust-manager
 description: 'Distributing Trust Bundles in Kubernetes'
 ---
 
 ## Distributing Trust Bundles in Kubernetes
 
-trust is an operator for distributing trust bundles across a Kubernetes cluster.
-trust is designed to complement
+trust-manager is an operator for distributing trust bundles across a Kubernetes cluster.
+trust-manager is designed to complement
 [cert-manager](https://github.com/cert-manager/cert-manager) by enabling services to
 trust X.509 certificates signed by Issuers, as well as external CAs which may
 not be known to cert-manager at all.
@@ -80,7 +80,7 @@ the `cert-manager` namespace.
 ```bash
 helm repo add jetstack https://charts.jetstack.io --force-update
 helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set installCRDs=true --wait --create-namespace
-helm upgrade -i -n cert-manager cert-manager-trust jetstack/cert-manager-trust --wait
+helm upgrade -i -n cert-manager trust-manager jetstack/trust-manager --wait
 ```
 
 #### Quick Start Example

--- a/content/next-docs/configuration/ca.md
+++ b/content/next-docs/configuration/ca.md
@@ -13,7 +13,7 @@ The CA issuer represents a Certificate Authority whose certificate and
 private key are stored inside the cluster as a Kubernetes `Secret`.
 
 Certificates issued by a CA issuer will not be publicly trusted and so are unlikely to be trusted
-by your applications without further configuration work. Consider the [cert-manager/trust](../projects/trust.md)
+by your applications without further configuration work. Consider the [trust-manager](../projects/trust-manager.md)
 project for distributing trust stores.
 
 ## Deployment

--- a/content/next-docs/configuration/selfsigned.md
+++ b/content/next-docs/configuration/selfsigned.md
@@ -138,7 +138,7 @@ spec:
 Clients consuming `SelfSigned` certificates have _no way_ to trust them
 without already having the certificates beforehand. This becomes hard to
 manage when the client of the server using the certificate exists in a
-different namespace. This limitation can be tackled by using [trust](../projects/trust.md)
+different namespace. This limitation can be tackled by using [trust-manager](../projects/trust-manager.md)
 to distribute the `ca.crt` to other namespaces. The alternative is to use
 "TOFU" (trust on first use), which has security implications in the event
 of a man-in-the-middle attack.

--- a/content/next-docs/manifest.json
+++ b/content/next-docs/manifest.json
@@ -350,7 +350,7 @@
               "path": "/docs/projects/approver-policy.md"
             },
             {
-              "title": "trust",
+              "title": "trust-manager",
               "path": "/docs/projects/trust-manager.md"
             }
           ]

--- a/content/next-docs/manifest.json
+++ b/content/next-docs/manifest.json
@@ -351,7 +351,7 @@
             },
             {
               "title": "trust",
-              "path": "/docs/projects/trust.md"
+              "path": "/docs/projects/trust-manager.md"
             }
           ]
         },

--- a/content/next-docs/projects/README.md
+++ b/content/next-docs/projects/README.md
@@ -28,6 +28,6 @@ These tools help with security, compliance and control.
   in the form of X.509 certificate key pairs to mounting Kubernetes Pods. The
   end result is all and any Pod running in Kubernetes can securely request their
   SPIFFE identity document from a Trust Domain with minimal configuration.
-- [trust](./trust.md): an
+- [trust-manager](./trust-manager.md): an
   operator to distribute trust bundles, like CA certificates, across a
   Kubernetes cluster.

--- a/content/next-docs/projects/trust.md
+++ b/content/next-docs/projects/trust.md
@@ -80,7 +80,7 @@ the `cert-manager` namespace.
 ```bash
 helm repo add jetstack https://charts.jetstack.io --force-update
 helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set installCRDs=true --wait --create-namespace
-helm upgrade -i -n cert-manager cert-manager-trust jetstack/cert-manager-trust --wait
+helm upgrade -i -n cert-manager trust-manager jetstack/trust-manager --wait
 ```
 
 #### Quick Start Example

--- a/content/v1.10-docs/configuration/ca.md
+++ b/content/v1.10-docs/configuration/ca.md
@@ -13,7 +13,7 @@ The CA issuer represents a Certificate Authority whose certificate and
 private key are stored inside the cluster as a Kubernetes `Secret`.
 
 Certificates issued by a CA issuer will not be publicly trusted and so are unlikely to be trusted
-by your applications without further configuration work. Consider the [cert-manager/trust](../projects/trust.md)
+by your applications without further configuration work. Consider the [trust-manager](../projects/trust-manager.md)
 project for distributing trust stores.
 
 ## Deployment

--- a/content/v1.10-docs/configuration/selfsigned.md
+++ b/content/v1.10-docs/configuration/selfsigned.md
@@ -138,7 +138,7 @@ spec:
 Clients consuming `SelfSigned` certificates have _no way_ to trust them
 without already having the certificates beforehand. This becomes hard to
 manage when the client of the server using the certificate exists in a
-different namespace. This limitation can be tackled by using [trust](../projects/trust.md)
+different namespace. This limitation can be tackled by using [trust-manager](../projects/trust-manager.md)
 to distribute the `ca.crt` to other namespaces. The alternative is to use
 "TOFU" (trust on first use), which has security implications in the event
 of a man-in-the-middle attack.

--- a/content/v1.7-docs/configuration/selfsigned.md
+++ b/content/v1.7-docs/configuration/selfsigned.md
@@ -131,7 +131,7 @@ spec:
 Clients consuming `SelfSigned` certificates have _no way_ to trust them
 without already having the certificates beforehand. This becomes hard to 
 manage when the client of the server using the certificate exists in a 
-different namespace. This limitation can be tackled by using [trust](https://github.com/cert-manager/trust) 
+different namespace. This limitation can be tackled by using [trust-manager](https://github.com/cert-manager/trust-manager) 
 to distribute the `ca.crt` to other namespaces. The alternative is to use 
 "TOFU" (trust on first use), which has security implications in the event 
 of a man-in-the-middle attack.

--- a/content/v1.8-docs/configuration/selfsigned.md
+++ b/content/v1.8-docs/configuration/selfsigned.md
@@ -131,7 +131,7 @@ spec:
 Clients consuming `SelfSigned` certificates have _no way_ to trust them
 without already having the certificates beforehand. This becomes hard to 
 manage when the client of the server using the certificate exists in a 
-different namespace. This limitation can be tackled by using [trust](https://github.com/cert-manager/trust) 
+different namespace. This limitation can be tackled by using [trust-manager](https://github.com/cert-manager/trust-manager) 
 to distribute the `ca.crt` to other namespaces. The alternative is to use 
 "TOFU" (trust on first use), which has security implications in the event 
 of a man-in-the-middle attack.

--- a/content/v1.9-docs/configuration/ca.md
+++ b/content/v1.9-docs/configuration/ca.md
@@ -13,7 +13,7 @@ The CA issuer represents a Certificate Authority whose certificate and
 private key are stored inside the cluster as a Kubernetes `Secret`.
 
 Certificates issued by a CA issuer will not be publicly trusted and so are unlikely to be trusted
-by your applications without further configuration work. Consider the [cert-manager/trust](../projects/trust.md)
+by your applications without further configuration work. Consider the [trust-manager](../projects/trust-manager.md)
 project for distributing trust stores.
 
 ## Deployment

--- a/content/v1.9-docs/configuration/selfsigned.md
+++ b/content/v1.9-docs/configuration/selfsigned.md
@@ -138,7 +138,7 @@ spec:
 Clients consuming `SelfSigned` certificates have _no way_ to trust them
 without already having the certificates beforehand. This becomes hard to
 manage when the client of the server using the certificate exists in a
-different namespace. This limitation can be tackled by using [trust](../projects/trust.md)
+different namespace. This limitation can be tackled by using [trust-manager](../projects/trust-manager.md)
 to distribute the `ca.crt` to other namespaces. The alternative is to use
 "TOFU" (trust on first use), which has security implications in the event
 of a man-in-the-middle attack.

--- a/public/_redirects
+++ b/public/_redirects
@@ -182,3 +182,6 @@ https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 302!
 
 # Demoted the cmctl x install page
 /docs/installation/cmctl/ /docs/reference/cmctl/ 301!
+
+# Rename trust to trust-manager
+/docs/projects/trust/ /docs/projects/trust-manager/ 301!


### PR DESCRIPTION
In https://github.com/cert-manager/trust/pull/64 the name trust was changed to trust-manager. This PR renames all occurrences of trust to trust-manager.