### PR TITLE
Only include latest version of docs in sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -4,7 +4,7 @@ module.exports = {
   changefreq: 'daily',
   priority: 0.7,
   sitemapSize: 7000,
-  exclude: ['[fallback]', '404', '/500', '*README'],
+  exclude: ['[fallback]', '404', '/500', '*README', '/v*-docs', '/v*-docs/*'],
   robotsTxtOptions: {
     policies: [
       {


### PR DESCRIPTION
The current sitemap contains `/vX.Y-docs/...` pages: https://cert-manager.io/sitemap-0.xml

This PR removes all those docs from the sitemap.
This way, Google will hopefully only show the latest docs.