### PR TITLE
Add/update docs for new trust-manager features

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -214,6 +214,7 @@ OpenWRT
 OperatorHub
 OperatorHub.io
 PEM
+PKCS12-formatted
 PKCS#12
 PKCS#8
 Pomerium
@@ -402,6 +403,7 @@ ndegory
 oauth2
 onwards
 openshift-supported-versions
+plaintext
 powershell
 pre
 preemptible
@@ -458,6 +460,8 @@ upstream
 userinfo
 vhosakot
 v0.5.0
+v0.7.0
+v0.7.0.
 v0.16
 v0.23.1
 v1

--- a/content/docs/trust/trust-manager/api-reference.md
+++ b/content/docs/trust/trust-manager/api-reference.md
@@ -246,6 +246,13 @@ Target is the target location in all namespaces to sync source data to.
           NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b><a href="#bundlespectargetsecret">secret</a></b></td>
+        <td>object</td>
+        <td>
+          Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -271,6 +278,13 @@ AdditionalFormats specifies any additional formats to write to the target
           JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b><a href="#bundlespectargetadditionalformatspkcs12">pkcs12</a></b></td>
+        <td>object</td>
+        <td>
+          PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -279,6 +293,31 @@ AdditionalFormats specifies any additional formats to write to the target
 
 
 JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          Key is the key of the entry in the object's `data` field to be used.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.spec.target.additionalFormats.pkcs12`
+
+
+PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
 
 <table>
     <thead>
@@ -346,6 +385,31 @@ NamespaceSelector will, if set, only sync the target resource in Namespaces whic
           MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.<br/>
         </td>
         <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.spec.target.secret`
+
+
+Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          Key is the key of the entry in the object's `data` field to be used.<br/>
+        </td>
+        <td>true</td>
       </tr></tbody>
 </table>
 
@@ -488,6 +552,13 @@ Target is the current Target that the Bundle is attempting or has completed sync
           NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b><a href="#bundlestatustargetsecret">secret</a></b></td>
+        <td>object</td>
+        <td>
+          Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -513,6 +584,13 @@ AdditionalFormats specifies any additional formats to write to the target
           JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b><a href="#bundlestatustargetadditionalformatspkcs12">pkcs12</a></b></td>
+        <td>object</td>
+        <td>
+          PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -521,6 +599,31 @@ AdditionalFormats specifies any additional formats to write to the target
 
 
 JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          Key is the key of the entry in the object's `data` field to be used.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.status.target.additionalFormats.pkcs12`
+
+
+PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
 
 <table>
     <thead>
@@ -588,5 +691,30 @@ NamespaceSelector will, if set, only sync the target resource in Namespaces whic
           MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.<br/>
         </td>
         <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.status.target.secret`
+
+
+Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          Key is the key of the entry in the object's `data` field to be used.<br/>
+        </td>
+        <td>true</td>
       </tr></tbody>
 </table>

--- a/scripts/gendocs/generate-trust-manager
+++ b/scripts/gendocs/generate-trust-manager
@@ -59,6 +59,6 @@ gendocs() {
 echo "+++ Cloning trust-manager repository..."
 git clone "https://github.com/cert-manager/trust-manager.git" "$tmpdir"
 
-checkout "v0.6.0"
+checkout "v0.7.0"
 
 gendocs "$REPO_ROOT/content/docs/trust/trust-manager/api-reference.md"


### PR DESCRIPTION
I noticed that trust-manager docs are not updated for new features available since trust-manager v0.7.0:

- PKCS#12 as additional target format
- `Secret` targets

~It also seems like the trust-manager API docs are outdated. Do we have CI to update it, or is it done manually? If we don't have CI, it would probably make sense to include an update in this PR?~ Update: API docs for trust-manager is now updated to v0.7.0.

\cc @inteon @SgtCoDFish 