### PR TITLE
Update references to ingress objects in the nginx-ingress tutorial

### DIFF
--- a/content/docs/tutorials/acme/nginx-ingress.md
+++ b/content/docs/tutorials/acme/nginx-ingress.md
@@ -136,7 +136,7 @@ it is saved:
 
 ```bash
 kubectl create --edit -f https://raw.githubusercontent.com/cert-manager/website/master/content/docs/tutorials/acme/example/ingress.yaml
-# expected output: ingress.extensions "kuard" created
+# expected output: ingress.networking.k8s.io/kuard created
 ```
 
 > Note: The ingress example we show above has a `host` definition within it. The
@@ -348,7 +348,7 @@ and apply it:
 
 ```bash
 kubectl create --edit -f https://raw.githubusercontent.com/cert-manager/website/master/content/docs/tutorials/acme/example/ingress-tls.yaml
-# expected output: ingress.extensions "kuard" configured
+# expected output: ingress.networking.k8s.io/kuard configured
 ```
 
 Cert-manager will read these annotations and use them to create a certificate,
@@ -447,7 +447,7 @@ can update the annotations in the ingress to specify the production issuer:
 
 ```bash
 $ kubectl create --edit -f https://raw.githubusercontent.com/cert-manager/website/master/content/docs/tutorials/acme/example/ingress-tls-final.yaml
-ingress.extensions "kuard" configured
+ingress.networking.k8s.io/kuard configured
 ```
 
 You will also need to delete the existing secret, which cert-manager is watching


### PR DESCRIPTION
From `ingress.extensions` to `ingress.networking.k8s.io`. The objects referenced in the page are not of type `ingress.extensions`