### PR TITLE
Use latest versions in cmctl install instructions

### DIFF
--- a/content/docs/reference/cmctl.md
+++ b/content/docs/reference/cmctl.md
@@ -11,7 +11,7 @@ description: |
 ### Homebrew
 
 On Mac or Linux if you have [Homebrew](https://brew.sh) installed, you can
-install `cmctl` with: 
+install `cmctl` with:
 
 ```console
 brew install cmctl
@@ -30,7 +30,7 @@ Run the following commands to set up the CLI. Replace OS and ARCH with your
 systems equivalents:
 
 ```console
-OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cmctl-$OS-$ARCH.tar.gz
+OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -fsSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/latest/download/cmctl-$OS-$ARCH.tar.gz
 tar xzf cmctl.tar.gz
 sudo mv cmctl /usr/local/bin
 ```

--- a/content/v1.10-docs/usage/cmctl.md
+++ b/content/v1.10-docs/usage/cmctl.md
@@ -21,7 +21,7 @@ Run the following commands to set up the CLI. Replace OS and ARCH with your
 systems equivalents:
 
 ```console
-OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cmctl-$OS-$ARCH.tar.gz
+OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -fsSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cmctl-$OS-$ARCH.tar.gz
 tar xzf cmctl.tar.gz
 sudo mv cmctl /usr/local/bin
 ```

--- a/content/v1.8-docs/usage/cmctl.md
+++ b/content/v1.8-docs/usage/cmctl.md
@@ -21,7 +21,7 @@ Run the following commands to set up the CLI. Replace OS and ARCH with your
 systems equivalents:
 
 ```console
-OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cmctl-$OS-$ARCH.tar.gz
+OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -fsSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cmctl-$OS-$ARCH.tar.gz
 tar xzf cmctl.tar.gz
 sudo mv cmctl /usr/local/bin
 ```

--- a/content/v1.9-docs/usage/cmctl.md
+++ b/content/v1.9-docs/usage/cmctl.md
@@ -21,7 +21,7 @@ Run the following commands to set up the CLI. Replace OS and ARCH with your
 systems equivalents:
 
 ```console
-OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cmctl-$OS-$ARCH.tar.gz
+OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -fsSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.9.2/cmctl-$OS-$ARCH.tar.gz
 tar xzf cmctl.tar.gz
 sudo mv cmctl /usr/local/bin
 ```


### PR DESCRIPTION
It looks like in some of the past releases we've forgotten to update the cmctl version in the installation instructions.

I've chosen to use `latest` for the current docs, since  `latest` is now configurable:
 * https://github.blog/changelog/2022-10-21-explicitly-set-the-latest-release/

I also added `-f` to the curl command so that people get early warning if the URL is broken and curl returns 404.