### PR TITLE
Venafi Issuer: Explain why "Do not select 'refresh token enabled'"

### DIFF
--- a/content/docs/configuration/venafi.md
+++ b/content/docs/configuration/venafi.md
@@ -141,7 +141,9 @@ credentials.
 
 1. [Set up token authentication](https://docs.venafi.com/Docs/23.1/TopNav/Content/SDK/AuthSDK/t-SDKa-Setup-OAuth.php).
 
-   NOTE: Do not select "Refresh Token Enabled" and set a *long* "Token Validity (days)".
+   NOTE: Do not select "Refresh Token Enabled" and set a *long* "Token Validity
+   (days)". The Refresh Token feature is not supported by cert-manager's Venafi
+   `Issuer`.
 
 2. Create a new user with sufficient privileges to manage and revoke certificates in a particular policy folder (zone).
 


### PR DESCRIPTION
A while back, when the "Access Token" authentication method was documented by Richard in https://github.com/cert-manager/website/pull/346, the following was added:

> NOTE: Do not select "Refresh Token Enabled" and set a *long* "Token Validity (days)".

I have read a few questions about "why is cert-manager not supporting refresh tokens?", so I figured I would explain why in this PR.
