### PR TITLE
Updates 1.12 expected release date

### DIFF
--- a/content/docs/installation/supported-releases.md
+++ b/content/docs/installation/supported-releases.md
@@ -28,7 +28,7 @@ cert-manager expects that ServerSideApply is enabled in the cluster for all vers
 
 | Release  |  Release Date  |  End of Life   | [Supported Kubernetes versions][s]  | [Supported OpenShift versions][s] |
 |----------|:--------------:|:--------------:|:-----------------------------------:|:---------------------------------:|
-| [1.12][] | ~Mar 15, 2023  | Mid July, 2023 |            1.22 → 1.26              |            4.9 → 4.13             |
+| [1.12][] | End of April, 2023  | End of August, 2023 |            1.22 → 1.27              |            4.9 → 4.13             |
 
 Dates in the future are uncertain and might change.
 


### PR DESCRIPTION
As discussed in standup, updates 1.12 release date and EOL accordingly to when we started the release cycle

Also add Kube 1.27 to supported releases as that will have been released by https://www.kubernetes.dev/resources/release/#:~:text=The%201.27%20release%20cycle%20is,2023%3A%20Week%205%20%E2%80%94%20Enhancements%20Freeze