### PR TITLE
Add notes about OpenShift incompatibility with cert-manager 1.10

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,3 +1,8 @@
+seccomp
+RedHat
+RoleBinding
+RoleBindings
+SecurityContextConstraint
 Mehak
 Saeed
 acmesolver

--- a/content/docs/installation/operator-lifecycle-manager.md
+++ b/content/docs/installation/operator-lifecycle-manager.md
@@ -16,6 +16,13 @@ cert-manager is in the [Red Hat-provided Operator catalog][] called "community-o
 On OpenShift 4 you can install cert-manager from the [OperatorHub web console][] or from the command line.
 These installation methods are described in Red Hat's [Adding Operators to a cluster][] documentation.
 
+> ⚠️ In cert-manager `v1.10.0` the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
+> is set to `RuntimeDefault`.
+> On some versions and configurations of OpenShift this can cause the Pod to be rejected by the
+> [Security Context Constraints admission webhook](https://docs.openshift.com/container-platform/4.10/authentication/managing-security-context-constraints.html#admission_configuring-internal-oauth).
+>
+> 📖 Read the [Breaking Changes section in the `v1.10.0` release notes](../release-notes/release-notes-1.10.md) before installing or upgrading.
+
 [Red Hat-provided Operator catalog]: https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-rh-catalogs.html#olm-rh-catalogs_olm-rh-catalogs
 [OperatorHub web console]: https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-understanding-operatorhub.html
 [Adding Operators to a cluster]: https://docs.openshift.com/container-platform/4.7/operators/admin/olm-adding-operators-to-cluster.html

--- a/content/docs/installation/upgrading/upgrading-1.9-1.10.md
+++ b/content/docs/installation/upgrading/upgrading-1.9-1.10.md
@@ -3,6 +3,15 @@ title: Upgrading from v1.9 to v1.10
 description: 'cert-manager installation: Upgrading v1.9 to v1.10'
 ---
 
-When upgrading from `v1.9` to `v1.10`, no special upgrade steps are required 🎉
+## On OpenShift the cert-manager Pods may fail until you modify Security Context Constraints
+
+In cert-manager `v1.10.0` the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
+is set to `RuntimeDefault`.
+On some versions and configurations of OpenShift this can cause the Pod to be rejected by the
+[Security Context Constraints admission webhook](https://docs.openshift.com/container-platform/4.10/authentication/managing-security-context-constraints.html#admission_configuring-internal-oauth).
+
+> 📖 Read the [Breaking Changes section in the `v1.10.0` release notes](../../release-notes/release-notes-1.10.md) before upgrading.
+
+## Next Steps
 
 From here on you can follow the [regular upgrade process](./README.md).


### PR DESCRIPTION
**Preview**: https://deploy-preview-1099--cert-manager-website.netlify.app/docs/release-notes/release-notes-1.10

There are some problems caused by the use of the `RuntimDefault` seccomp profile in cert-manager 1.10.
These are some release notes and documentation explaining the situation to OpenShift users.