### PR TITLE
Fix leading whitespaces in YAML code block

### DIFF
--- a/content/docs/tutorials/acme/example/production-issuer.yaml
+++ b/content/docs/tutorials/acme/example/production-issuer.yaml
@@ -1,18 +1,18 @@
-   apiVersion: cert-manager.io/v1
-   kind: Issuer
-   metadata:
-     name: letsencrypt-prod
-   spec:
-     acme:
-       # The ACME server URL
-       server: https://acme-v02.api.letsencrypt.org/directory
-       # Email address used for ACME registration
-       email: user@example.com
-       # Name of a secret used to store the ACME account private key
-       privateKeySecretRef:
-         name: letsencrypt-prod
-       # Enable the HTTP-01 challenge provider
-       solvers:
-       - http01:
-           ingress:
-             class: nginx
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: user@example.com
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/content/docs/tutorials/acme/example/staging-issuer.yaml
+++ b/content/docs/tutorials/acme/example/staging-issuer.yaml
@@ -1,18 +1,18 @@
-   apiVersion: cert-manager.io/v1
-   kind: Issuer
-   metadata:
-     name: letsencrypt-staging
-   spec:
-     acme:
-       # The ACME server URL
-       server: https://acme-staging-v02.api.letsencrypt.org/directory
-       # Email address used for ACME registration
-       email: user@example.com
-       # Name of a secret used to store the ACME account private key
-       privateKeySecretRef:
-         name: letsencrypt-staging
-       # Enable the HTTP-01 challenge provider
-       solvers:
-       - http01:
-           ingress:
-             class:  nginx
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: user@example.com
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - http01:
+        ingress:
+          class:  nginx


### PR DESCRIPTION
The leading whitespaces seemed to have caused an issue when rendered to markdown