### PR TITLE
Move CA bundle note from next-docs on master branch to docs/ ...

### DIFF
--- a/content/docs/configuration/acme/README.md
+++ b/content/docs/configuration/acme/README.md
@@ -346,9 +346,29 @@ In this case the `DNS01` solver for Cloudflare will only be used to solve a
 challenge for a DNS name if the `Certificate` has a label from
 `matchLabels` _and_ the DNS name matches a zone from `dnsZones`.
 
+## Private ACME Servers
+
+cert-manager should also work with private or self-hosted ACME servers, as long as they follow the ACME spec.
+
+If your ACME server doesn't use a publicly trusted certificate, you can pass a trusted CA to use when creating your
+issuer, from cert-manager 1.11 onwards:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: my-acme-server-issuer
+spec:
+  acme:
+    server: https://my-acme-server.example.com
+    caBundle: <base64 encoded CA Bundle in PEM format>
+    ...
+```
+
+
 ## Alternative Certificate Chains
 
-{/* This empty link preserves old links to #alternative-certificate-chain", which matched the old title of this section */}
+{/* The empty link below preserves old links to #alternative-certificate-chain", which matched the old title of this section */}
 
 <a id="alternative-certificate-chain" className="hidden-link"></a>
 


### PR DESCRIPTION
... on release-next branch.

I previously added this note to content/next-docs in https://github.com/cert-manager/website/pull/1133 before we switched to using a release-next branch (which is a huge improvement).

This will preserve that commit. As far as I can tell, this is the only commit which needs preserving in this way and we should be free to remove content/next-docs soon.