### PR TITLE
Release notes and updates for v1.13.3

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -243,6 +243,7 @@ SecretTemplate
 ServerSideApply
 SelfSigned
 SgtCoDFish
+Slowloris
 Smallstep
 SubjectAccessReview
 SVIDs
@@ -628,6 +629,7 @@ v1.13.0
 v1.13.0.
 v1.13.1
 v1.13.2
+v1.13.3
 v1.13.
 v1.12.5
 v1.12.6

--- a/content/docs/cli/controller.md
+++ b/content/docs/cli/controller.md
@@ -14,7 +14,7 @@ Usage:
   controller [flags]
 
 Flags:
-      --acme-http01-solver-image string                     The docker image to use to solve ACME HTTP01 challenges. You most likely will not need to change this parameter unless you are testing a new feature or developing cert-manager. (default "quay.io/jetstack/cert-manager-acmesolver:v1.13.2")
+      --acme-http01-solver-image string                     The docker image to use to solve ACME HTTP01 challenges. You most likely will not need to change this parameter unless you are testing a new feature or developing cert-manager. (default "quay.io/jetstack/cert-manager-acmesolver:v1.13.3")
       --acme-http01-solver-nameservers strings              A list of comma separated dns server endpoints used for ACME HTTP01 check requests. This should be a list containing host and port, for example 8.8.8.8:53,8.8.4.4:53
       --acme-http01-solver-resource-limits-cpu string       Defines the resource limits CPU size when spawning new ACME HTTP01 challenge solver pods. (default "100m")
       --acme-http01-solver-resource-limits-memory string    Defines the resource limits Memory size when spawning new ACME HTTP01 challenge solver pods. (default "64Mi")

--- a/content/docs/installation/README.md
+++ b/content/docs/installation/README.md
@@ -12,7 +12,7 @@ Learn about the various ways you can install cert-manager and how to choose betw
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
 ```
 
 📖 Read more about [installing cert-manager using kubectl apply and static manifests](./kubectl.md).

--- a/content/docs/installation/code-signing.md
+++ b/content/docs/installation/code-signing.md
@@ -22,7 +22,7 @@ The simplest way to verify signatures is to download the public key and then pas
 
 ```console
 curl -sSOL https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
-IMAGE_TAG=v1.13.2  # change as needed
+IMAGE_TAG=v1.13.3  # change as needed
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-ctl:$IMAGE_TAG

--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -47,7 +47,7 @@ section below for details on each method.
 > Recommended for production installations
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -70,7 +70,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.2 \
+  --version v1.13.3 \
   # --set installCRDs=true
 ```
 
@@ -83,7 +83,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.2 \
+  --version v1.13.3 \
   # --set installCRDs=true
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
@@ -114,7 +114,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.13.2
+    version: v1.13.3
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -148,7 +148,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.2 \
+  --version v1.13.3 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/docs/installation/kubectl.md
+++ b/content/docs/installation/kubectl.md
@@ -21,7 +21,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/docs/installation/operator-lifecycle-manager.md
+++ b/content/docs/installation/operator-lifecycle-manager.md
@@ -218,7 +218,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.13.2 \
+kubectl patch csv cert-manager.v1.13.3 \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```

--- a/content/docs/releases/release-notes/release-notes-1.13.md
+++ b/content/docs/releases/release-notes/release-notes-1.13.md
@@ -3,6 +3,70 @@ title: Release 1.13
 description: 'cert-manager release notes: cert-manager 1.13'
 ---
 
+## v1.13.3
+
+This patch release contains fixes for the following security vulnerabilities in the cert-manager-controller:
+- [`GO-2023-2334`](https://pkg.go.dev/vuln/GO-2023-2334): Decryption of malicious PBES2 JWE objects can consume unbounded system resources.
+
+If you use
+[ArtifactHub Security report](https://artifacthub.io/packages/helm/cert-manager/cert-manager/1.13.2?modal=security-report) or
+[trivy](https://trivy.dev/),
+this patch will also silence the following warning
+about a vulnerability in code which is imported but **not used** by the cert-manager-controller:
+- [`CVE-2023-47108`](https://access.redhat.com/security/cve/CVE-2023-47108): DoS vulnerability in `otelgrpc` due to unbound cardinality metrics.
+
+An ongoing security audit of cert-manager suggested some changes to the webhook code to mitigate DoS attacks,
+and these are included in this patch release.
+
+### Changes
+
+#### Bug or Regression
+
+- The webhook server now returns HTTP error 413 (Content Too Large) for requests with body size `>= 3MiB`.
+  This is to mitigate DoS attacks that attempt to crash the webhook process by sending large requests that exceed the available memory.
+  ([#6507](https://github.com/cert-manager/cert-manager/pull/6507), [@inteon](https://github.com/inteon))
+- The webhook server now returns HTTP error 400 (Bad Request) if the request contains an empty body.
+  ([#6507](https://github.com/cert-manager/cert-manager/pull/6507), [@inteon](https://github.com/inteon))
+- The webhook server now returns HTTP error 500 (Internal Server Error) rather than crashing, if the code panics while handling a request.
+  ([#6507](https://github.com/cert-manager/cert-manager/pull/6507), [@inteon](https://github.com/inteon))
+- Mitigate potential "Slowloris" attacks by setting `ReadHeaderTimeout` in all `http.Server` instances.
+  ([#6538](https://github.com/cert-manager/cert-manager/pull/6538), [@wallrj](https://github.com/wallrj))
+- Upgrade Go modules: `otel`, `docker`, and `jose` to fix CVE alerts. See
+  https://github.com/advisories/GHSA-8pgv-569h-w5rw,
+  https://github.com/advisories/GHSA-jq35-85cj-fj4p, and
+  https://github.com/advisories/GHSA-2c7c-3mj9-8fqh.
+  ([#6514](https://github.com/cert-manager/cert-manager/pull/6514), [@inteon](https://github.com/inteon))
+
+### Dependencies
+
+#### Added
+_Nothing has changed._
+
+#### Changed
+- `cloud.google.com/go/firestore`: `v1.11.0 → v1.12.0`
+- `cloud.google.com/go`: `v0.110.6 → v0.110.7`
+- `github.com/felixge/httpsnoop`: [`v1.0.3 → v1.0.4`](https://github.com/felixge/httpsnoop/compare/v1.0.3...v1.0.4)
+- `github.com/go-jose/go-jose/v3`: [`v3.0.0 → v3.0.1`](https://github.com/go-jose/go-jose/v3/compare/v3.0.0...v3.0.1)
+- `github.com/go-logr/logr`: [`v1.2.4 → v1.3.0`](https://github.com/go-logr/logr/compare/v1.2.4...v1.3.0)
+- `github.com/golang/glog`: [`v1.1.0 → v1.1.2`](https://github.com/golang/glog/compare/v1.1.0...v1.1.2)
+- `github.com/google/go-cmp`: [`v0.5.9 → v0.6.0`](https://github.com/google/go-cmp/compare/v0.5.9...v0.6.0)
+- `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`: `v0.45.0 → v0.46.0`
+- `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`: `v0.44.0 → v0.46.0`
+- `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`: `v1.19.0 → v1.20.0`
+- `go.opentelemetry.io/otel/exporters/otlp/otlptrace`: `v1.19.0 → v1.20.0`
+- `go.opentelemetry.io/otel/metric`: `v1.19.0 → v1.20.0`
+- `go.opentelemetry.io/otel/sdk`: `v1.19.0 → v1.20.0`
+- `go.opentelemetry.io/otel/trace`: `v1.19.0 → v1.20.0`
+- `go.opentelemetry.io/otel`: `v1.19.0 → v1.20.0`
+- `go.uber.org/goleak`: `v1.2.1 → v1.3.0`
+- `golang.org/x/sys`: `v0.13.0 → v0.14.0`
+- `google.golang.org/genproto/googleapis/api`: `f966b18 → b8732ec`
+- `google.golang.org/genproto`: `f966b18 → b8732ec`
+- `google.golang.org/grpc`: `v1.58.3 → v1.59.0`
+
+#### Removed
+_Nothing has changed._
+
 ## v1.13.2
 
 v1.13.2 fixes some CVE alerts and contains fixes for:
@@ -72,29 +136,29 @@ plan to promote these feature gates to GA in the future, which will mean that th
 
 ### Community
 
-Welcome to these new cert-manager members (more info - https://github.com/cert-manager/cert-manager/pull/6260):  
-@jsoref  
-@FlorianLiebhart  
-@hawksight  
-@erikgb  
+Welcome to these new cert-manager members (more info - https://github.com/cert-manager/cert-manager/pull/6260):
+@jsoref
+@FlorianLiebhart
+@hawksight
+@erikgb
 
-Thanks again to all open-source contributors with commits in this release, including:  
-@AcidLeroy  
-@FlorianLiebhart  
-@lucacome  
-@cypres  
-@erikgb  
-@ubergesundheit  
-@jkroepke  
-@jsoref  
-@gdvalle  
-@rouke-broersma  
-@schrodit  
-@zhangzhiqiangcs  
-@arukiidou  
-@hawksight  
-@Richardds  
-@kahirokunn  
+Thanks again to all open-source contributors with commits in this release, including:
+@AcidLeroy
+@FlorianLiebhart
+@lucacome
+@cypres
+@erikgb
+@ubergesundheit
+@jkroepke
+@jsoref
+@gdvalle
+@rouke-broersma
+@schrodit
+@zhangzhiqiangcs
+@arukiidou
+@hawksight
+@Richardds
+@kahirokunn
 
 Thanks also to the following cert-manager maintainers for their contributions during this release:
 @SgtCoDFish

--- a/content/v1.13-docs/installation/README.md
+++ b/content/v1.13-docs/installation/README.md
@@ -12,7 +12,7 @@ Learn about the various ways you can install cert-manager and how to choose betw
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
 ```
 
 📖 Read more about [installing cert-manager using kubectl apply and static manifests](./kubectl.md).

--- a/content/v1.13-docs/installation/code-signing.md
+++ b/content/v1.13-docs/installation/code-signing.md
@@ -22,7 +22,7 @@ The simplest way to verify signatures is to download the public key and then pas
 
 ```console
 curl -sSOL https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
-IMAGE_TAG=v1.13.2  # change as needed
+IMAGE_TAG=v1.13.3  # change as needed
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-ctl:$IMAGE_TAG

--- a/content/v1.13-docs/installation/helm.md
+++ b/content/v1.13-docs/installation/helm.md
@@ -47,7 +47,7 @@ section below for details on each method.
 > Recommended for production installations
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -70,7 +70,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.2 \
+  --version v1.13.3 \
   # --set installCRDs=true
 ```
 
@@ -83,7 +83,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.2 \
+  --version v1.13.3 \
   # --set installCRDs=true
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
@@ -114,7 +114,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.13.2
+    version: v1.13.3
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -148,7 +148,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.2 \
+  --version v1.13.3 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml
@@ -247,7 +247,7 @@ of their approach [here](https://helm.sh/docs/chart_best_practices/custom_resour
 
 cert-manager actually bundles the CRDs along with the other templates
 in the Helm chart. This means that Helm manages these resources so they are
-upgraded with your cert-manager release when you use 
+upgraded with your cert-manager release when you use
 `installCRDs: true` in your values file or CLI command. This does also mean
 that if you uninstall the release, the CRDs will also be uninstalled. If that
 happens then you will loose all instances of those CRDs, e.g. all `Certificate`
@@ -282,7 +282,6 @@ Generally we recommend:
 You may want to consider your approach along with other tools that may offer
 helm compatible installs, for a standardized approach to managing CRD
 resources. If you have an approach that cert-manager does not currently
-support, then please 
+support, then please
 [raise an issue](https://github.com/cert-manager/cert-manager/issues) to
 discuss.
-

--- a/content/v1.13-docs/installation/kubectl.md
+++ b/content/v1.13-docs/installation/kubectl.md
@@ -19,7 +19,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/v1.13-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.13-docs/installation/operator-lifecycle-manager.md
@@ -217,7 +217,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.13.2 \
+kubectl patch csv cert-manager.v1.13.3 \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```


### PR DESCRIPTION
Release notes for v1.13.3

* Release thread on Slack: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1702028018348709
* Release branch: https://github.com/cert-manager/cert-manager/tree/release-1.13
* Tag: https://github.com/cert-manager/cert-manager/releases/tag/v1.13.3