### PR TITLE
Mobile Menu: Partially revert #1312

### DIFF
--- a/components/docs/Sidebar/Dropdown.jsx
+++ b/components/docs/Sidebar/Dropdown.jsx
@@ -6,6 +6,7 @@ import SidebarLink from './SidebarLink'
 export default function Dropdown({
   routes,
   parentOpen = true,
+  setSidebarCollapsed,
   setParentOpen
 }) {
   const [open, setSelfOpen] = useState(false)
@@ -45,6 +46,7 @@ export default function Dropdown({
                     routes={r}
                     parentOpen={open}
                     key={`${r.title}-${idx}`}
+                    setSidebarCollapsed={setSidebarCollapsed}
                     setParentOpen={setOpen}
                   />
               </li>
@@ -56,6 +58,7 @@ export default function Dropdown({
                   href={r.path}
                   caption={r.title}
                   parentOpen={open}
+                  setSidebarCollapsed={setSidebarCollapsed}
                   setParentOpen={setOpen}
                 />
               </li>

--- a/components/docs/Sidebar/ListItems.jsx
+++ b/components/docs/Sidebar/ListItems.jsx
@@ -1,14 +1,22 @@
 import SidebarLink from './SidebarLink'
 import Dropdown from './Dropdown'
 
-export default function ListItems({ routes, setParentOpen }) {
+export default function ListItems({
+  routes,
+  setSidebarCollapsed,
+  setParentOpen
+}) {
   if (!routes) return null
   if (routes) {
     return routes.map((r, idx) => {
       if (!r.path) {
         return (
           <li key={`${r.title}-${idx}`}>
-            <Dropdown routes={r} setParentOpen={setParentOpen} />
+            <Dropdown
+              routes={r}
+              setSidebarCollapsed={setSidebarCollapsed}
+              setParentOpen={setParentOpen}
+            />
           </li>
         )
       } else {
@@ -17,6 +25,7 @@ export default function ListItems({ routes, setParentOpen }) {
             <SidebarLink
               href={r.path}
               caption={r.title}
+              setSidebarCollapsed={setSidebarCollapsed}
               setParentOpen={setParentOpen}
             />
           </li>

--- a/components/docs/Sidebar/SidebarLink.jsx
+++ b/components/docs/Sidebar/SidebarLink.jsx
@@ -7,6 +7,7 @@ export default function SidebarLink({
   href,
   caption,
   parentOpen = true,
+  setSidebarCollapsed,
   setParentOpen
 }) {
   const router = useRouter()
@@ -24,7 +25,8 @@ export default function SidebarLink({
     (<Link
       href={href}
       className={linkClasses}
-      tabIndex={parentOpen ? 0 : -1}>
+      tabIndex={parentOpen ? 0 : -1}
+      onClick={() => setSidebarCollapsed(true)}>
 
       {caption}
 

--- a/components/docs/Sidebar/index.jsx
+++ b/components/docs/Sidebar/index.jsx
@@ -40,7 +40,8 @@ export default function Sidebar({ router, routes, versions }) {
                       <ul>
                         <ListItems
                           routes={obj.routes}
-                          setParentOpen={setSidebarCollapsed}
+                          setSidebarCollapsed={setSidebarCollapsed}
+                          setParentOpen={() => {}}
                         />
                       </ul>
                     </div>
@@ -51,7 +52,8 @@ export default function Sidebar({ router, routes, versions }) {
               <VersionSelect
                 version={version}
                 versions={versions}
-                setParentOpen={setSidebarCollapsed}
+                setSidebarCollapsed={setSidebarCollapsed}
+                setParentOpen={() => {}}
               />
             </div>
           </aside>

--- a/components/docs/VersionSelect.jsx
+++ b/components/docs/VersionSelect.jsx
@@ -13,6 +13,7 @@ function labelFromVersion(version) {
 export default function VersionSelect({
   version,
   versions,
+  setSidebarCollapsed,
   setParentOpen
 }) {
   const [selectedVersion, setSelectedVersion] = useState(version)
@@ -35,6 +36,7 @@ export default function VersionSelect({
               <SidebarLink
                 href="docs"
                 caption="latest"
+                setSidebarCollapsed={setSidebarCollapsed}
                 setParentOpen={setParentOpen}
               />
             </div>
@@ -45,6 +47,7 @@ export default function VersionSelect({
                 <SidebarLink
                   href={version}
                   caption={labelFromVersion(version)}
+                  setSidebarCollapsed={setSidebarCollapsed}
                   setParentOpen={setParentOpen}
                 />
               </div>
@@ -54,6 +57,7 @@ export default function VersionSelect({
             <SidebarLink
               href="https://release-next--cert-manager-website.netlify.app/docs/"
               caption="next release"
+              setSidebarCollapsed={setSidebarCollapsed}
               setParentOpen={setParentOpen}
             />
           </div>


### PR DESCRIPTION
In #1312, I fixed the side menu which was not being unfolded when you directly go to a URL.
That PR removed the old "setSidebarCollapsed" logic, because it was not clear what it was used for ( I thought it was broken logic that was meant to unfold the menu when you go to a URL directly ).

Now, I found that the "setSidebarCollapsed" is for the mobile menu, it collapses the menu when you click a link that takes you to a new page.
This PR partially reverts the removal of "setSidebarCollapsed" that was done in #1312, making the sidemenu work on desktop and mobile & also keeps the sidemenu unfolding when you go to a URL directly.