### PR TITLE
fix(supported-releases): fix the year of the 1.12 release date and eol

### DIFF
--- a/content/docs/installation/supported-releases.md
+++ b/content/docs/installation/supported-releases.md
@@ -17,7 +17,7 @@ and other world events.
 
 | Release  | Release Date |      End of Life       | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |----------|:------------:|:----------------------:|:----------------------------------:|:---------------------------------:|
-| [1.12][] | May 19, 2024 | End of September, 2024 |            1.22 → 1.27             |            4.9 → 4.14             |
+| [1.12][] | May 19, 2023 | End of September, 2023 |            1.22 → 1.27             |            4.9 → 4.14             |
 | [1.11][] | Jan 11, 2023 |    Release of 1.13     |            1.21 → 1.27             |            4.8 → 4.14             |
 
 ## Upcoming releases


### PR DESCRIPTION
I've found that the release date of 1.12 is written as `2024`, but I think it should be `2023`.

Also, please check the comment in #1236.
https://github.com/cert-manager/website/pull/1236/files#r1209815760