### PR TITLE
Fix broken approver-policy link (google)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -196,6 +196,7 @@ https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 302!
 
 # Integrating the project pages into the main website
 /docs/usage/istio/ /docs/usage/istio-csr/ 301!
+/docs/usage/approver-policy/ /docs/policy/approval/approver-policy/ 301!
 /docs/projects/istio-csr/ /docs/usage/istio-csr/ 301!
 /docs/projects/csi-driver/ /docs/usage/csi-driver/ 301!
 /docs/projects/csi-driver-spiffe/ /docs/usage/csi-driver-spiffe/ 301!


### PR DESCRIPTION
In https://github.com/cert-manager/website/pull/1309, I forgot to add a redirect statement for the https://cert-manager.io/docs/usage/approver-policy/ url. This URL is still listed on google etc..

https://deploy-preview-1313--cert-manager-website.netlify.app/docs/usage/approver-policy/ now redirects to https://deploy-preview-1313--cert-manager-website.netlify.app/docs/policy/approval/approver-policy/.

This PR fixes this mistake.