### PR TITLE
Helm install: add hint for installCRDs in both cases

### DIFF
--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -79,6 +79,7 @@ helm install \
   --namespace cert-manager \
   --create-namespace \
   --version v1.11.0 \
+  # --set installCRDs=true
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
 ```


### PR DESCRIPTION
I wanted the cert-manager without prometheus so I jumped to the second command.
There was the hint for installCRDs missing so I had a hard time installing cert-manager.