### PR TITLE
Add ejbca-issuer to external issuers list

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -139,6 +139,7 @@ etcd
 EC2
 enj
 ECDSA
+ejbca
 EKS
 ELB
 Ed25519

--- a/content/docs/configuration/external.md
+++ b/content/docs/configuration/external.md
@@ -45,6 +45,7 @@ These external issuers are known to support and honor [approval](https://cert-ma
 - [CFSSL Issuer](https://gerrit.wikimedia.org/r/plugins/gitiles/operations/software/cfssl-issuer/): Request certificates signed by a [CFSSL](https://github.com/cloudflare/cfssl) `multirootca` instance.
 - [ncm-issuer](https://github.com/nokia/ncm-issuer): Requests certificates from the [Nokia](https://www.nokia.com/) [Netguard Certificate Manager](https://www.nokia.com/networks/security-portfolio/netguard/certificate-manager)
 - [tcs-issuer](https://github.com/intel/trusted-certificate-issuer) Requests certificates signed securely using [Intel's SGX technology](https://www.intel.com/content/www/us/en/developer/tools/software-guard-extensions/overview.html).
+- [ejbca-issuer](https://github.com/Keyfactor/ejbca-cert-manager-issuer): Request certificates from [EJBCA](https://www.ejbca.org/).
 
 ## Building New External Issuers
 


### PR DESCRIPTION
Added the EJBCA External Issuer for cert-manager to the list of external cert-manager issuers.