### PR TITLE
Various updates + tweaks

### DIFF
--- a/components/docs/VersionSelect.jsx
+++ b/components/docs/VersionSelect.jsx
@@ -3,6 +3,8 @@ import { useState } from 'react'
 import SidebarLink from './Sidebar/SidebarLink'
 import Icon from 'components/Icon'
 
+import { compareVersions } from 'compare-versions';
+
 function labelFromVersion(version) {
     return (
         version === 'docs'
@@ -17,6 +19,10 @@ export default function VersionSelect({
   setSidebarCollapsed
 }) {
   const [selectedVersion, setSelectedVersion] = useState(version)
+
+  versions = versions.sort(function(first, second){
+	  return compareVersions(labelFromVersion(first), labelFromVersion(second))
+  }).reverse()
 
   return (
       <div className="bg-gray-1 rounded-md border-2 border-gray-2/50">
@@ -34,7 +40,7 @@ export default function VersionSelect({
               />
             </div>
           </Listbox.Option>
-          {versions.reverse().map((version) => (
+          {versions.map((version) => (
             <Listbox.Option key={version} value={version}>
               <div className="block px-2">
                 <SidebarLink

--- a/content/docs/installation/supported-releases.md
+++ b/content/docs/installation/supported-releases.md
@@ -54,6 +54,7 @@ Dates in the future are uncertain and might change.
 | [0.11][] | Oct 10, 2019 | Jan 21, 2020 |           1.9 → 1.21           |          3.09 → 4.7           |
 
 [s]: #kubernetes-supported-versions
+[1.12]: https://github.com/cert-manager/cert-manager/milestone/33
 [1.11]: https://github.com/cert-manager/cert-manager/milestone/32
 [1.10]: https://cert-manager.io/docs/release-notes/release-notes-1.10
 [1.9]: https://cert-manager.io/docs/release-notes/release-notes-1.9

--- a/content/docs/release-notes/release-notes-0.1.md
+++ b/content/docs/release-notes/release-notes-0.1.md
@@ -21,6 +21,6 @@ Notable features:
   - Events logged to the Kubernetes API
   - Status block utilized to store additional state about resources
 
-Please check the [README(https://github.com/jetstack-experimental/cert-manager) for a quick-start guide.
+Please check the [README](https://github.com/cert-manager/cert-manager) for a quick-start guide.
 
 We really value any feedback and contributions to the project. If you'd like to get involved, please open some issues, comment or pick something up and get started!

--- a/content/next-docs/configuration/acme/README.md
+++ b/content/next-docs/configuration/acme/README.md
@@ -346,9 +346,29 @@ In this case the `DNS01` solver for Cloudflare will only be used to solve a
 challenge for a DNS name if the `Certificate` has a label from
 `matchLabels` _and_ the DNS name matches a zone from `dnsZones`.
 
+## Private ACME Servers
+
+cert-manager should also work with private or self-hosted ACME servers, as long as they follow the ACME spec.
+
+If your ACME server doesn't use a publicly trusted certificate, you can pass a trusted CA to use when creating your
+issuer, from cert-manager 1.11 onwards:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    ...
+    caBundle: <base64 encoded CA Bundle in PEM format>
+    ...
+```
+
+
 ## Alternative Certificate Chains
 
-{/* This empty link preserves old links to #alternative-certificate-chain", which matched the old title of this section */}
+{/* The empty link below preserves old links to #alternative-certificate-chain", which matched the old title of this section */}
 
 <a id="alternative-certificate-chain" className="hidden-link"></a>
 

--- a/content/next-docs/installation/supported-releases.md
+++ b/content/next-docs/installation/supported-releases.md
@@ -54,6 +54,7 @@ Dates in the future are uncertain and might change.
 | [0.11][] | Oct 10, 2019 | Jan 21, 2020 |           1.9 → 1.21           |          3.09 → 4.7           |
 
 [s]: #kubernetes-supported-versions
+[1.12]: https://github.com/cert-manager/cert-manager/milestone/33
 [1.11]: https://github.com/cert-manager/cert-manager/milestone/32
 [1.10]: https://cert-manager.io/docs/release-notes/release-notes-1.10
 [1.9]: https://cert-manager.io/docs/release-notes/release-notes-1.9

--- a/content/next-docs/manifest.json
+++ b/content/next-docs/manifest.json
@@ -532,6 +532,10 @@
               "path": "/docs/release-notes/README.md"
             },
             {
+              "title": "v1.10",
+              "path": "/docs/release-notes/release-notes-1.10.md"
+            },
+            {
               "title": "v1.9",
               "path": "/docs/release-notes/release-notes-1.9.md"
             },

--- a/content/next-docs/release-notes/release-notes-0.1.md
+++ b/content/next-docs/release-notes/release-notes-0.1.md
@@ -21,6 +21,6 @@ Notable features:
   - Events logged to the Kubernetes API
   - Status block utilized to store additional state about resources
 
-Please check the [README(https://github.com/jetstack-experimental/cert-manager) for a quick-start guide.
+Please check the [README](https://github.com/cert-manager/cert-manager) for a quick-start guide.
 
 We really value any feedback and contributions to the project. If you'd like to get involved, please open some issues, comment or pick something up and get started!

--- a/content/next-docs/release-notes/release-notes-1.10.md
+++ b/content/next-docs/release-notes/release-notes-1.10.md
@@ -1,0 +1,139 @@
+---
+title: Release 1.10
+description: 'cert-manager release notes: cert-manager 1.10'
+---
+
+Release 1.10 adds a variety of quality-of-life fixes and features including improvements to the test suite.
+
+The latest version is `v1.10.1`.
+
+## Breaking Changes (You **MUST** read this before you upgrade!)
+
+### Container Name Changes
+
+This change is only relevant if you install cert-manager using Helm or the static manifest files. `v1.10.0` changes the names of containers in pods created by cert-manager.
+
+The names are changed to better reflect what they do; for example, the container in the controller pod had its name changed from `cert-manager` to `cert-manager-controller`,
+and the webhook pod had its container name changed from `cert-manager` to `cert-manager-webhook`.
+
+This change could cause a break if you:
+
+1. Use Helm or the static manifests, and
+2. Have scripts, tools or tasks which rely on the names of the cert-manager containers being static
+
+If both of these are true, you may need to update your automation before you upgrade.
+
+### On OpenShift the cert-manager Pods may fail until you modify Security Context Constraints
+
+In cert-manager 1.10 the [secure computing (seccomp) profile](https://kubernetes.io/docs/tutorials/security/seccomp/) for all the Pods
+is set to `RuntimeDefault`.
+(See [cert-manager pull request 5259](https://github.com/cert-manager/cert-manager/pull/5259/files).)
+The `securityContext` fields of the Pod are set as follows:
+```yaml
+...
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault
+    ...
+```
+
+On some versions and configurations of OpenShift this can cause the Pod to be rejected by the
+[Security Context Constraints admission webhook](https://docs.openshift.com/container-platform/4.10/authentication/managing-security-context-constraints.html#admission_configuring-internal-oauth).
+
+#### On OpenShift `v4.7`, `v4.8`, `v4.9` and `v4.10` you may need to modify Security Context Constraints to allow cert-manager Pods to be deployed
+
+In OpenShift `v4.7`, `v4.8`, `v4.9` and `v4.10`, the default SecurityContextConstraint is called "restricted", and it forbids Pods that have the `RuntimeDefault` seccomp profile.
+If you deploy cert-manager on these versions of OpenShift you may see the following error condition on the cert-manager Deployments:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+# ...
+status:
+  conditions:
+# ...
+  - lastTransitionTime: "2022-11-01T09:41:41Z"
+    lastUpdateTime: "2022-11-01T09:41:41Z"
+    message: 'pods "cert-manager-84bc577876-qzbnf" is forbidden: unable to validate
+      against any security context constraint: [pod.metadata.annotations.seccomp.security.alpha.kubernetes.io/pod:
+      Forbidden: seccomp may not be set pod.metadata.annotations.container.seccomp.security.alpha.kubernetes.io/cert-manager-controller:
+      Forbidden: seccomp may not be set provider "anyuid": Forbidden: not usable by
+      user or serviceaccount provider "nonroot": Forbidden: not usable by user or
+      serviceaccount provider "hostmount-anyuid": Forbidden: not usable by user or
+      serviceaccount provider "machine-api-termination-handler": Forbidden: not usable
+      by user or serviceaccount provider "hostnetwork": Forbidden: not usable by user
+      or serviceaccount provider "hostaccess": Forbidden: not usable by user or serviceaccount
+      provider "privileged": Forbidden: not usable by user or serviceaccount]'
+    reason: FailedCreate
+    status: "True"
+    type: ReplicaFailure
+# ...
+```
+
+The work around is to copy the "restricted" SecurityContextConstraint resource and then modify it to allow Pods with `RuntimeDefault` seccomp profile.
+Then use `oc adm policy add-scc-to-user` to create a Role and a RoleBinding that allows all the cert-manager ServiceAccounts to use that SecurityContextConstraint.
+
+> 📖 Read [Enabling the default seccomp profile for all pods](https://docs.openshift.com/container-platform/4.10/security/seccomp-profiles.html#configuring-default-seccomp-profile_configuring-seccomp-profiles) to learn more about this process.
+
+#### On OpenShift `v4.11` you may need to modify Security Context Constraints to allow cert-manager Pods to be deployed
+
+In OpenShift `v4.11`, there is a new SecurityContextConstraint called `restricted-v2`, which permits Pods that have the `RuntimeDefault` seccomp profile and this will used for the cert-manager Pods by default, allowing the Pods to be created.
+
+But if you have upgraded OpenShift from a previous version, the old `restricted` SecurityContextConstraint may still be used and you will have to make changes to the RoleBindings in order to make it the default for all Pods.
+
+> 📖 Read [Pod security admission in the OpenShift `v4.11` release notes](https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-auth-pod-security-admission) to learn more about the changes to the default security context constraints in `v4.11`.
+>
+> 📖 Read [Default security context constraints](https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html#default-sccs_configuring-internal-oauth) in the OpenShift `v4.11` documentation to learn about the characteristics of the default Security Context Constraints in OpenShift.
+
+#### When using the OLM packages for OperatorHub on OpenShift `>= v4.7`, you may need to modify Security Context Constraints to allow the cert-manager ACME HTTP01 Pod to be deployed
+
+In the cert-manager OLM packages for RedHat OpenShift OperatorHub, the `seccompProfile` field in the Deployment resource has been removed,
+and this should allow you to install it on OpenShift `v4.7`, `v4.8`, `v4.9`, `v4.10`, and `v4.11` without any extra configuration.
+
+But if you are using the ACME Issuer with the HTTP01 solver, cert-manager will deploy a short lived Pod that uses the `RuntimDefault` seccomp profile which may be denied because of the existing Security Context Constraints.
+
+> 📖 Read [Enabling the default seccomp profile for all pods](https://docs.openshift.com/container-platform/4.10/security/seccomp-profiles.html#configuring-default-seccomp-profile_configuring-seccomp-profiles) to learn how to configure your system to allow Pods that use the `RuntimeDefault` seccomp profile.
+
+## `v1.10.1`: Changes since `v1.10.0`
+
+### Bug or Regression
+
+- The Venafi Issuer now supports TLS 1.2 renegotiation, so that it can connect to TPP servers where the `vedauth` API endpoints are configured to *accept* client certificates.
+  (Note: This does not mean that the Venafi Issuer supports client certificate authentication).
+  ([#5576](https://github.com/cert-manager/cert-manager/pull/5371), [@wallrj](https://github.com/wallrj))
+- Upgrade to latest go patch release
+  ([#5560](https://github.com/cert-manager/cert-manager/pull/5560), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
+## `v1.10.0`: Changes since `v1.9.1`
+
+### Feature
+
+- Add `issuer_name`, `issuer_kind` and `issuer_group` labels to `certificate_expiration_timestamp_seconds`, `certmanager_certificate_renewal_timestamp_seconds` and `certmanager_certificate_ready_status` metrics (#5461, @dkulchinsky)
+- Add make targets for running scans with trivy against locally built containers (#5358, @SgtCoDFish)
+- CertificateRequests: requests that use the SelfSigned Issuer will be re-reconciled when the target private key Secret has been informed `cert-manager.io/private-key-secret-name`. This resolves an issue whereby a request would never be signed when the target Secret was not created or was misconfigured before the request. (#5336, @JoshVanL)
+- CertificateSigningRequests: requests that use the SelfSigned Issuer will be re-reconciled when the target private key Secret has been informed `experimental.cert-manager.io/private-key-secret-name`. This resolves an issue whereby a request would never be signed when the target Secret was not created or was misconfigured before the request.
+  CertificateSigningRequests will also now no-longer be marked as failed when the target private key Secret is malformed- now only firing an event. When the Secret data is resolved, the request will attempt issuance. (#5379, @JoshVanL)
+- Upgraded Gateway API to v0.5.0 (#5376, @inteon)
+- Add caBundleSecretRef to the Vault Issuer to allow referencing the Vault CA Bundle with a Secret. Cannot be used in conjunction with the in-line caBundle field. (#5387, @Tolsto)
+- The feature to create certificate requests with the name being a function of certificate name and revision has been introduced under the feature flag "StableCertificateRequestName" and it is disabled by default. This helps to prevent the error "multiple CertificateRequests were found for the 'next' revision...". (#5487, @sathyanarays)
+- Helm: Added a new parameter `commonLabels` which gives you the capability to add the same label on all the resource deployed by the chart. (#5208, @thib-mary)
+
+### Bug or Regression
+
+- CertificateSigningRequest: no longer mark a request as failed when using the SelfSigned issuer, and the Secret referenced in `experimental.cert-manager.io/private-key-secret-name` doesn't exist. (#5323, @JoshVanL)
+- DNS Route53: Remove incorrect validation which rejects solvers that don't define either a `accessKeyID` or `secretAccessKeyID`. (#5339, @JoshVanL)
+- Enhanced securityContext for PSS/restricted compliance. (#5259, @joebowbeer)
+- Fix issue where CertificateRequests marked as InvalidRequest did not properly trigger issuance failure handling leading to 'stuck' requests (#5366, @munnerz)
+- `cmctl` and `kubectl cert-manager` now report their actual versions instead of "canary", fixing issue [#5020](https://github.com/cert-manager/cert-manager/issues/5020) (#5022, @maelvls)
+
+### Other
+
+- Avoid hard-coding release namespace in helm chart (#5163, @james-callahan)
+- Bump cert-manager's version of Go to `1.19` (#5466, @lucacome)
+- Remove `.bazel` and `.bzl` files from cert-manager now that bazel has been fully replaced (#5340, @SgtCoDFish)
+- Updates Kubernetes libraries to `v0.25.2`. (#5456, @lucacome)
+- Add annotations for ServiceMonitor in helm chart (#5401, @sathieu)
+- Helm: Add NetworkPolicy support (#5417, @mjudeikis)
+- To help troubleshooting, make the container names unique.
+  BREAKING: this change will break scripts/ CI that depend on `cert-manager` being the container name. (#5410, @rgl)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@headlessui/react": "^1.5.0",
         "@next/mdx": "^12.1.4",
         "classnames": "^2.3.1",
+        "compare-versions": "^6.0.0-rc.1",
         "gray-matter": "^4.0.3",
         "next": "12.1.4",
         "next-mdx-remote": "^4.1.0",
@@ -2107,6 +2108,11 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
+      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -17734,6 +17740,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
+      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1843,9 +1843,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001319",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
-      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==",
+      "version": "1.0.30001441",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
+      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
       "funding": [
         {
           "type": "opencollective",
@@ -17553,9 +17553,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001319",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
-      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw=="
+      "version": "1.0.30001441",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
+      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg=="
     },
     "ccount": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@headlessui/react": "^1.5.0",
     "@next/mdx": "^12.1.4",
     "classnames": "^2.3.1",
+    "compare-versions": "^6.0.0-rc.1",
     "gray-matter": "^4.0.3",
     "next": "12.1.4",
     "next-mdx-remote": "^4.1.0",


### PR DESCRIPTION
- Fixes the version selector to sort descending by release number rather than the current sorting which is ascending and is broken in any case. Pictures below.
- NPM told me to update caniuse-lite, so I did
- Fixes a currently broken link on supported releases
- Adds 1.10 release notes to next docs (this was missed previously. Doesn't matter since next-docs aren't appearing on the site ATM anyway and the manifest for next docs is broken since it refers to `docs` and not `next-docs` - this is just a cleanup thing)


:warning: Also adds some docs to next-docs for the new ACME caBundle support!

## Old Version Picker

![Old version picker](https://user-images.githubusercontent.com/1972547/208981163-51c3d210-26f6-472b-8cc5-eef44116e6ed.png)

## New Version Picker

![New version picker](https://user-images.githubusercontent.com/1972547/208981158-158e1651-724a-459c-8a97-f7c9556b7f81.png)
