### PR TITLE
Reorganise 'Certificate resource' page

### DIFF
--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -230,7 +230,7 @@ data:
 ## Issuance triggers
 
 <a id="renewal-reissuance"></a>
-### Renewal-triggered reissuance
+### Reissuance triggered by expiry (renewal)
 
 cert-manager will automatically renew `Certificate`s. It will calculate _when_ to renew a `Certificate` based on the issued X.509 certificate's duration and a 'renewBefore' value which specifies _how long_ before expiry a certificate should be renewed.
 
@@ -242,14 +242,10 @@ Once an X.509 certificate has been issued, cert-manager will calculate the renew
 
 <a id="non-renewal-reissuance"></a>
 <a id="actions-triggering-private-key-rotation"></a>
-### Non-renewal-triggered reissuance
+### Reissuance triggered by user actions
 
-Setting the `rotationPolicy: Always` won't rotate the private key immediately.
-In order to rotate the private key, the certificate objects must be reissued. A
-certificate object is reissued under the following circumstances:
+A certificate object is reissued under the following circumstances:
 
-- when the X.509 certificate is nearing expiry, which is when the Certificate's
-  `status.renewalTime` is reached;
 - when a change is made to one of the following fields on the Certificate's
   spec: `commonName`, `dnsNames`, `ipAddresses`, `uris`, `emailAddresses`,
   `subject`, `isCA`, `usages`, `duration` or `issuerRef`;

--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -249,6 +249,7 @@ A certificate object is reissued under the following circumstances:
 - when a change is made to one of the following fields on the Certificate's
   spec: `commonName`, `dnsNames`, `ipAddresses`, `uris`, `emailAddresses`,
   `subject`, `isCA`, `usages`, `duration` or `issuerRef`;
+  A more detailed explanation can be found on the [FAQ page](../faq/README.md#when-do-certs-get-re-issued).
 - when a reissuance is manually triggered with the following:
   ```sh
   cmctl renew cert-1
@@ -269,10 +270,8 @@ cmctl renew cert-1
 
 </div>
 
-## Issuance behavior
-
 <a id="temporary-certificates-whilst-issuing"></a>
-### Temporary Certificates while Issuing
+## Issuance behavior: Temporary Certificates while Issuing
 
 When requesting certificates [using the ingress-shim](./ingress.md), the
 component `ingress-gce`, if used, requires that a temporary certificate is
@@ -294,7 +293,7 @@ Adding the following annotation on an ingress will automatically set "issue-temp
  ```
 
 <a id="rotation-private-key"></a>
-### Rotation of the private key
+## Issuance behavior: Rotation of the private key
 
 By default, the private key won't be rotated automatically. Using the setting
 `rotationPolicy: Always`, the private key Secret associated with a Certificate

--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -6,10 +6,14 @@ description: 'cert-manager usage: Certificates'
 > **apiVersion:** cert-manager.io/v1  
 > **kind:** Certificate
 
-In cert-manager, the [`Certificate`](../concepts/certificate.md) resource
-represents a human readable definition of a certificate request that is to be
-honored by an issuer which is to be kept up-to-date. This is the usual way that
-you will interact with cert-manager to request signed certificates.
+In cert-manager, the `Certificate` resource represents a human readable definition
+of a certificate request. cert-manager uses this input to generate a private key
+and [`CertificateRequest`](./certificaterequest.md) resource in order to obtain
+a signed certificate from an [`Issuer`](../configuration/README.md) or
+[`ClusterIssuer`](../configuration/README.md). The signed certificate and private
+key are then stored in the specified `Secret` resource. cert-manager will ensure
+that the certificate is [auto-renewed before it expires](#renewal-reissuance) and
+[re-issued if requested](#non-renewal-reissuance).
 
 In order to issue any certificates, you'll need to configure an
 [`Issuer`](../configuration/README.md) or [`ClusterIssuer`](../configuration/README.md)
@@ -121,7 +125,7 @@ A full list of the fields supported on the Certificate resource can be found in
 the [API reference documentation](../reference/api-docs.md#cert-manager.io/v1.CertificateSpec).
 
 <a id="key-usages"></a>
-## X.509 key usages and extended key usages
+### X.509 key usages and extended key usages
 
 cert-manager supports requesting certificates that have a number of [custom key
 usages](https://tools.ietf.org/html/rfc5280#section-4.2.1.3) and [extended key
@@ -138,159 +142,8 @@ certificate does not match the current key usage set.
 An exhaustive list of supported key usages can be found in the [API reference
 documentation](../reference/api-docs.md#cert-manager.io/v1.KeyUsage).
 
-<a id="temporary-certificates-whilst-issuing"></a>
-## Temporary Certificates while Issuing
 
-When requesting certificates [using the ingress-shim](./ingress.md), the
-component `ingress-gce`, if used, requires that a temporary certificate is
-present while waiting for the issuance of a signed certificate when serving. To
-facilitate this, if the following annotation:
-
- ```yaml
- cert-manager.io/issue-temporary-certificate: "true"
- ```
-
-is present on the certificate, a self-signed temporary certificate will be
-present on the `Secret` until it is overwritten once the signed certificate has
-been issued.
-
-Adding the following annotation on an ingress will automatically set "issue-temporary-certificate" on the certificate:
-
- ```yaml
- acme.cert-manager.io/http01-edit-in-place: "true"
- ```
-
-<a id="rotation-private-key"></a>
-## Rotation of the private key
-
-By default, the private key won't be rotated automatically. Using the setting
-`rotationPolicy: Always`, the private key Secret associated with a Certificate
-object can be configured to be rotated as soon as an action triggers the
-reissuance of the Certificate object (see
-[Actions that will trigger a rotation of the private key](#actions-triggering-private-key-rotation) below).
-
-With `rotationPolicy: Always`, cert-manager waits until the Certificate
-object is correctly signed before overwriting the `tls.key` file in the
-Secret.
-
-With this setting, you can expect **no downtime** if your application can detect
-changes to the mounted `tls.crt` and `tls.key` and reload them gracefully or
-automatically restart.
-
-If your application only loads the private key and signed certificate once
-at start up, the new certificate won't immediately be served by your
-application, and you will want to either manually restart your pod with
-`kubectl rollout restart`, or automate the action by running
-[wave](https://github.com/wave-k8s/wave). Wave is a Secret controller that
-makes sure deployments get restarted whenever a mounted Secret changes.
-
-<div className="alert">
-
-Re-use of private keys
-
-Some issuers, like the built-in [Venafi
-issuer](../configuration/venafi.md), may disallow re-using private keys.
-If this is the case, you must explicitly configure the `rotationPolicy:
-Always` setting for each of your Certificate objects accordingly.
-
-</div>
-
-In the following example, the certificate has been set with
-`rotationPolicy: Always`:
-
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-spec:
-  secretName: my-cert-tls
-  privateKey:
-    rotationPolicy: Always # 🔰 Here.
-```
-
-<a id="actions-triggering-private-key-rotation"></a>
-### Actions that will trigger a rotation of the private key
-
-Setting the `rotationPolicy: Always` won't rotate the private key immediately.
-In order to rotate the private key, the certificate objects must be reissued. A
-certificate object is reissued under the following circumstances:
-
-- when the X.509 certificate is nearing expiry, which is when the Certificate's
-  `status.renewalTime` is reached;
-- when a change is made to one of the following fields on the Certificate's
-  spec: `commonName`, `dnsNames`, `ipAddresses`, `uris`, `emailAddresses`,
-  `subject`, `isCA`, `usages`, `duration` or `issuerRef`;
-- when a reissuance is manually triggered with the following:
-  ```sh
-  cmctl renew cert-1
-  ```
-  Note that the above command requires [cmctl](../reference/cmctl.md#renew).
-
-<div className="warning">
-
-**❌** Deleting the Secret resource associated with a Certificate resource is
-**not a recommended solution** for manually rotating the private key. The
-recommended way to manually rotate the private key is to trigger the reissuance
-of the Certificate resource with the following command (requires
-[`cmctl`](../reference/cmctl.md#renew)):
-
-```sh
-cmctl renew cert-1
-```
-
-</div>
-
-### The `rotationPolicy` setting
-
-The possible values for `rotationPolicy` are:
-
-| Value                  | Description                                                   |
-| ---------------------- | ------------------------------------------------------------- |
-| `Never` (default)      | cert-manager reuses the existing private key on each issuance |
-| `Always` (recommended) | cert-manager regenerates a new private key on each issuance   |
-
-With `rotationPolicy: Never`, a private key is only generated if one does not
-already exist in the target Secret resource (using the `tls.key` key). All
-further issuances will re-use this private key. This is the default in order to
-maintain compatibility with previous releases.
-
-With `rotationPolicy: Always`, a new private key will be generated each time an
-action triggers the reissuance of the certificate object (see [Actions that will
-trigger a rotation of the private key](#actions-triggering-private-key-rotation)
-above). Note that if the private key secret already exists when creating the
-certificate object, the existing private key will not be used, since the
-rotation mechanism also includes the initial issuance.
-
-<div className="info">
-
-👉 We recommend that you configure `rotationPolicy: Always` on your Certificate
-resources. Rotating both the certificate and the private key simultaneously
-prevents the risk of issuing a certificate with an exposed private key. Another
-benefit to renewing the private key regularly is to let you be confident that
-the private key rotation can be done in case of emergency. More generally, it is
-a good practice to be rotating the keys as often as possible, reducing the risk
-associated with compromised keys.
-
-</div>
-
-## Cleaning up Secrets when Certificates are deleted
-
-By default, cert-manager does not delete the `Secret` resource containing the signed certificate when the corresponding `Certificate` resource is deleted.
-This means that deleting a `Certificate` won't take down any services that are currently relying on that certificate, but the certificate will no longer be renewed.
-The `Secret` needs to be manually deleted if it is no longer needed.
-
-If you would prefer the `Secret` to be deleted automatically when the `Certificate` is deleted, you need to configure your installation to pass the `--enable-certificate-owner-ref` flag to the controller.
-
-## Renewal
-
-cert-manager will automatically renew `Certificate`s. It will calculate _when_ to renew a `Certificate` based on the issued X.509 certificate's duration and a 'renewBefore' value which specifies _how long_ before expiry a certificate should be renewed.
-
-`spec.duration` and `spec.renewBefore` fields on a `Certificate` can be used to specify an X.509 certificate's duration and a 'renewBefore' value. Default value for `spec.duration` is 90 days. Some issuers might be configured to only issue certificates with a set duration, so the actual duration may be different.
-Minimum value for `spec.duration` is 1 hour and minimum value for `spec.renewBefore` is 5 minutes.
-It is also required that `spec.duration` > `spec.renewBefore`.
-
-Once an X.509 certificate has been issued, cert-manager will calculate the renewal time for the `Certificate`. By default this will be 2/3 through the X.509 certificate's duration. If `spec.renewBefore` has been set, it will be `spec.renewBefore` amount of time before expiry. cert-manager will set `Certificate`'s `status.RenewalTime` to the time when the renewal will be attempted.
-
-## Additional Certificate Output Formats
+### Additional Certificate Output Formats
 
 <div className="warning">
 
@@ -373,6 +226,163 @@ data:
   key.der: <DER binary format of private key>
   ...
 ```
+
+## Issuance triggers
+
+<a id="renewal-reissuance"></a>
+### Renewal-triggered reissuance
+
+cert-manager will automatically renew `Certificate`s. It will calculate _when_ to renew a `Certificate` based on the issued X.509 certificate's duration and a 'renewBefore' value which specifies _how long_ before expiry a certificate should be renewed.
+
+`spec.duration` and `spec.renewBefore` fields on a `Certificate` can be used to specify an X.509 certificate's duration and a 'renewBefore' value. Default value for `spec.duration` is 90 days. Some issuers might be configured to only issue certificates with a set duration, so the actual duration may be different.
+Minimum value for `spec.duration` is 1 hour and minimum value for `spec.renewBefore` is 5 minutes.
+It is also required that `spec.duration` > `spec.renewBefore`.
+
+Once an X.509 certificate has been issued, cert-manager will calculate the renewal time for the `Certificate`. By default this will be 2/3 through the X.509 certificate's duration. If `spec.renewBefore` has been set, it will be `spec.renewBefore` amount of time before expiry. cert-manager will set `Certificate`'s `status.RenewalTime` to the time when the renewal will be attempted.
+
+<a id="non-renewal-reissuance"></a>
+<a id="actions-triggering-private-key-rotation"></a>
+### Non-renewal-triggered reissuance
+
+Setting the `rotationPolicy: Always` won't rotate the private key immediately.
+In order to rotate the private key, the certificate objects must be reissued. A
+certificate object is reissued under the following circumstances:
+
+- when the X.509 certificate is nearing expiry, which is when the Certificate's
+  `status.renewalTime` is reached;
+- when a change is made to one of the following fields on the Certificate's
+  spec: `commonName`, `dnsNames`, `ipAddresses`, `uris`, `emailAddresses`,
+  `subject`, `isCA`, `usages`, `duration` or `issuerRef`;
+- when a reissuance is manually triggered with the following:
+  ```sh
+  cmctl renew cert-1
+  ```
+  Note that the above command requires [cmctl](../reference/cmctl.md#renew).
+
+<div className="warning">
+
+**❌** Deleting the Secret resource associated with a Certificate resource is
+**not a recommended solution** for manually rotating the private key. The
+recommended way to manually rotate the private key is to trigger the reissuance
+of the Certificate resource with the following command (requires
+[`cmctl`](../reference/cmctl.md#renew)):
+
+```sh
+cmctl renew cert-1
+```
+
+</div>
+
+## Issuance behavior
+
+<a id="temporary-certificates-whilst-issuing"></a>
+### Temporary Certificates while Issuing
+
+When requesting certificates [using the ingress-shim](./ingress.md), the
+component `ingress-gce`, if used, requires that a temporary certificate is
+present while waiting for the issuance of a signed certificate when serving. To
+facilitate this, if the following annotation:
+
+ ```yaml
+ cert-manager.io/issue-temporary-certificate: "true"
+ ```
+
+is present on the certificate, a self-signed temporary certificate will be
+present on the `Secret` until it is overwritten once the signed certificate has
+been issued.
+
+Adding the following annotation on an ingress will automatically set "issue-temporary-certificate" on the certificate:
+
+ ```yaml
+ acme.cert-manager.io/http01-edit-in-place: "true"
+ ```
+
+<a id="rotation-private-key"></a>
+### Rotation of the private key
+
+By default, the private key won't be rotated automatically. Using the setting
+`rotationPolicy: Always`, the private key Secret associated with a Certificate
+object can be configured to be rotated as soon as an the Certificate is reissued (see
+[Issuance triggers](#issuance-triggers)).
+
+With `rotationPolicy: Always`, cert-manager waits until the Certificate
+object is correctly signed before overwriting the `tls.key` file in the
+Secret.
+
+With this setting, you can expect **no downtime** if your application can detect
+changes to the mounted `tls.crt` and `tls.key` and reload them gracefully or
+automatically restart.
+
+If your application only loads the private key and signed certificate once
+at start up, the new certificate won't immediately be served by your
+application, and you will want to either manually restart your pod with
+`kubectl rollout restart`, or automate the action by running
+[wave](https://github.com/wave-k8s/wave). Wave is a Secret controller that
+makes sure deployments get restarted whenever a mounted Secret changes.
+
+<div className="alert">
+
+Re-use of private keys
+
+Some issuers, like the built-in [Venafi
+issuer](../configuration/venafi.md), may disallow re-using private keys.
+If this is the case, you must explicitly configure the `rotationPolicy:
+Always` setting for each of your Certificate objects accordingly.
+
+</div>
+
+In the following example, the certificate has been set with
+`rotationPolicy: Always`:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+spec:
+  secretName: my-cert-tls
+  privateKey:
+    rotationPolicy: Always # 🔰 Here.
+```
+
+#### The `rotationPolicy` setting
+
+The possible values for `rotationPolicy` are:
+
+| Value                  | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `Never` (default)      | cert-manager reuses the existing private key on each issuance |
+| `Always` (recommended) | cert-manager regenerates a new private key on each issuance   |
+
+With `rotationPolicy: Never`, a private key is only generated if one does not
+already exist in the target Secret resource (using the `tls.key` key). All
+further issuances will re-use this private key. This is the default in order to
+maintain compatibility with previous releases.
+
+With `rotationPolicy: Always`, a new private key will be generated each time an
+action triggers the reissuance of the certificate object (see [Actions that will
+trigger a rotation of the private key](#actions-triggering-private-key-rotation)
+above). Note that if the private key secret already exists when creating the
+certificate object, the existing private key will not be used, since the
+rotation mechanism also includes the initial issuance.
+
+<div className="info">
+
+👉 We recommend that you configure `rotationPolicy: Always` on your Certificate
+resources. Rotating both the certificate and the private key simultaneously
+prevents the risk of issuing a certificate with an exposed private key. Another
+benefit to renewing the private key regularly is to let you be confident that
+the private key rotation can be done in case of emergency. More generally, it is
+a good practice to be rotating the keys as often as possible, reducing the risk
+associated with compromised keys.
+
+</div>
+
+## Cleaning up Secrets when Certificates are deleted
+
+By default, cert-manager does not delete the `Secret` resource containing the signed certificate when the corresponding `Certificate` resource is deleted.
+This means that deleting a `Certificate` won't take down any services that are currently relying on that certificate, but the certificate will no longer be renewed.
+The `Secret` needs to be manually deleted if it is no longer needed.
+
+If you would prefer the `Secret` to be deleted automatically when the `Certificate` is deleted, you need to configure your installation to pass the `--enable-certificate-owner-ref` flag to the controller.
 
 ## Inner workings diagram for developers
 


### PR DESCRIPTION
This PR improves the structure of the 'Certificate resource' page.

One notable difference is the https://deploy-preview-1327--cert-manager-website.netlify.app/docs/usage/certificate/#reissuance-triggered-by-expiry-renewal section (that was actually talking about the different ways to trigger reissuance) is now moved and renamed to a "Reissuance triggered by user actions
" https://deploy-preview-1327--cert-manager-website.netlify.app/docs/usage/certificate/#reissuance-triggered-by-user-actions section in the new structure.

Other changes: grouped all the sections about the different Certificate properties in the "Creating Certificate Resources" section.

Before:
- Certificate resource
- Creating Certificate Resources
- X.509 key usages and extended key usages
- Temporary Certificates while Issuing
- Rotation of the private key
    - Actions that will trigger a rotation of the private key
- Cleaning up Secrets when Certificates are deleted
- Renewal
- Additional Certificate Output Formats

After:
- Creating Certificate Resources
    - X.509 key usages and extended key usages
    - Additional Certificate Output Formats
- Issuance triggers
    - Reissuance triggered by expiry (renewal)
    - Reissuance triggered by user actions
- Issuance behavior: Temporary Certificates while Issuing
- Issuance behavior: Rotation of the private key
- Cleaning up Secrets when Certificates are deleted

| Before | After |
|--------|-------|
| ![cert-manager io_](https://github.com/cert-manager/website/assets/42113979/84d5f96d-aae5-4794-a77f-922d77c851fb) | ![deploy-preview-1327--cert-manager-website netlify app_docs_usage_certificate](https://github.com/cert-manager/website/assets/42113979/64664b7d-9329-477d-821a-cae596479db9) |
