### PR TITLE
Docs: Clarify zeroSSL setup instructions

### DIFF
--- a/content/docs/tutorials/zerossl/zerossl.md
+++ b/content/docs/tutorials/zerossl/zerossl.md
@@ -63,14 +63,14 @@ Once you will get your credentials first step is to create seed with secrets. Th
 $ kubectl create secret generic \
        zero-ssl-eabsecret \
        --namespace=cert-manager \
-       --from-literal=secret='YOUR_ZEROSSL_EAB_SECRET'
+       --from-literal=secret='YOUR_ZEROSSL_EAB_HMAC_KEY'
 ```
 
 ### Another way of creating secret.
 
 Encode it in base64 first.
 ```bash
-echo -n "YOUR_ZEROSSL_EAB_SECRET" | base64 -w 0
+echo -n "YOUR_ZEROSSL_EAB_HMAC_KEY" | base64 -w 0
 ```
 
 ```yaml
@@ -79,7 +79,7 @@ kind: Secret
 metadata:
   name: zero-ssl-eabsecret
 data:
-  secret: YOUR_ENCODED_ZEROSSL_EAB_SECRET
+  secret: YOUR_ENCODED_ZEROSSL_EAB_HMAC_KEY
 ```
 ```bash
 kubectl apply -f zero-ssl-eabsecret.yaml -n cert-manager
@@ -105,7 +105,7 @@ spec:
 
     # for each cert-manager new EAB credencials are required
     externalAccountBinding:
-      keyID: ZEROSSL_KEY_ID
+      keyID: YOUR_ZEROSSL_EAB_KEY_ID
       keySecretRef:
         name: zero-ssl-eabsecret
         key: secret

--- a/content/docs/tutorials/zerossl/zerossl.md
+++ b/content/docs/tutorials/zerossl/zerossl.md
@@ -13,9 +13,6 @@ The ZeroSSL just like Let's Encrypt and its competitors allows to create free 90
 `Please note!` \
 EAB credentials are not stored in your account, please make sure to note them somewhere. Each click on "Generate" will create a new set of credentials. Even if you create multiple credentials, all of them will remain functional.
 
-`Please note!` \
-EAB credentials are one-use only. Create additional pair for different environments.
-
 
 
 # Prerequisites


### PR DESCRIPTION
I went through a bit of confusion trying to setup ZeroSSL with certmanager.io this morning when I went through the docs. 

This PR updates the ZeroSSL setup instructions to clarify what values go where, so the next person doesn't end up spending a good hour wondering why they keep getting `Failed to register ACME account: 400 urn:ietf:params:acme:error:malformed: [External Account Binding] The Key Identifier was not recognized`