### PR TITLE
Go Workspace Documentation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -417,6 +417,8 @@ subcommands
 subdomain
 subdomains
 subfolders
+submodule
+submodules
 subresource
 symlink
 tamalsaha

--- a/content/docs/contributing/building.md
+++ b/content/docs/contributing/building.md
@@ -67,6 +67,29 @@ go version go1.AB.C linux/amd64
 go binary used for above version information: go
 ```
 
+### Go Workspaces
+
+In short: Some development tools will complain about cert-manager's module layout; to help with this, generate a
+`go.work` file using `make go-workspace`.
+
+The cert-manager repository as of cert-manager 1.12 contains multiple Go modules, in a setup where only the core module `github.com/cert-manager/cert-manager`
+is expected to be imported by third party modules. There are separate modules (which we call submodules), all of which have replace statements for the core
+cert-manager module.
+
+This setup is intentional to convey that these submodules are not intended to be imported by third parties, and to ensure that each submodule always uses
+whatever the cert-manager core module version is at the same commit - but this structure can have the side effect that certain development tools and scripts
+will not work as expected.
+
+As an example, `go test ./...` will by default only affect the core module. To test, say, the controller, you'd need to use `cd cmd/controller && go test ./...`.
+
+This can be avoided through the use of go workspaces, which will handle local replacements for you and work better with editors such as VS Code.
+
+You can run `make go-workspace` to generate a `go.work` file which should enable `go test ./...` to work across the
+whole repo, and which should help editors to understand the module structure.
+
+Note that go workspaces are not used when testing pull requests in CI. If you see errors in CI which you can't replicate
+locally, try deleting the `go.work` file.
+
 ### Parallelism
 
 The cert-manager Makefile is designed to be highly parallel wherever possible. Any build and test commands should be able to be executed in parallel using
@@ -103,6 +126,8 @@ There are make targets to help with this; see [Developing with Kind](./kind.md) 
 
 First of all: If you want to test using `go test`, feel free! For unit tests (which we define as any test outside of the `test/` directory), `go test` will
 work on a fresh checkout.
+
+Note that the cert-manager repo is split into multiple modules and unless you're using go workspaces `go test ./...` won't actually run all tests. See [Go Workspaces](./building.md#go-workspaces) above for more details.
 
 Integration tests may require some external tools to be set up first, so to run the integration tests inside `test/` you might need to run:
 

--- a/content/docs/contributing/building.md
+++ b/content/docs/contributing/building.md
@@ -88,7 +88,7 @@ You can run `make go-workspace` to generate a `go.work` file which should enable
 whole repo, and which should help editors to understand the module structure.
 
 Note that go workspaces are not used when testing pull requests in CI. If you see errors in CI which you can't replicate
-locally, try deleting the `go.work` file.
+locally, try building with the `GOWORK` environment variable set to `off` or deleting the `go.work` file.
 
 ### Parallelism
 

--- a/content/docs/contributing/importing.md
+++ b/content/docs/contributing/importing.md
@@ -30,14 +30,13 @@ aware of this need! We'll always try to avoid breakage where we can.
 
 ## Module Import Paths
 
-The original cert-manager repository was created on GitHub as `https://github.com/jetstack/cert-manager`, and was later
+For all supported versions of cert-manager, the module import path is `github.com/cert-manager/cert-manager`.
+
+Historically, the cert-manager repository was created on GitHub as `https://github.com/jetstack/cert-manager`, and was later
 migrated to `https://github.com/cert-manager/cert-manager`.
 
-This means the Go module import path you need depends on the version of cert-manager you're trying to use.
+This means that the Go module import path you need may be different if you're trying to use an older version of cert-manager.
 
-For cert-manager 1.8 and later, use the new path:   
-`github.com/cert-manager/cert-manager`
+For cert-manager 1.8 and later, use the new path listed above.
 
-
-For cert-manager 1.7 and earlier, including all point releases, use the old path:   
-`github.com/jetstack/cert-manager`
+For cert-manager versions older than 1.8 use the old path: `github.com/jetstack/cert-manager`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11857,6 +11857,7 @@
       }
     },
     "scripts/gendocs/postprocess": {
+      "name": "format-api-docs",
       "version": "1.0.0",
       "dev": true,
       "license": "ISC",


### PR DESCRIPTION
Also tweaks our importing docs. Probably blocked behind https://github.com/cert-manager/cert-manager/pull/5935