### PR TITLE
Execute next lint via npm run lint script

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,15 @@
+name: check
+on:
+  push:
+    branches: [master]
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - run: npm run lint


### PR DESCRIPTION
There's already an `npm run lint` "script" which in turn runs `next lint` which runs `eslint`. See
 * https://nextjs.org/docs/basic-features/eslint