### PR TITLE
feat(docs): update typo in venafi doc

### DIFF
--- a/content/docs/configuration/venafi.md
+++ b/content/docs/configuration/venafi.md
@@ -275,8 +275,8 @@ metadata:
   annotations:
     venafi.cert-manager.io/custom-fields: |-
       [
-        {"name": "field-name", "value": "vield value"},
-        {"name": "field-name-2", "value": "vield value 2"}
+        {"name": "field-name", "value": "field value"},
+        {"name": "field-name-2", "value": "field value 2"}
       ]
 ...
 ```


### PR DESCRIPTION
Signed-off-by: Casale, Robert <Robert.Casale@fmr.com>

This PR will fix a typo within the Venafi documentation page.

Also, it will resolve this issue: https://github.com/cert-manager/website/issues/1128