### PR TITLE
Expand Google Workload Identity section with a note about Ambient Credentials

### DIFF
--- a/content/docs/configuration/acme/dns01/google.md
+++ b/content/docs/configuration/acme/dns01/google.md
@@ -149,6 +149,10 @@ detailed instructions on how to enable workload identity in your GKE cluster.
 The instructions in the following sections assume you are deploying cert-manager
 to a GKE cluster with workload identity already enabled.
 
+### Enable Ambient Credential Usage
+
+'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. When this flag is enabled Cert-Manager will access the GKE Metadata server for credentials. By default this is enabled for ClusterIssuer resources but is disabled for Issuer resources. To enable it for Issuer resources set the `--issuer-ambient-credentials` flag.
+
 ### Link KSA to GSA in GCP
 
 The cert-manager component that needs to modify DNS records is the pod created


### PR DESCRIPTION
Signed-off-by: Alex <17101722+ar-qun@users.noreply.github.com>

At least for me, the Workload Identity didn't start working until Ambient Credentials where enabled. I added a small section to cover that dependency.