### PR TITLE
Link to the official Flux example repo and remove unnecessary --crds flags from example

### DIFF
--- a/content/docs/installation/continuous-deployment-and-gitops.md
+++ b/content/docs/installation/continuous-deployment-and-gitops.md
@@ -71,7 +71,6 @@ flux create helmrelease cert-manager \
   --release-name cert-manager \
   --target-namespace cert-manager \
   --create-target-namespace \
-  --crds CreateReplace \
   --values values.yaml \
   --chart-version 1.12.x
 ```
@@ -88,7 +87,6 @@ flux create helmrelease cert-manager \
   --release-name cert-manager \
   --target-namespace cert-manager \
   --create-target-namespace \
-  --crds CreateReplace \
   --values values.yaml \
   --chart-version 1.13.x
 ```

--- a/content/docs/installation/continuous-deployment-and-gitops.md
+++ b/content/docs/installation/continuous-deployment-and-gitops.md
@@ -28,6 +28,12 @@ configured with your desired cert-manager chart values and release.
 Here is an example which installs the latest patch version of the cert-manager 1.12 release,
 and then upgrades to the latest patch version of the 1.13 release.
 
+> ⚠️ This is a simple example which may not be suitable for production use.
+> You should also refer to the [official Flux example repo](https://github.com/fluxcd/flux2-kustomize-helm-example),
+> where cert-manager is now fully integrated.
+> It shows how to deploy ClusterIssuer resources in the right order,
+> after cert-manager CRDs and controller have been installed.
+
 ### Prerequisites
 
 You'll need the [`flux` CLI](https://fluxcd.io/flux/cmd/)


### PR DESCRIPTION
**Preview**: https://deploy-preview-1343--cert-manager-website.netlify.app/docs/installation/continuous-deployment-and-gitops/#using-the-flux-helm-controller

1. Linked to official Flux example repo

   In https://github.com/fluxcd/flux2/discussions/3009#discussioncomment-7508833 @stefanprodan wrote:
   > cert-manager is now fully integrated in the official Flux example repo, including deploying Cluster Issuers in the right 
   order, after cert-manager CRDs and controller have been installed.
   > it would great if you could add a link to https://github.com/fluxcd/flux2-kustomize-helm- 
  example/blob/main/infrastructure/controllers/cert-manager.yaml for a GitOps example

2. Removed `--crds CreateReplace` because cert-manager CRDs do not use the Helm `crds/` directory.

   In https://github.com/fluxcd/flux2/discussions/3009#discussioncomment-7510213 @stefanprodan wrote:
   > CreateReplace will not do anything if there is no crds dir inside the chart.


