### PR TITLE
Updated info about issue-temporary-certificate

### DIFF
--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -136,24 +136,24 @@ documentation](../reference/api-docs.md#cert-manager.io/v1.KeyUsage).
 
 <h2 id="temporary-certificates-whilst-issuing">Temporary Certificates while Issuing</h2>
 
-On old GKE versions (`1.10.7-gke.1` and below), when requesting certificates
-[using the ingress-shim](./ingress.md) alongside the
-[`ingress-gce`](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress)
-ingress controller, `ingress-gce`
-[required](https://github.com/kubernetes/ingress-gce/pull/388) a temporary
-certificate must be present while waiting for the issuance of a signed
-certificate. Note that this issue was
-[solved](https://github.com/cert-manager/cert-manager/issues/606#issuecomment-424397233)
-in `1.10.7-gke.2`.
+When requesting certificates [using the ingress-shim](./ingress.md), the
+component `ingress-gce`, if used, requires that a temporary certificate is
+present while waiting for the issuance of a signed certificate when serving. To
+facilitate this, if the following annotation:
 
-```yaml
-# Required for GKE 1.10.7-gke.1 and below.
-cert-manager.io/issue-temporary-certificate": "true"
-```
+ ```yaml
+ cert-manager.io/issue-temporary-certificate": "true"
+ ```
 
-That made sure that a temporary self-signed certificate was present in the
-`Secret`. The self-signed certificate was replaced with the signed certificate
-later on.
+is present on the certificate, a self-signed temporary certificate will be
+present on the `Secret` until it is overwritten once the signed certificate has
+been issued.
+
+Adding the following annotation on an ingress will automatically set "issue-temporary-certificate" on the certificate:
+
+ ```yaml
+ acme.cert-manager.io/http01-edit-in-place: "true"
+ ```
 
 <h2 id="rotation-private-key">Rotation of the private key</h2>
 


### PR DESCRIPTION
The gist of commit 4232d0c64cb215dc487ac5ec4fe36a0e17713b25 , which remains in the documentation, is that 4 years ago all issues surrounding temporary certificates on GKE were "solved", and therefore you don't need "cert-manager.io/issue-temporary-certificate" any more.

That seems to be wrong.

Based on testing, the absence of a certificate at the beginning of the process will cause errors such as this:

"""
45s                   Warning   Sync                                Ingress/www-example                                                    Error syncing to GCP: error running load balancer syncing routine: error initializing translator env: secrets "www-example-tls" not found
"""

[The cert-manager GKE tutorial](https://cert-manager.io/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/) recommends manually creating a temporary certificate which further corroborates the idea that it's necessary. You can't launch an ingress that refers to a secret without the secret existing.

Therefore, it seems the clearest version of the text is to revert commit 4232d0c64cb215dc487ac5ec4fe36a0e17713b25 .   

Next, 

Also based on testing, something else is occurring which I don't completely understand.

"cert-manager.io/issue-temporary-certificate": "true" was not sufficient to generate a temporary certificate on GKE.

"acme.cert-manager.io/http01-edit-in-place": "true" must also be specified.

Consider the meaning of variable assignment `issue-temporary-certificate = true`.  It should issue a temporary certificate, right? And yet it didn't.  

Additionally, on the [Ingress page](https://cert-manager.io/docs/usage/ingress/) "issue-temporary-certificate" doesn't have it's own entry in the list of Supported Annotations. It would be good to add an entry in order to clarify the annotation.  

Yet another option (which may not be right) is if you were to say "issue-temporary-certificate is obsolete and should tend to be removed from the docs". In which case the current pull request ought to be changed and only discuss "http01-edit-in-place".

Any feedback is welcome, I could modify the wording further.
