### PR TITLE
Post-release 1.12: add empty upgrade notes

### DIFF
--- a/content/docs/installation/upgrading/upgrading-1.11-1.12.md
+++ b/content/docs/installation/upgrading/upgrading-1.11-1.12.md
@@ -1,0 +1,10 @@
+---
+title: Upgrading from v1.11 to v1.12
+description: 'cert-manager installation: Upgrading v1.11 to v1.12'
+---
+
+There are no breaking changes between cert-manager 1.11 and 1.12.
+
+## Next Steps
+
+From here on you can follow the [regular upgrade process](./README.md).

--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -67,6 +67,10 @@
                   "path": "/docs/installation/upgrading/remove-deprecated-apis.md"
                 },
                 {
+                  "title": "v1.11 to v1.12",
+                  "path": "/docs/installation/upgrading/upgrading-1.11-1.12.md"
+                },
+                {
                   "title": "v1.10 to v1.11",
                   "path": "/docs/installation/upgrading/upgrading-1.10-1.11.md"
                 },


### PR DESCRIPTION
I don't know how but I forgot a step in the Release Process!

Fixes https://github.com/cert-manager/website/issues/1243.