### PR TITLE
Release notes for cert-manager v1.10.1

### DIFF
--- a/content/docs/installation/README.md
+++ b/content/docs/installation/README.md
@@ -12,7 +12,7 @@ Learn about the various ways you can install cert-manager and how to choose betw
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
 ```
 
 📖 Read more about [installing cert-manager using kubectl apply and static manifests](./kubectl.md).

--- a/content/docs/installation/code-signing.md
+++ b/content/docs/installation/code-signing.md
@@ -22,7 +22,7 @@ The simplest way to verify signatures is to download the public key and then pas
 
 ```console
 curl -sSOL https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
-IMAGE_TAG=v1.10.0  # change as needed
+IMAGE_TAG=v1.10.1  # change as needed
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-ctl:$IMAGE_TAG

--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -44,7 +44,7 @@ or using the `installCRDs` option when installing the Helm chart.
 
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -65,7 +65,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   # --set installCRDs=true
 ```
 
@@ -78,7 +78,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
 ```
@@ -97,7 +97,7 @@ This capability is now available in the cert-manager chart and can be set either
 
 #### Example usage
 
-Below is an example `Chart.yaml` with cert-manager as a subchart 
+Below is an example `Chart.yaml` with cert-manager as a subchart
 
 ```yaml
 apiVersion: v2
@@ -108,7 +108,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.10.0
+    version: v1.10.1
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -139,7 +139,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/docs/installation/kubectl.md
+++ b/content/docs/installation/kubectl.md
@@ -19,7 +19,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/docs/installation/operator-lifecycle-manager.md
+++ b/content/docs/installation/operator-lifecycle-manager.md
@@ -16,12 +16,12 @@ cert-manager is in the [Red Hat-provided Operator catalog][] called "community-o
 On OpenShift 4 you can install cert-manager from the [OperatorHub web console][] or from the command line.
 These installation methods are described in Red Hat's [Adding Operators to a cluster][] documentation.
 
-> ⚠️ In cert-manager `v1.10.0` the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
+> ⚠️ In cert-manager 1.10 the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
 > is set to `RuntimeDefault`.
 > On some versions and configurations of OpenShift this can cause the Pod to be rejected by the
 > [Security Context Constraints admission webhook](https://docs.openshift.com/container-platform/4.10/authentication/managing-security-context-constraints.html#admission_configuring-internal-oauth).
 >
-> 📖 Read the [Breaking Changes section in the `v1.10.0` release notes](../release-notes/release-notes-1.10.md) before installing or upgrading.
+> 📖 Read the [Breaking Changes section in the 1.10 release notes](../release-notes/release-notes-1.10.md) before installing or upgrading.
 
 [Red Hat-provided Operator catalog]: https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-rh-catalogs.html#olm-rh-catalogs_olm-rh-catalogs
 [OperatorHub web console]: https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-understanding-operatorhub.html
@@ -217,7 +217,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.10.0 \
+kubectl patch csv cert-manager.v1.10.1 \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```

--- a/content/docs/installation/upgrading/upgrading-1.9-1.10.md
+++ b/content/docs/installation/upgrading/upgrading-1.9-1.10.md
@@ -5,12 +5,12 @@ description: 'cert-manager installation: Upgrading v1.9 to v1.10'
 
 ## On OpenShift the cert-manager Pods may fail until you modify Security Context Constraints
 
-In cert-manager `v1.10.0` the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
+In cert-manager 1.10 the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
 is set to `RuntimeDefault`.
 On some versions and configurations of OpenShift this can cause the Pod to be rejected by the
 [Security Context Constraints admission webhook](https://docs.openshift.com/container-platform/4.10/authentication/managing-security-context-constraints.html#admission_configuring-internal-oauth).
 
-> 📖 Read the [Breaking Changes section in the `v1.10.0` release notes](../../release-notes/release-notes-1.10.md) before upgrading.
+> 📖 Read the [Breaking Changes section in the 1.10 release notes](../../release-notes/release-notes-1.10.md) before upgrading.
 
 ## Next Steps
 

--- a/content/docs/release-notes/release-notes-1.10.md
+++ b/content/docs/release-notes/release-notes-1.10.md
@@ -1,15 +1,16 @@
 ---
 title: Release 1.10
-description: 'cert-manager release notes: cert-manager v1.10'
+description: 'cert-manager release notes: cert-manager 1.10'
 ---
 
-Version 1.10 adds a variety of quality-of-life fixes and features including improvements to the test suite.
+Release 1.10 adds a variety of quality-of-life fixes and features including improvements to the test suite.
+The latest version is `v1.10.1`.
 
 ## Breaking Changes (You **MUST** read this before you upgrade!)
 
 ### On OpenShift the cert-manager Pods may fail until you modify Security Context Constraints
 
-In cert-manager `v1.10.0` the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
+In cert-manager 1.10 the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
 is set to `RuntimeDefault`.
 (See [cert-manager pull request 5259](https://github.com/cert-manager/cert-manager/pull/5259/files).)
 The `securityContext` fields of the Pod are set as follows:
@@ -79,7 +80,17 @@ But if you are using the ACME Issuer with the HTTP01 solver, cert-manager will d
 
 > 📖 Read [Enabling the default seccomp profile for all pods](https://docs.openshift.com/container-platform/4.10/security/seccomp-profiles.html#configuring-default-seccomp-profile_configuring-seccomp-profiles) to learn how to configure your system to allow Pods that use the `RuntimeDefault` seccomp profile.
 
-## Changes since v1.9.1
+## `v1.10.1`: Changes since `v1.10.0`
+
+### Bug or Regression
+
+- The Venafi Issuer now supports TLS 1.2 renegotiation, so that it can connect to TPP servers where the `vedauth` API endpoints are configured to *accept* client certificates.
+  (Note: This does not mean that the Venafi Issuer supports client certificate authentication).
+  ([#5576](https://github.com/cert-manager/cert-manager/pull/5371), [@wallrj](https://github.com/wallrj))
+- Upgrade to latest go patch release
+  ([#5560](https://github.com/cert-manager/cert-manager/pull/5560), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
+## `v1.10.0`: Changes since `v1.9.1`
 
 ### Feature
 

--- a/content/docs/tutorials/acme/pomerium-ingress.md
+++ b/content/docs/tutorials/acme/pomerium-ingress.md
@@ -65,7 +65,7 @@ This tutorial covers installing the [Pomerium Ingress Controller](https://pomeri
 Install cert-manager using any of the methods documented in the [Installation](https://cert-manager.io/docs/installation/) section of the cert-manager docs. The simplest method is to download and apply the provided manifest:
 
 ```sh
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
 ```
 
 ## Configure Let's Encrypt Issuer

--- a/content/next-docs/installation/README.md
+++ b/content/next-docs/installation/README.md
@@ -14,7 +14,7 @@ install methods are listed below for each of the situations.
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
 ```
 
 More information on this install method [can be found here](./kubectl.md).

--- a/content/next-docs/installation/code-signing.md
+++ b/content/next-docs/installation/code-signing.md
@@ -22,7 +22,7 @@ The simplest way to verify signatures is to download the public key and then pas
 
 ```console
 curl -sSOL https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
-IMAGE_TAG=v1.10.0  # change as needed
+IMAGE_TAG=v1.10.1  # change as needed
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-ctl:$IMAGE_TAG

--- a/content/next-docs/installation/helm.md
+++ b/content/next-docs/installation/helm.md
@@ -44,7 +44,7 @@ or using the `installCRDs` option when installing the Helm chart.
 
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -65,7 +65,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   # --set installCRDs=true
 ```
 
@@ -78,7 +78,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
 ```
@@ -97,7 +97,7 @@ This capability is now available in the cert-manager chart and can be set either
 
 #### Example usage
 
-Below is an example `Chart.yaml` with cert-manager as a subchart 
+Below is an example `Chart.yaml` with cert-manager as a subchart
 
 ```yaml
 apiVersion: v2
@@ -108,7 +108,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.10.0
+    version: v1.10.1
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -139,7 +139,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/next-docs/installation/kubectl.md
+++ b/content/next-docs/installation/kubectl.md
@@ -19,7 +19,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/next-docs/installation/operator-lifecycle-manager.md
+++ b/content/next-docs/installation/operator-lifecycle-manager.md
@@ -210,7 +210,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.10.0 \
+kubectl patch csv cert-manager.v1.10.1 \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```

--- a/content/v1.10-docs/installation/README.md
+++ b/content/v1.10-docs/installation/README.md
@@ -14,7 +14,7 @@ install methods are listed below for each of the situations.
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
 ```
 
 More information on this install method [can be found here](./kubectl.md).

--- a/content/v1.10-docs/installation/code-signing.md
+++ b/content/v1.10-docs/installation/code-signing.md
@@ -22,7 +22,7 @@ The simplest way to verify signatures is to download the public key and then pas
 
 ```console
 curl -sSOL https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
-IMAGE_TAG=v1.10.0  # change as needed
+IMAGE_TAG=v1.10.1  # change as needed
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-ctl:$IMAGE_TAG

--- a/content/v1.10-docs/installation/helm.md
+++ b/content/v1.10-docs/installation/helm.md
@@ -44,7 +44,7 @@ or using the `installCRDs` option when installing the Helm chart.
 
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -65,7 +65,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   # --set installCRDs=true
 ```
 
@@ -78,7 +78,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
 ```
@@ -97,7 +97,7 @@ This capability is now available in the cert-manager chart and can be set either
 
 #### Example usage
 
-Below is an example `Chart.yaml` with cert-manager as a subchart 
+Below is an example `Chart.yaml` with cert-manager as a subchart
 
 ```yaml
 apiVersion: v2
@@ -108,7 +108,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.10.0
+    version: v1.10.1
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -139,7 +139,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.10.0 \
+  --version v1.10.1 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/v1.10-docs/installation/kubectl.md
+++ b/content/v1.10-docs/installation/kubectl.md
@@ -19,7 +19,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/v1.10-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.10-docs/installation/operator-lifecycle-manager.md
@@ -210,7 +210,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.10.0 \
+kubectl patch csv cert-manager.v1.10.1 \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```


### PR DESCRIPTION
**Preview**: https://deploy-preview-1115--cert-manager-website.netlify.app/docs/release-notes/release-notes-1.10

Adding release notes for v1.10.1

As part of the [release process](https://cert-manager.io/docs/contributing/release-process/#minor-releases).

/hold until the release artifacts are published.