### PR TITLE
Add an x-robots-tag: noindex header for all branch deploys

### DIFF
--- a/custom-headers/branch-deploy-site-headers
+++ b/custom-headers/branch-deploy-site-headers
@@ -1,0 +1,5 @@
+# Prevent search engines from indexing preview sites for branch deploys. See
+# - https://docs.netlify.com/routing/headers/#custom-headers-for-different-branch-or-deploy-contexts
+# - https://developers.google.com/search/docs/crawling-indexing/block-indexing
+/*
+  X-Robots-Tag: noindex

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,9 @@
 	NEXT_PUBLIC_DOCS_SEARCH_APP_ID = "01YP6XYAE7"
 	NEXT_PUBLIC_DOCS_SEARCH_INDEX_NAME = "cert-manager"
 	NEXT_PUBLIC_DOMAIN_URL = "https://cert-manager.io"
+
+# Prevent search engines from indexing preview sites for branch deploys. See
+# - https://docs.netlify.com/routing/headers/#custom-headers-for-different-branch-or-deploy-contexts
+# - https://developers.google.com/search/docs/crawling-indexing/block-indexing
+[context.branch-deploy]
+  command = "./scripts/build-release && cp ./custom-headers/branch-deploy-site-headers ./out/_headers"


### PR DESCRIPTION
This will not affect production deploys which use a different Netlify deploy context

The aim is to prevent search engines indexing the https://release-next--cert-manager-website.netlify.app/ preview site,
especially once we start linking to that site in :
 * https://github.com/cert-manager/website/pull/1135