### PR TITLE
Rename the "Configuration" and "Usage" top-level menu items

### DIFF
--- a/content/docs/configuration/venafi.md
+++ b/content/docs/configuration/venafi.md
@@ -100,7 +100,7 @@ vaas-issuer    True    Venafi issuer started  2m
 You are now ready to issue certificates using the newly provisioned Venafi
 `Issuer` and Venafi as a Service.
 
-Read the [Issuing Certificates](../usage/certificate.md) document for
+Read the [Requesting Certificates](../usage/certificate.md) document for
 more information on how to create Certificate resources.
 
 
@@ -256,7 +256,7 @@ $ kubectl describe issuer tpp-issuer --namespace='NAMESPACE OF YOUR ISSUER RESOU
 You are now ready to issue certificates using the newly provisioned Venafi
 `Issuer` and Trust Protection Platform.
 
-Read the [Issuing Certificates](../usage/certificate.md) document for
+Read the [Requesting Certificates](../usage/certificate.md) document for
 more information on how to create Certificate resources.
 
 ## Issuer specific annotations

--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -195,7 +195,7 @@
           ]
         },
         {
-          "title": "Configuration",
+          "title": "Configuring Issuers",
           "routes": [
             {
               "title": "Introduction",
@@ -291,7 +291,7 @@
           ]
         },
         {
-          "title": "Usage",
+          "title": "Requesting Certificates",
           "routes": [
             {
               "title": "Introduction",

--- a/content/docs/tutorials/venafi/venafi.md
+++ b/content/docs/tutorials/venafi/venafi.md
@@ -384,7 +384,7 @@ correctly, we can begin requesting certificates which can be used by Kubernetes
 applications.
 
 Full information on how to specify and request Certificate resources can be
-found in the [Issuing certificates](../../usage/certificate.md) guide.
+found in the [Requesting Certificates](../../usage/certificate.md) guide.
 
 For now, we will create a basic X.509 Certificate that is valid for our domain,
 `example.com`:

--- a/content/docs/usage/README.md
+++ b/content/docs/usage/README.md
@@ -1,5 +1,5 @@
 ---
-title: Issuing Certificates
+title: Requesting Certificates
 description: 'cert-manager usage: Overview'
 ---
 


### PR DESCRIPTION
Based on what was proposed in https://github.com/cert-manager/website/pull/1260