### PR TITLE
Explains what happens if CertificateRequest is denied

### DIFF
--- a/content/docs/projects/approver-policy.md
+++ b/content/docs/projects/approver-policy.md
@@ -72,6 +72,14 @@ selector.
 least one policy is appropriate for the request but none of those permit the
 request, the request is denied.**
 
+A denied CertificateRequest is considered to be permanently failed. If it was
+created for a Certificate resource, the issuance will be retried with
+[exponential
+backoff](../faq/README.md#what-happens-if-issuance-fails-will-it-be-retried)
+like all other permanent issuance failures. A CertificateRequest that is neither
+approved nor denied (because no matching policy was found) will not be further
+processed by cert-manager until it gets either approved or denied.
+
 CertificateRequestPolicies are cluster scoped resources that can be thought of
 as "policy profiles". They describe any request that is approved by that
 policy. Policies are bound to Kubernetes users and ServiceAccounts using RBAC.


### PR DESCRIPTION
As per the discussion we had today at standup I think it'd be useful to document what happens if a CertificateRequest for a Certificate is denied.

The issuance fails and is retried with exponential backoff see https://github.com/cert-manager/cert-manager/blob/master/pkg/controller/certificates/issuing/issuing_controller.go#L294

I've also tested it by hand to be extra sure and observed that issuance gets retried with exponential backoff as expected
```
I0302 12:56:29.444148       1 trigger_controller.go:179] cert-manager/certificates-trigger "msg"="Backing off from issuance due to previously failed issuance(s). Issuance will next be attempted at 2023-03-02 14:56:29.000000712 +0000 UTC m=+10822.311055205" "key"="default/foo-denied"
```