### PR TITLE
Adjust the release process: Sign off the cmd/ctl and push the tag only after merging the PR

### DIFF
--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -453,6 +453,8 @@ page if a step is missing or if it is outdated.
     ```bash
      # Must be run from the cert-manager repo folder.
      git fetch origin $BRANCH
+     git checkout $BRANCH
+     git pull --ff-only origin $BRANCH
      git tag -m"cmd/ctl/$RELEASE_VERSION" "cmd/ctl/$RELEASE_VERSION" origin/$BRANCH
      git push origin "cmd/ctl/$RELEASE_VERSION"
      ```

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -421,19 +421,6 @@ page if a step is missing or if it is outdated.
      git commit -m"Update cmd/ctl's go.mod to $RELEASE_VERSION"
      ```
 
-    Third, create a tag for the `cmd/ctl` module:
-
-     ```bash
-     # Must be run from the cert-manager repo folder.
-     git tag -m"cmd/ctl/$RELEASE_VERSION" "cmd/ctl/$RELEASE_VERSION"
-     git push origin "cmd/ctl/$RELEASE_VERSION"
-     ```
-
-    > **Note:** the reason we need to do this is explained on Stack Overflow:
-    [how-are-versions-of-a-sub-module-managed][]
-
-    [how-are-versions-of-a-sub-module-managed]: https://stackoverflow.com/questions/60601011/how-are-versions-of-a-sub-module-managed/60601402#60601402
-
     Then, push the branch to your fork of cert-manager. For example:
 
      ```bash
@@ -459,11 +446,22 @@ page if a step is missing or if it is outdated.
      EOF
      ```
 
-   Finally, get back to the branch you were on initially:
+   Wait for the PR to be merged.
 
-   ```bash
-   git checkout $BRANCH
-   ```
+   Finally, create a tag for the `cmd/ctl` module:
+
+    ```bash
+     # Must be run from the cert-manager repo folder.
+     git fetch origin $BRANCH
+     git tag -m"cmd/ctl/$RELEASE_VERSION" "cmd/ctl/$RELEASE_VERSION" origin/$BRANCH
+     git push origin "cmd/ctl/$RELEASE_VERSION"
+     ```
+
+    > **Note:** the reason we need to do this is explained on Stack Overflow:
+    [how-are-versions-of-a-sub-module-managed][]
+
+    [how-are-versions-of-a-sub-module-managed]: https://stackoverflow.com/questions/60601011/how-are-versions-of-a-sub-module-managed/60601402#60601402
+
 
 10. In this section, we will be creating the description for the GitHub Release.
 

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -631,6 +631,10 @@ page if a step is missing or if it is outdated.
 
 16. Open a PR for a [Homebrew](https://github.com/Homebrew/homebrew-core/pulls) formula update for `cmctl`.
 
+    > ℹ️ The PR is [created automatically](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-core+cmctl&type=pullrequests&s=created&o=desc)
+    > if you are publishing the `latest` version of cert-manager, in which case this step can be skipped.
+    > But not if you are publishing a patch for a previous version.
+
     Assuming you have `brew` installed, you can use the `brew bump-formula-pr`
     command to do this. You'll need the new tag name and the commit hash of that
     tag. See `brew bump-formula-pr --help` for up to date details, but the command

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -418,7 +418,7 @@ page if a step is missing or if it is outdated.
 
      find . -name go.mod -not -path ./_bin/\* -exec dirname '{}' \; | xargs -L1 -I@ sh -c 'cd @; go mod tidy'
      git add **/go.mod **/go.sum
-     git commit -m"Update cmd/ctl's go.mod to $RELEASE_VERSION"
+     git commit --signoff -m"Update cmd/ctl's go.mod to $RELEASE_VERSION"
      ```
 
     Then, push the branch to your fork of cert-manager. For example:

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -417,7 +417,7 @@ page if a step is missing or if it is outdated.
      cd ../..
 
      find . -name go.mod -not -path ./_bin/\* -exec dirname '{}' \; | xargs -L1 -I@ sh -c 'cd @; go mod tidy'
-     git add **/go.mod **/go.sum
+     git add "**/go.mod" "**/go.sum"
      git commit --signoff -m"Update cmd/ctl's go.mod to $RELEASE_VERSION"
      ```
 


### PR DESCRIPTION
**Preview**: https://deploy-preview-1363--cert-manager-website.netlify.app/docs/contributing/release-process/#process-for-releasing-a-version

While releasing v1.13.3, I didn't signoff the commit which updates the `cmd/ctl/go.mod` file, 
which caused the PR to fail the DCO checks.
 * I've added the `--signoff` option in this PR.

The problem was compounded by the fact that I had already pushed the `cmd/ctl@v1.13.3` tag to the cert-manager repo.
* I've  changed the order of the instructions so that the Tag only gets pushed after the PR has been merged.