### PR TITLE
Fix selector.issuerRef example to use map instead of list

### DIFF
--- a/content/docs/projects/approver-policy.md
+++ b/content/docs/projects/approver-policy.md
@@ -298,7 +298,7 @@ spec:
   ...
   selector:
     issuerRef:
-    - name: "my-ca"
+      name: "my-ca"
       kind: "*Issuer"
       group: "cert-manager.io"
 ```


### PR DESCRIPTION
Fixes: https://github.com/cert-manager/approver-policy/issues/217