### PR TITLE
Move copy icon to fix mobile view

### DIFF
--- a/styles/docs.scss
+++ b/styles/docs.scss
@@ -11,7 +11,7 @@
   }
 
   .docs-codeblock-btn {
-    @apply text-blue-1 absolute top-3 -right-8;
+    @apply text-blue-1 absolute top-3 right-3;
   }
 
   .docs-tabs-mobile-select {


### PR DESCRIPTION
On mobile the top menu was misaligned:
before:
<img width="278" alt="image" src="https://github.com/cert-manager/website/assets/42113979/4b13d285-e38b-47eb-9cf3-c85bc5e8432c">

after:
<img width="273" alt="image" src="https://github.com/cert-manager/website/assets/42113979/21106b73-5f5c-4176-8f11-f20689f4c6c0">


This is thanks to the copy icons that were off-screen:
before:
<img width="342" alt="image" src="https://github.com/cert-manager/website/assets/42113979/18923f80-0b63-4dce-8994-f450671935f0">

after:
<img width="345" alt="image" src="https://github.com/cert-manager/website/assets/42113979/1c0bbf45-4464-4c2d-8450-32b0be25a08a">

