### PR TITLE
CSS: smaller font for code blocks, 1rem for normal font

### DIFF
--- a/styles/docs.scss
+++ b/styles/docs.scss
@@ -27,7 +27,6 @@
     li {
       @apply mb-0;
       @apply mt-0;
-      @apply text-lg;
     }
 
     .docs-copy-btn {
@@ -52,9 +51,12 @@
       @apply block align-baseline font-normal text-dark-2;
     }
 
-    p,
-    div {
-      @apply text-lg text-dark-2;
+    .prism-code {
+      font-size: 0.8rem;
+    }
+
+    p {
+      @apply text-dark-2;
     }
 
     a:hover {


### PR DESCRIPTION
The code blocks were unreadable. Their font size was set to 1.25 em, i.e., the same font size as the normal text content. Another problem of setting the same font size as the normal text is that monospaced fonts usually have a bigger footprint (`monospace` is a notable example). With all that, I propose to set the monospaced font to 0.8 em.

I also propose to reduce the font size to a "normal" font size of 1 em, like any other documentation website would do. Examples: Cilium is at 1 em, Linkerd is at 1 em.

| Before | After |
|--|--|
| ![Screenshot from 2023-02-13 12-52-19](https://user-images.githubusercontent.com/2195781/218450975-a635d0ae-49e8-46b9-857b-0fe8d8601dcb.png) | ![Screenshot from 2023-02-13 12-52-06](https://user-images.githubusercontent.com/2195781/218450986-915e3d19-3d8a-4d41-980d-7ba274323759.png) |
