### PR TITLE
Add redirect rules for broken links

### DIFF
--- a/content/docs/installation/upgrade.md
+++ b/content/docs/installation/upgrade.md
@@ -3,9 +3,10 @@ title: Upgrading cert-manager
 description: 'cert-manager installation: Upgrading cert-manager overview'
 ---
 
-This section contains information on upgrading cert-manager.
-It also contains documents detailing breaking changes between cert-manager
-versions, and information on things to look out for when upgrading.
+In the [releases section](../releases/README.md) of the documentation, you can find the release notes
+and upgrade instructions for each release of cert-manager. It also contains
+information on the breaking changes between each release and things to look out
+for when upgrading.
 
 > Note: Before performing upgrades of cert-manager, it is advised to take a
 > backup of all your cert-manager resources just in case an issue occurs whilst

--- a/public/_redirects
+++ b/public/_redirects
@@ -212,9 +212,12 @@ https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 302!
 /docs/installation/api-compatibility/ /docs/contributing/api-compatibility/ 301!
 
 # Moved the "upgrading" and "release-notes" pages to the release section
+/docs/installation/upgrading/ /docs/installation/upgrade/ 301!
 /docs/installation/upgrading/* /docs/releases/upgrading/:splat 301!
 /docs/release-notes/* /docs/releases/release-notes/:splat 301!
 /docs/installation/supported-releases/ /docs/releases/ 301!
+/docs/releases/upgrading/ /docs/releases/ 301!
+/docs/releases/release-notes/ /docs/releases/ 301!
 
 # Moved the concept pages into the main website
 /docs/concepts/certificaterequest/ /docs/usage/certificaterequest/ 301!


### PR DESCRIPTION
This PR adds the following redirects:
- /docs/installation/upgrading/ to /docs/installation/upgrade/
- /docs/releases/upgrading/ to /docs/releases/
- /docs/releases/release-notes/ to /docs/releases/

Example: the link <https://deploy-preview-1332--cert-manager-website.netlify.app/docs/installation/upgrading/> now redirects to <https://deploy-preview-1332--cert-manager-website.netlify.app/docs/installation/upgrade/>.