### PR TITLE
Release notes for cert-manager v1.9.2

### DIFF
--- a/content/docs/release-notes/release-notes-1.9.md
+++ b/content/docs/release-notes/release-notes-1.9.md
@@ -3,6 +3,25 @@ title: Release 1.9
 description: 'cert-manager release notes: cert-manager v1.9'
 ---
 
+## `v1.9.2`
+
+cert-manager `v1.9.2` is a bug fix release which fixes
+an issue where CertificateRequests marked as InvalidRequest did not properly trigger issuance failure handling leading to 'stuck' requests, and
+a problem which prevented the Venafi Issuer from connecting to TPP servers where the `vedauth` API endpoints were configured to *accept* client certificates.
+It is also compiled with a newer version of Go 1.18 (`v1.18.8`) which fixes some vulnerabilities in the Go standard library.
+
+## Changes since `v1.9.1`
+
+### Bug or Regression
+
+- Fix issue where CertificateRequests marked as InvalidRequest did not properly trigger issuance failure handling leading to 'stuck' requests.
+  ([#5371](https://github.com/cert-manager/cert-manager/pull/5371), [@munnerz](https://github.com/munnerz) )
+- The Venafi Issuer now supports TLS 1.2 renegotiation, so that it can connect to TPP servers where the `vedauth` API endpoints are configured to *accept* client certificates. (Note: This does not mean that the Venafi Issuer supports client certificate authentication).
+  ([#5577](https://github.com/cert-manager/cert-manager/pull/5577), [@wallrj](https://github.com/wallrj))
+- Upgrade to latest go patch release.
+  ([#5561](https://github.com/cert-manager/cert-manager/pull/5561), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
+
 ## v1.9.1
 
 cert-manager v1.9.1 is a bug fix release which removes an incorrect check in the Route53 DNS solver. This accidental change prevented the use of credentials derived from


### PR DESCRIPTION
**Preview**: https://deploy-preview-1114--cert-manager-website.netlify.app/docs/release-notes/release-notes-1.9#v192

Adding release notes for v1.9.2.

As part of the [release process](https://cert-manager.io/docs/contributing/release-process/#minor-releases).

/hold until the release artifacts are published.