### PR TITLE
Add information about OpenShift 4.12

### DIFF
--- a/content/docs/installation/supported-releases.md
+++ b/content/docs/installation/supported-releases.md
@@ -17,7 +17,7 @@ and other world events.
 
 | Release  | Release Date |   End of Life   | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |----------|:------------:|:---------------:|:----------------------------------:|:---------------------------------:|
-| [1.10][] | Oct 17, 2022 | Release of 1.12 |            1.20 → 1.25\*            |            4.7 → 4.11             |
+| [1.10][] | Oct 17, 2022 | Release of 1.12 |            1.20 → 1.25\*            |            4.8 → 4.12             |
 | [1.9][]  | Jul 22, 2022 | Release of 1.11 |            1.20 → 1.24\*            |            4.7 → 4.11             |
 
 \*ServerSideApply should be enabled in the cluster
@@ -26,7 +26,7 @@ and other world events.
 
 | Release  |  Release Date  |  End of Life   | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |----------|:--------------:|:--------------:|:----------------------------------:|:---------------------------------:|
-| [1.11][] |  Jan 11, 2023  | Mid June, 2023 |            1.20 → 1.25\*            |            4.7 → 4.11             |
+| [1.11][] |  Jan 11, 2023  | Mid June, 2023 |            1.20 → 1.25\*            |            4.8 → 4.12            |
 
 Dates in the future are uncertain and might change.
 
@@ -231,6 +231,7 @@ that each version maps to. For convenience, the following table shows these vers
 
 | OpenShift versions | Kubernetes version |
 |--------------------|--------------------|
+| 4.12               | 1.25               |
 | 4.11               | 1.24               |
 | 4.10, 4.10 EUS     | 1.23               |
 | 4.9                | 1.22               |


### PR DESCRIPTION
As part of the release of cert-manager v1.11.0-alpha.0 I've checked the supported Kubernetes versions page and noticed the following: 

* We weren't yet mentioning  OpenShift 4.12 (now added)
* [OpenShift 4.7  reached EOL in in august 2022](https://access.redhat.com/support/policy/updates/openshift/#dates), before the release of cert-manager 1.10 so I've removed OpenShift 4.7 from the support table for cert-manager 1.10 and 1.11.

I considered adding Kubernetes 1.26 to the table, since it should be released soon, but perhaps we should only do that once we can test 1.26 with Kind.