### PR TITLE
Fix sidemenu collapse

### DIFF
--- a/components/docs/Sidebar/Dropdown.jsx
+++ b/components/docs/Sidebar/Dropdown.jsx
@@ -6,9 +6,13 @@ import SidebarLink from './SidebarLink'
 export default function Dropdown({
   routes,
   parentOpen = true,
-  setSidebarCollapsed
+  setParentOpen
 }) {
-  const [open, setOpen] = useState(false)
+  const [open, setSelfOpen] = useState(false)
+  const setOpen = (v) => {
+    if (v) setParentOpen(v)
+    setSelfOpen(v)
+  }
   const iconClasses = classNames({
     'block w-4 h-4 transform text-blue-1': true,
     'rotate-180': open
@@ -41,7 +45,7 @@ export default function Dropdown({
                     routes={r}
                     parentOpen={open}
                     key={`${r.title}-${idx}`}
-                    setSidebarCollapsed={setSidebarCollapsed}
+                    setParentOpen={setOpen}
                   />
               </li>
             )
@@ -52,7 +56,7 @@ export default function Dropdown({
                   href={r.path}
                   caption={r.title}
                   parentOpen={open}
-                  setSidebarCollapsed={setSidebarCollapsed}
+                  setParentOpen={setOpen}
                 />
               </li>
             )

--- a/components/docs/Sidebar/ListItems.jsx
+++ b/components/docs/Sidebar/ListItems.jsx
@@ -1,14 +1,14 @@
 import SidebarLink from './SidebarLink'
 import Dropdown from './Dropdown'
 
-export default function ListItems({ routes, setSidebarCollapsed }) {
+export default function ListItems({ routes, setParentOpen }) {
   if (!routes) return null
   if (routes) {
     return routes.map((r, idx) => {
       if (!r.path) {
         return (
           <li key={`${r.title}-${idx}`}>
-            <Dropdown routes={r} setSidebarCollapsed={setSidebarCollapsed} />
+            <Dropdown routes={r} setParentOpen={setParentOpen} />
           </li>
         )
       } else {
@@ -17,7 +17,7 @@ export default function ListItems({ routes, setSidebarCollapsed }) {
             <SidebarLink
               href={r.path}
               caption={r.title}
-              setSidebarCollapsed={setSidebarCollapsed}
+              setParentOpen={setParentOpen}
             />
           </li>
         )

--- a/components/docs/Sidebar/SidebarLink.jsx
+++ b/components/docs/Sidebar/SidebarLink.jsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from 'react';
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import classNames from 'classnames'
@@ -6,7 +7,7 @@ export default function SidebarLink({
   href,
   caption,
   parentOpen = true,
-  setSidebarCollapsed
+  setParentOpen
 }) {
   const router = useRouter()
   const active = router.asPath === href + '/'
@@ -14,12 +15,16 @@ export default function SidebarLink({
     'flex text-dark-2 hover:text-blue-2 text-base py-2 transition ease-in-out duration-150 no-underline': true,
     'font-medium opacity-60 w-full': active
   })
+
+  useEffect(() => {
+    if (active) setParentOpen(true)
+  }, []);
+
   return (
     (<Link
       href={href}
       className={linkClasses}
-      tabIndex={parentOpen ? 0 : -1}
-      onClick={() => setSidebarCollapsed(true)}>
+      tabIndex={parentOpen ? 0 : -1}>
 
       {caption}
 

--- a/components/docs/Sidebar/index.jsx
+++ b/components/docs/Sidebar/index.jsx
@@ -40,7 +40,7 @@ export default function Sidebar({ router, routes, versions }) {
                       <ul>
                         <ListItems
                           routes={obj.routes}
-                          setSidebarCollapsed={setSidebarCollapsed}
+                          setParentOpen={setSidebarCollapsed}
                         />
                       </ul>
                     </div>
@@ -51,7 +51,7 @@ export default function Sidebar({ router, routes, versions }) {
               <VersionSelect
                 version={version}
                 versions={versions}
-                setSidebarCollapsed={setSidebarCollapsed}
+                setParentOpen={setSidebarCollapsed}
               />
             </div>
           </aside>

--- a/components/docs/VersionSelect.jsx
+++ b/components/docs/VersionSelect.jsx
@@ -13,7 +13,7 @@ function labelFromVersion(version) {
 export default function VersionSelect({
   version,
   versions,
-  setSidebarCollapsed
+  setParentOpen
 }) {
   const [selectedVersion, setSelectedVersion] = useState(version)
 
@@ -35,7 +35,7 @@ export default function VersionSelect({
               <SidebarLink
                 href="docs"
                 caption="latest"
-                setSidebarCollapsed={setSidebarCollapsed}
+                setParentOpen={setParentOpen}
               />
             </div>
           </Listbox.Option>
@@ -45,7 +45,7 @@ export default function VersionSelect({
                 <SidebarLink
                   href={version}
                   caption={labelFromVersion(version)}
-                  setSidebarCollapsed={setSidebarCollapsed}
+                  setParentOpen={setParentOpen}
                 />
               </div>
             </Listbox.Option>
@@ -54,7 +54,7 @@ export default function VersionSelect({
             <SidebarLink
               href="https://release-next--cert-manager-website.netlify.app/docs/"
               caption="next release"
-              setSidebarCollapsed={setSidebarCollapsed}
+              setParentOpen={setParentOpen}
             />
           </div>
         </Listbox.Options>


### PR DESCRIPTION
Fixes missing logic to unfold side menu when going to the link directly.

eg. if you go to https://deploy-preview-1312--cert-manager-website.netlify.app/docs/devops-tips/backup/, you will see that the side menu is expanded.