### PR TITLE
Adds a warning about Gateway APi cross-namespace secrets

### DIFF
--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -122,11 +122,10 @@ spec:
     - example.com # ✅ Copied from the `hostname` field.
   secretName: example-com-tls
 ```
-</div>
 
 <div className="info">
 
-🚧   this mechanism can only be used to create Secrets in the same namespace as the `Gateway`, see [cert-manager#5610](https://github.com/cert-manager/cert-manager/issues/5610)
+🚧   this mechanism can only be used to create Secrets in the same namespace as the `Gateway`, see [`cert-manager#5610`](https://github.com/cert-manager/cert-manager/issues/5610)
 
 </div>
 
@@ -143,8 +142,8 @@ meet the following requirements:
 | `tls.hostname`             | Must not be empty.                                          |
 | `tls.mode`                 | Must be set to `Terminate`. `Passthrough` is not supported. |
 | `tls.certificateRef.name`  | Cannot be left empty.                                       |
-| `tls.certificateRef.kind`  | Must be set to `Secret`.                                    |
-| `tls.certificateRef.group` | Must be set to `core`.                                      |
+| `tls.certificateRef.kind`  | If specified, must be set to `Secret`.                                    |
+| `tls.certificateRef.group` | If specified, must be set to `core`.                                      |
 
 In the following example, the first three listener blocks will not be used to
 generate Certificate resources:

--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -122,6 +122,13 @@ spec:
     - example.com # ✅ Copied from the `hostname` field.
   secretName: example-com-tls
 ```
+</div>
+
+<div className="info">
+
+🚧   this mechanism can only be used to create Secrets in the same namespace as the `Gateway`, see [cert-manager#5610](https://github.com/cert-manager/cert-manager/issues/5610)
+
+</div>
 
 ## Use cases
 


### PR DESCRIPTION
Gateway API cross-namespace secrets don't work with gateway-shim see https://github.com/cert-manager/cert-manager/issues/5610

This PR updates docs to add a warning about that.