### PR TITLE
Adds a link to example approver-policy plugin implementation

### DIFF
--- a/content/docs/projects/approver-policy/README.md
+++ b/content/docs/projects/approver-policy/README.md
@@ -417,6 +417,10 @@ spec:
 
 There are currently no open source plugins.
 
+If you want to implement an external approver policy plugin take a look at the
+example implementation at
+https://github.com/cert-manager/example-approver-policy-plugin.
+
 ## API Reference
 
 > 📖 Read the [approver-policy API reference](api-reference.md).


### PR DESCRIPTION
Adds a link to example policy plugin implementation https://github.com/cert-manager/example-approver-policy-plugin

Should be merged after https://github.com/cert-manager/example-approver-policy-plugin/pull/1 gets merged

/hold