### PR TITLE
Correct the cmctl release generation flow

### DIFF
--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -254,7 +254,7 @@ that commit to the release branch _before_ pushing the tag for the new release.
      ```bash
      # This tag is required to be able to go install cmctl
      # See https://stackoverflow.com/questions/60601011/how-are-versions-of-a-sub-module-managed/60601402#60601402
-     git tag -m"cmd/ctl/$RELEASE_VERSION" "cmd/ctl/$RELASE_VERSION"
+     git tag -m"cmd/ctl/$RELEASE_VERSION" "cmd/ctl/$RELEASE_VERSION"
      git push origin "cmd/ctl/$RELEASE_VERSION"
      ```
 

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -225,7 +225,7 @@ page if a step is missing or if it is outdated.
    >  This is only a temporary change to allow you to update the branch.
    >  [Prow will re-apply the branch protection within 24 hours](https://docs.prow.k8s.io/docs/components/optional/branchprotector/#updating).
 
-5. Ensure that cert-manager library dependency in `cmctl` refers to the latest
+5. (only required when releasing cert-manager v1.12 and newer) Ensure that cert-manager library dependency in `cmctl` refers to the latest
 cert-manager commit on the branch you want to release from. See comment
 [here](https://github.com/cert-manager/cert-manager/blob/v1.12.1/cmd/ctl/go.mod#L5-L12).
 You must bump the cert-manager version in `cmctl` `go.mod` file and cherry-pick
@@ -250,7 +250,7 @@ that commit to the release branch _before_ pushing the tag for the new release.
       kicking off a build using the steps in `gcb/build_cert_manager.yaml`. Users with access to
       the cert-manager-release project on GCP should be able to view logs in [GCB build history](https://console.cloud.google.com/cloud-build/builds?project=cert-manager-release).
 
-Add the tag for cmctl:
+(only required when releasing cert-manager v1.12 and newer) Add the tag for cmctl:
      ```bash
      # This tag is required to be able to go install cmctl
      # See https://stackoverflow.com/questions/60601011/how-are-versions-of-a-sub-module-managed/60601402#60601402

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -225,7 +225,13 @@ page if a step is missing or if it is outdated.
    >  This is only a temporary change to allow you to update the branch.
    >  [Prow will re-apply the branch protection within 24 hours](https://docs.prow.k8s.io/docs/components/optional/branchprotector/#updating).
 
-5. Create the required tags for the new release locally and push it upstream (starting the cert-manager build):
+5. Ensure that cert-manager library dependency in `cmctl` refers to the latest
+cert-manager commit on the branch you want to release from. See comment
+[here](https://github.com/cert-manager/cert-manager/blob/v1.12.1/cmd/ctl/go.mod#L5-L12).
+You must bump the cert-manager version in `cmctl` `go.mod` file and cherry-pick
+that commit to the release branch _before_ pushing the tag for the new release.
+
+6. Create the required tags for the new release locally and push it upstream (starting the cert-manager build):
 
      ```bash
      RELEASE_VERSION=v1.8.0-beta.0
@@ -238,15 +244,11 @@ page if a step is missing or if it is outdated.
       `admin` GitHub permission on the cert-manager repo to create or push to
       the branch, see [prerequisites](#prerequisites). If you do not have this
       permission, you will have to open a PR to merge master into the release
-      branch), and wait for the PR checks to become green.
+      branch, and wait for the PR checks to become green.
 
       For recent versions of cert-manager, the tag being pushed will trigger a Google Cloud Build job to start,
       kicking off a build using the steps in `gcb/build_cert_manager.yaml`. Users with access to
       the cert-manager-release project on GCP should be able to view logs in [GCB build history](https://console.cloud.google.com/cloud-build/builds?project=cert-manager-release).
-
-6. Ensure that cmctl refers to the latest tag of cert-manager:
-
-Bump cert-manager version in [cmctl `go.mod` file](https://github.com/cert-manager/cert-manager/blob/v1.12.0/cmd/ctl/go.mod#L15) and cherry-pick the commit to the release branch.
 
 Add the tag for cmctl:
      ```bash


### PR DESCRIPTION
The flow for cmctl release should be:

- get all commits we want to release in release branch where the top commit is X
- bump cert-manager dependency version to X in cmctl go.mod and cherry-pick that change to release branch
- continue with release as normal by pushing the two tags etc

