### PR TITLE
Fix broken link

### DIFF
--- a/content/docs/usage/README.md
+++ b/content/docs/usage/README.md
@@ -20,7 +20,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.0-docs/usage/README.md
+++ b/content/v1.0-docs/usage/README.md
@@ -19,7 +19,7 @@ cases and methods for requesting certificates through cert-manager:
   Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.1-docs/usage/README.md
+++ b/content/v1.1-docs/usage/README.md
@@ -19,7 +19,7 @@ cases and methods for requesting certificates through cert-manager:
   Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.10-docs/usage/README.md
+++ b/content/v1.10-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.11-docs/usage/README.md
+++ b/content/v1.11-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.12-docs/usage/README.md
+++ b/content/v1.12-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.13-docs/usage/README.md
+++ b/content/v1.13-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.2-docs/usage/README.md
+++ b/content/v1.2-docs/usage/README.md
@@ -19,7 +19,7 @@ cases and methods for requesting certificates through cert-manager:
   Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.3-docs/usage/README.md
+++ b/content/v1.3-docs/usage/README.md
@@ -19,7 +19,7 @@ cases and methods for requesting certificates through cert-manager:
   Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.4-docs/usage/README.md
+++ b/content/v1.4-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.5-docs/usage/README.md
+++ b/content/v1.5-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.6-docs/usage/README.md
+++ b/content/v1.6-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.7-docs/usage/README.md
+++ b/content/v1.7-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.8-docs/usage/README.md
+++ b/content/v1.8-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of

--- a/content/v1.9-docs/usage/README.md
+++ b/content/v1.9-docs/usage/README.md
@@ -16,7 +16,7 @@ There are several use cases and methods for requesting certificates through cert
 - [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
-- [Securing Knative](https://knative.dev/docs/serving/using-auto-tls/): Secure
+- [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure
   your Knative services with trusted HTTPS certificates.
 - [Enable mTLS on Pods with CSI](./csi.md): Using the cert-manager CSI
   driver to provide unique keys and certificates that share the lifecycle of


### PR DESCRIPTION
Fix broken link due to the [new structure](https://github.com/knative/docs/commit/6d938133f7810d1ae588bee103a488ecbf16c2a8) of the [Knative docs website](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/) 