### PR TITLE
Add Certificate 'otherNames' SAN field description

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -33,7 +33,7 @@ For example you can create certificates with this block in the spec:
     - oid: 1.3.6.1.4.1.311.20.2.3 # UPN OID
       utf8Value: upn@domain.local
 ```
-The feature is still in alpha stage and requires you to enable the "OtherName" feature flag in controller and webhook components, [details here](https://cert-manager.io/docs/installation/configuring-components/#feature-gates).
+The feature is still in alpha stage and requires you to [enable the `OtherName` feature flag in the controller and webhook components](../../installation/configuring-components/README.md#feature-gates).
 
 #### New CA certificate Features
 

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -25,7 +25,7 @@ The KeyUsage and BasicConstraints extensions will now be encoded as critical in 
 The cert-manager Certificate resource now allows you to configure a subset of "Other Name" SANs,
 which are described in the [Subject Alternative Name section of RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6) (on page 37).
 
-We specifically support any utf8 valued otherName type such as the [User Principal Name](https://docs.venafi.com/Docs/current/TopNav/Content/Certificates/r-UEP-support-SANs.php) or [sAMAccountName](https://learn.microsoft.com/en-us/windows/win32/ad/naming-properties).
+We specifically support any `otherName` type with a `UTF-8` value, such as the [User Principal Name](https://docs.venafi.com/Docs/current/TopNav/Content/Certificates/r-UEP-support-SANs.php) or [`sAMAccountName`](https://learn.microsoft.com/en-us/windows/win32/ad/naming-properties).
 These are useful when issuing unique certificates for authenticating with LDAP systems such as Microsoft Active Directory.
 For example you can create certificates with this block in the spec:
 ```

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -33,7 +33,7 @@ For example you can create certificates with this block in the spec:
     - oid: 1.3.6.1.4.1.311.20.2.3 # UPN OID
       utf8Value: upn@domain.local
 ```
-The feature is still in alpha stage and requires you to [enable the `OtherName` feature flag in the controller and webhook components](../../installation/configuring-components/README.md#feature-gates).
+The feature is still in alpha stage and requires you to [enable the `OtherName` feature flag in the controller and webhook components](../../installation/configuring-components.md#feature-gates).
 
 #### New CA certificate Features
 

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -33,6 +33,7 @@ For example you can create certificates with this block in the spec:
     - oid: 1.3.6.1.4.1.311.20.2.3 # UPN OID
       utf8Value: upn@domain.local
 ```
+The feature is still in alpha stage and requires you to enable the "OtherName" feature flag in controller and webhook components, [details here](https://cert-manager.io/docs/installation/configuring-components/#feature-gates).
 
 #### New CA certificate Features
 

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -22,8 +22,8 @@ The KeyUsage and BasicConstraints extensions will now be encoded as critical in 
 
 #### New X.509 Features
 
-The cert-manager Certificate resource now allows you to configure a subset of "Other Name" SANs.
-Other Name is one of the GeneralNames like dnsName, IP , URL or URI SAN, described [page 37 in this RFC section on SANs](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6)
+The cert-manager Certificate resource now allows you to configure a subset of "Other Name" SANs,
+which are described in the [Subject Alternative Name section of RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6) (on page 37).
 
 We specifically support any utf8 valued otherName type such as the [User Principal Name](https://docs.venafi.com/Docs/current/TopNav/Content/Certificates/r-UEP-support-SANs.php) or [sAMAccountName](https://learn.microsoft.com/en-us/windows/win32/ad/naming-properties).
 These are useful when issuing unique certificates for authenticating with LDAP systems such as Microsoft Active Directory.

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -22,8 +22,17 @@ The KeyUsage and BasicConstraints extensions will now be encoded as critical in 
 
 #### New X.509 Features
 
-The cert-manager Certificate resource now allows you to configure "Other Name" SANs,
-which are useful when issuing certificates for authenticating with LDAP systems such as Microsoft Active Directory.
+The cert-manager Certificate resource now allows you to configure a subset of "Other Name" SANs.
+Other Name is one of the GeneralNames like dnsName, IP , URL or URI SAN, described [page 37 in this RFC section on SANs](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6)
+
+We specifically support any utf8 valued otherName type such as the [User Principal Name](https://docs.venafi.com/Docs/current/TopNav/Content/Certificates/r-UEP-support-SANs.php) or [sAMAccountName](https://learn.microsoft.com/en-us/windows/win32/ad/naming-properties).
+These are useful when issuing unique certificates for authenticating with LDAP systems such as Microsoft Active Directory.
+For example you can create certificates with this block in the spec:
+```
+  otherNames:
+    - oid: 1.3.6.1.4.1.311.20.2.3 # UPN OID
+      utf8Value: upn@domain.local
+```
 
 #### New CA certificate Features
 

--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -74,7 +74,7 @@ spec:
   usages:
     - server auth
     - client auth
-  # At least one of a DNS Name, URI, or IP address is required.
+  # At least one of a DNS Name, URI, IP address or otherName is required.
   dnsNames:
     - example.com
     - www.example.com
@@ -82,6 +82,11 @@ spec:
     - spiffe://cluster.local/ns/sandbox/sa/example
   ipAddresses:
     - 192.168.0.5
+  # Needs cert-manager 1.14+ and OtherName feature flag
+  otherNames:
+    # Should only supply oid of ut8 valued types 
+    - oid: 1.3.6.1.4.1.311.20.2.3 # User Principal Name "OID"
+      utf8Value: upn@example.local
   # Issuer references are always required.
   issuerRef:
     name: ca-issuer

--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -82,7 +82,7 @@ spec:
     - spiffe://cluster.local/ns/sandbox/sa/example
   ipAddresses:
     - 192.168.0.5
-  # Needs cert-manager 1.14+ and OtherName feature flag
+  # Needs cert-manager 1.14+ and "OtherName" feature flag
   otherNames:
     # Should only supply oid of ut8 valued types 
     - oid: 1.3.6.1.4.1.311.20.2.3 # User Principal Name "OID"


### PR DESCRIPTION
This provides a minimal level of documentation to the new otherNames field introduced in 1.14.0