### PR TITLE
Updates uninstall doc with backup and restore guide link

### DIFF
--- a/content/docs/installation/uninstall.md
+++ b/content/docs/installation/uninstall.md
@@ -10,3 +10,5 @@ cert-manager to go to the relevant uninstall documentation.
 
 - [kubectl](./kubectl.md#uninstalling)
 - [helm](./helm.md#uninstalling)
+
+If you need to preserve cert-manager custom resources (`Certificate`s, `Issuer`s etc), that are not version controlled or backed up by other means, take a look at our [backup and restore guide](../tutorials/backup.md).


### PR DESCRIPTION
Adds backup and restore guide link to uninstall doc as that seems to be a good place for it, it's hard to find otherwise.
I'm undecided if maybe the whole page should be moved under ./installation it's not really a tutorial as such.