### PR TITLE
Verify Mastodon social media link

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -47,7 +47,7 @@ export default function Header() {
           target="_blank"
           icon="mastodon"
           iconWClass="w-4"
-	  rel="me"
+           rel="me"
           className="px-3 py-1 text-11px mx-4 "
         />
       </div>

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -47,6 +47,7 @@ export default function Header() {
           target="_blank"
           icon="mastodon"
           iconWClass="w-4"
+	  rel="me"
           className="px-3 py-1 text-11px mx-4 "
         />
       </div>


### PR DESCRIPTION
Adding the rel="me" attribute to a Mastodon link causes Mastodon to treat the link as 'verified', and will display a green check next to the website link in the cert-manager Mastodon profile. See https://docs.joinmastodon.org/user/profile/#verification for more details on this feature.