### PR TITLE
Fix typos / some wording for approver-policy docs

### DIFF
--- a/content/docs/installation/compatibility.md
+++ b/content/docs/installation/compatibility.md
@@ -84,7 +84,7 @@ helm install \
   --version ${CERT_MANAGER_VERSION} --set global.leaderElection.namespace=cert-manager
 ```
 
-The implication for a `kubectl apply` type installation is then either "you must manually update the manifests prior to installation by replacing kube-system with cert-manager" or "Don't install cert-manager using kubectl apply. Helm is the recommended solution".
+The implication for a `kubectl apply` type installation is then either "you must manually update the manifests prior to installation by replacing `kube-system` with cert-manager" or "Don't install cert-manager using kubectl apply. Helm is the recommended solution".
 
 ## AWS EKS
 

--- a/content/docs/projects/approver-policy.md
+++ b/content/docs/projects/approver-policy.md
@@ -1,27 +1,26 @@
 ---
 title: approver-policy
-description: ''
+description: 'Policy plugin for cert-manager'
 ---
 
 approver-policy is a cert-manager
 [approver](../concepts/certificaterequest.md#approval)
-that will approve or deny CertificateRequests based on CRD defined policies.
-
----
+that will approve or deny CertificateRequests based on policies defined in
+the `CertificateRequestPolicy` custom resource.
 
 ## Installation
 
-[cert-manager](../installation/README.md) is required to be installed with approver-policy.
+[cert-manager](../installation/README.md) is a dependency of approver-policy.
 
 > ⚠️
 >
 > It is important that the
 > [default approver is disabled in cert-manager](../concepts/certificaterequest.md#approver-controller).
 > If the default approver is not disabled in cert-manager, approver-policy will
-> race with cert-manager and thus policy becomes useless.
+> race with cert-manager and policy will be ineffective.
 >
 > ```terminal
-> $ helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set extraArgs={--controllers='*\,-certificaterequests-approver'} --set installCRDs=true --create-namespace
+> helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set extraArgs={--controllers='*\,-certificaterequests-approver'} --set installCRDs=true --create-namespace
 > ```
 >
 > ⚠️
@@ -29,8 +28,8 @@ that will approve or deny CertificateRequests based on CRD defined policies.
 To install approver-policy:
 
 ```terminal
-$ helm repo add jetstack https://charts.jetstack.io --force-update
-$ helm upgrade -i -n cert-manager cert-manager-approver-policy jetstack/cert-manager-approver-policy --wait
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm upgrade -i -n cert-manager cert-manager-approver-policy jetstack/cert-manager-approver-policy --wait
 ```
 
 If you are using approver-policy with [external
@@ -39,7 +38,7 @@ include their signer names so that approver-policy has permissions to approve
 and deny CertificateRequests that
 [reference them](../concepts/certificaterequest.md#rbac-syntax).
 For example, if using approver-policy for the internal issuer types, along with
-[google-ca-issuer](https://github.com/jetstack/google-cas-issuer), and
+[google-cas-issuer](https://github.com/jetstack/google-cas-issuer), and
 [aws-privateca-issuer](https://github.com/cert-manager/aws-privateca-issuer),
 set the following values when installing:
 
@@ -51,8 +50,6 @@ googlecasclusterissuers.cas-issuer.jetstack.io/*,googlecasissuers.cas-issuer.jet
 awspcaclusterissuers.awspca.cert-manager.io/*,awspcaissuers.awspca.cert-manager.io/*\
 }"
 ```
-
----
 
 ## Configuration
 
@@ -74,8 +71,7 @@ request, the request is denied.**
 
 A denied CertificateRequest is considered to be permanently failed. If it was
 created for a Certificate resource, the issuance will be retried with
-[exponential
-backoff](../faq/README.md#what-happens-if-issuance-fails-will-it-be-retried)
+[exponential backoff](../faq/README.md#what-happens-if-issuance-fails-will-it-be-retried)
 like all other permanent issuance failures. A CertificateRequest that is neither
 approved nor denied (because no matching policy was found) will not be further
 processed by cert-manager until it gets either approved or denied.
@@ -131,8 +127,6 @@ subjects:
   name: system:authenticated
   apiGroup: rbac.authorization.k8s.io
 ```
-
----
 
 ## Behavior
 
@@ -373,7 +367,7 @@ time. Plugins are designed to be used as extensions to the existing policy
 checks where the user requires special functionality that the existing checks
 can't provide.
 
-Plugins are defined as a block on the CertificateRequestPolicy Spec.
+Plugins are defined as a block on the CertificateRequestPolicy `spec`.
 
 ```yaml
 apiVersion: policy.cert-manager.io/v1alpha1
@@ -388,4 +382,4 @@ spec:
         val-1: key-1
 ```
 
-There are currently no none open source plugins.
+There are currently no open source plugins.


### PR DESCRIPTION
Also fixes a spelling checker failure in an unrelated file which somehow was broken prior to this PR by #1205 