### PR TITLE
Add 1.12.5 release notes

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -618,6 +618,7 @@ v0.6.0.
 v4.4.1
 v1.13.0
 v1.13.
+v1.12.5
 liveness
 apiservices
 arm64

--- a/content/docs/release-notes/release-notes-1.12.md
+++ b/content/docs/release-notes/release-notes-1.12.md
@@ -3,6 +3,21 @@ title: Release 1.12
 description: 'cert-manager release notes: cert-manager 1.12'
 ---
 
+## v1.12.5
+
+v1.12.5 contains a backport for a name collision bug that was found in v1.13.0
+
+### Changes
+
+#### Bug or Regression
+
+- BUGFIX: fix CertificateRequest name collision bug in StableCertificateRequestName feature. (#6359, @jetstack-bot)
+
+#### Other (Cleanup or Flake)
+
+- Updated base images to the latest version. (#6372, @inteon)
+- Upgrade Go from 1.20.7 to 1.20.8. (#6371, @jetstack-bot)
+
 ## v1.12.4
 
 v1.12.4 contains an important security fix that


### PR DESCRIPTION
We just released 1.12.5: https://github.com/cert-manager/cert-manager/releases/tag/v1.12.5