### PR TITLE
release-process: explain how and when to merge master into release-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ Sometimes you'll want to add a comment which is only for documentation maintaine
 
 Use `{/* my comment */}` rather than the HTML-style comments you'd normally use for Markdown files. Other comment types will cause errors.
 
+### Task: Merging `master` into `release-next`
+
+In rare occasions, when writing documentation for an unreleased feature, you may
+notice that some recent changes in `master` aren't present in `release-next`. If
+that is a problem, you will want to update `release-next` branch with the latest
+changes from `master`. To update `release-next` with the changes made to
+`master`, follow these steps:
+
+1. Create a PR to merge `master` into `release-next` using [this magic
+   link][ff-release-next].
+2. If you see the label `dco-signoff: no`, add a comment on the PR with:
+
+   ```text
+    /override dco
+    ```
+
+   It is necessary because some the merge commits have been written by the bot
+   and do not have a DCO signoff.
+
+[ff-release-next]: https://github.com/cert-manager/website/compare/release-next...master?quick_pull=1&title=%5Brelease-next%5D+Merge+master+into+release-next&body=%3C%21--%0A%0AThe+command+%22%2Foverride+dco%22+is+necessary+because+some+the+merge+commits%0Ahave+been+written+by+the+bot+and+do+not+have+a+DCO+signoff.%0A%0A--%3E%0A%0A%2Foverride+dco
+
 ## Website Development Tooling
 
 First [install nodejs (and package manager called `npm`)](https://nodejs.org/en/).

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -578,3 +578,32 @@ Other than the different `cert-manager/release` tag and `cmrel` version, you can
 is used for 1.6 and 1.7 - just remember to change the version of `cmrel` you install!
 
 [older-release-process]: https://github.com/cert-manager/website/blob/6fa0db74de0ae17d7be638a08155d1b4e036aaa9/content/en/docs/contributing/release-process.md?plain=1
+
+## Documentation Process
+
+Everytime a PR is opened on the cert-manager/website repository, you will need
+to check that the "base branch" is correct.
+
+|                Description                 |  Base branch   |     Folder     |
+|--------------------------------------------|----------------|----------------|
+| Documentation PR for an existing feature   | `master`       | `content/docs` |
+| Documentation PR for an unreleased feature | `release-next` | `content/docs` |
+
+When creating a documentation PR for an unreleased feature, you will need to
+fast-forward the `release-next` branch to `master` before asking for a review of
+the PR:
+
+1. Create a PR to fast-forward `release-next` to `master` using [this magic
+   link][ff-release-next].
+2. If you see the label `dco-signoff: no`, add a comment on the PR with:
+
+   ```text
+    /override dco
+    ```
+
+   It is necessary because some the merge commits have been written by the bot
+   and do not have a DCO signoff.
+3. Once the PR is merged, look at your PR and check that the unrelated commits
+   that were previously showing are gone.
+
+[ff-release-next]: https://github.com/cert-manager/website/compare/release-next...master?quick_pull=1&title=%5Brelease-next%5D+Fast-forward+to+master&body=%3C%21--%0A%0AThe+command+%22%2Foverride+dco%22+is+necessary+because+some+the+merge+commits%0Ahave+been+written+by+the+bot+and+do+not+have+a+DCO+signoff.%0A%0A--%3E%0A%0A%2Foverride+dco

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -578,32 +578,3 @@ Other than the different `cert-manager/release` tag and `cmrel` version, you can
 is used for 1.6 and 1.7 - just remember to change the version of `cmrel` you install!
 
 [older-release-process]: https://github.com/cert-manager/website/blob/6fa0db74de0ae17d7be638a08155d1b4e036aaa9/content/en/docs/contributing/release-process.md?plain=1
-
-## Documentation Process
-
-Authors of PRs to cert-manager/website need to check that the "base branch" is
-correct:
-
-|                Description                 |  Base branch   |     Folder     |
-|--------------------------------------------|----------------|----------------|
-| Documentation PR for an existing feature   | `master`       | `content/docs` |
-| Documentation PR for an unreleased feature | `release-next` | `content/docs` |
-
-In rare occasions, when writing documentation for an unreleased feature, you may
-notice that some recent changes in `master` aren't present in `release-next`. If
-that is a problem, you will want to update `release-next` branch with the latest
-changes from `master`. To update `release-next` with the changes made to
-`master`, follow these steps:
-
-1. Create a PR to merge `master` into `release-next` using [this magic
-   link][ff-release-next].
-2. If you see the label `dco-signoff: no`, add a comment on the PR with:
-
-   ```text
-    /override dco
-    ```
-
-   It is necessary because some the merge commits have been written by the bot
-   and do not have a DCO signoff.
-
-[ff-release-next]: https://github.com/cert-manager/website/compare/release-next...master?quick_pull=1&title=%5Brelease-next%5D+Fast-forward+to+master&body=%3C%21--%0A%0AThe+command+%22%2Foverride+dco%22+is+necessary+because+some+the+merge+commits%0Ahave+been+written+by+the+bot+and+do+not+have+a+DCO+signoff.%0A%0A--%3E%0A%0A%2Foverride+dco

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -581,19 +581,21 @@ is used for 1.6 and 1.7 - just remember to change the version of `cmrel` you ins
 
 ## Documentation Process
 
-Everytime a PR is opened on the cert-manager/website repository, you will need
-to check that the "base branch" is correct.
+Authors of PRs to cert-manager/website need to check that the "base branch" is
+correct:
 
 |                Description                 |  Base branch   |     Folder     |
 |--------------------------------------------|----------------|----------------|
 | Documentation PR for an existing feature   | `master`       | `content/docs` |
 | Documentation PR for an unreleased feature | `release-next` | `content/docs` |
 
-When creating a documentation PR for an unreleased feature, you will need to
-fast-forward the `release-next` branch to `master` before asking for a review of
-the PR:
+In rare occasions, when writing documentation for an unreleased feature, you may
+notice that some recent changes in `master` aren't present in `release-next`. If
+that is a problem, you will want to update `release-next` branch with the latest
+changes from `master`. To update `release-next` with the changes made to
+`master`, follow these steps:
 
-1. Create a PR to fast-forward `release-next` to `master` using [this magic
+1. Create a PR to merge `master` into `release-next` using [this magic
    link][ff-release-next].
 2. If you see the label `dco-signoff: no`, add a comment on the PR with:
 
@@ -603,7 +605,5 @@ the PR:
 
    It is necessary because some the merge commits have been written by the bot
    and do not have a DCO signoff.
-3. Once the PR is merged, look at your PR and check that the unrelated commits
-   that were previously showing are gone.
 
 [ff-release-next]: https://github.com/cert-manager/website/compare/release-next...master?quick_pull=1&title=%5Brelease-next%5D+Fast-forward+to+master&body=%3C%21--%0A%0AThe+command+%22%2Foverride+dco%22+is+necessary+because+some+the+merge+commits%0Ahave+been+written+by+the+bot+and+do+not+have+a+DCO+signoff.%0A%0A--%3E%0A%0A%2Foverride+dco


### PR DESCRIPTION
These changes were extracted from https://github.com/cert-manager/website/pull/1081#discussion_r1114395964.