### PR TITLE
Add queried endpoint to check Vault status when initializing issuer

### DIFF
--- a/content/docs/configuration/vault.md
+++ b/content/docs/configuration/vault.md
@@ -375,8 +375,7 @@ been deployed.
 The Vault issuer tests your Vault instance by querying the `v1/sys/health`
 endpoint, to ensure your Vault instance is unsealed and initialized before
 requesting certificates. The result of that query will populate the `STATUS`
-column
-
+column.
 
 ```bash
 $ kubectl get issuers vault-issuer -n sandbox -o wide

--- a/content/docs/configuration/vault.md
+++ b/content/docs/configuration/vault.md
@@ -369,8 +369,14 @@ Kubernetes 1.24 and above.
 ## Verifying the issuer Deployment
 
 Once the Vault issuer has been deployed, it will be marked as ready if the
-configuration is valid. Replace `issuers` here with `clusterissuers` if that is what has
+configuration is valid. Replace `issuers` below with `clusterissuers` if that is what has
 been deployed.
+
+The Vault issuer tests your Vault instance by querying the `v1/sys/health`
+endpoint, to ensure your Vault instance is unsealed and initialized before
+requesting certificates. The result of that query will populate the `STATUS`
+column
+
 
 ```bash
 $ kubectl get issuers vault-issuer -n sandbox -o wide


### PR DESCRIPTION
The Vault Issuer queries an endpoint to check is the Vault instance is healthy. When configuring the Issuer with a remote Vault instance protected behind a firewall, the 'Vault sealed or unintialized' error could be thrown when the endpoint could simply not be reached. There was no sign of this endpoint in the docs, so adding it for commodity.