### PR TITLE
Add FAQ entry on ca.crt

### DIFF
--- a/content/docs/trust/README.md
+++ b/content/docs/trust/README.md
@@ -13,14 +13,13 @@ This is because:
 
 1. That `Secret` also contains the private key of the server, which should only be accessible to the server.
    You should use RBAC to ensure that the `Secret` containing the serving certificate and private key are only accessible to Pods that need it.
-2. Rotating CA certificates safely relies on being able to have both the old and new CA certificates trusted at the same time.
-   By consuming the CA directly from the source, this isn't possible;
-   you'll be _forced_ to have some down-time in order to rotate certificates.
+2. Rotating CA certificates safely relies on being able to have both the old and new CA certificates trusted at the same time. See [the FAQ](../faq/README.md#chain-cacrt) for more details.
 
 </div>
 
 When configuring the client you should independently choose and fetch the CA certificates that you want to trust.
 Download the CA out of band and store it in a `Secret` or `ConfigMap` separate from the `Secret` containing the server's private key and certificate.
+
 [trust-manager](trust-manager) can be used to manage these certificates and automatically distribute them to multiple namespaces.
 
 This ensures that if the material in the `Secret` containing the server key and certificate is tampered with,


### PR DESCRIPTION
We regularly see people using ca.crt or requesting it be changed. This FAQ entry is intended to be something we can link to in those situations to try and clarify why it can be dangerous!