### PR TITLE
add label selector doc

### DIFF
--- a/content/docs/trust/trust-manager/README.md
+++ b/content/docs/trust/trust-manager/README.md
@@ -109,7 +109,7 @@ spec:
 
 Support for `Secret` targets must be explicitly enabled in the trust-manager controller; see details below under "Enable Secret targets".
 
-Both `ConfigMap` and `Secret` also support specifying label selectors to select multiple resources at once, which is useful in dynamics
+Both `ConfigMap` and `Secret` also support specifying label selectors to select multiple resources at once, which is useful in dynamic
 environments where the name of the `ConfigMap` or `Secret` is known only at runtime. When adding a source, either of type `ConfigMap` or `Secret`, 
 the fields `name` and `selector` are mutually exclusive: one **must** be set, but not both.
 

--- a/content/docs/trust/trust-manager/README.md
+++ b/content/docs/trust/trust-manager/README.md
@@ -54,10 +54,24 @@ spec:
       name: "my-db-tls"
       key: "ca.crt"
 
+  # Here is another Secret source, but this time using a label selector instead of a Secret's name. 
+  - secret:
+      selector:
+        matchLabels: 
+          fruit: apple
+      key: "ca.crt"
+
   # A ConfigMap in the "trust" namespace; see "Trust Namespace" below for further details
   - configMap:
       name: "my-org.net"
       key: "root-certs.pem"
+  
+  # Here is another ConfigMap source, but this time using a label selector instead of a ConfigMap's name. 
+  - configMap:
+      selector:
+        matchLabels: 
+          fruit: apple
+      key: "ca.crt"
 
   # A manually specified string
   - inLine: |
@@ -94,6 +108,11 @@ spec:
 `ConfigMap` is the default target type, but as of v0.7.0 trust-manager also supports `Secret` resources as targets.
 
 Support for `Secret` targets must be explicitly enabled in the trust-manager controller; see details below under "Enable Secret targets".
+
+Both `ConfigMap` and `Secret` also support specifying label selectors to select multiple resources at once, which is useful in dynamics
+environments where the name of the `ConfigMap` or `Secret` is known only at runtime. When adding a source, either of type `ConfigMap` or `Secret`, 
+the fields `name` and `selector` are mutually exclusive: one **must** be set, but not both.
+
 
 All sources and target options are documented in the trust-manager [API reference documentation](./api-reference.md).
 

--- a/content/docs/trust/trust-manager/api-reference.md
+++ b/content/docs/trust/trust-manager/api-reference.md
@@ -172,17 +172,17 @@ ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name is the name of the source object in the trust Namespace.<br/>
+          Name is the name of the source object in the trust Namespace. If not set, `selector` must be set.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr></tbody>
       </tr><tr>
         <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#labelselector-v1-meta">selector</a></b></td>
         <td>LabelSelector</td>
         <td>
-          Name is the name of the source object in the trust Namespace.<br/>
+          A LabelSelector object to reference, by labels, a list of source objects in the trust Namespace. If not set, `name` must be set.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -212,9 +212,17 @@ Secret is a reference to a Secrets's `data` key, in the trust Namespace.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name is the name of the source object in the trust Namespace.<br/>
+          Name is the name of the source object in the trust Namespace. If not set, `selector` must be set.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
+      </tr></tbody>
+      </tr><tr>
+        <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#labelselector-v1-meta">selector</a></b></td>
+        <td>LabelSelector</td>
+        <td>
+          A LabelSelector object to reference, by labels, a list of source objects in the trust Namespace. If not set, `name` must be set.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/content/docs/trust/trust-manager/api-reference.md
+++ b/content/docs/trust/trust-manager/api-reference.md
@@ -175,7 +175,6 @@ ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
           Name is the name of the source object in the trust Namespace. If not set, `selector` must be set.<br/>
         </td>
         <td>false</td>
-      </tr></tbody>
       </tr><tr>
         <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#labelselector-v1-meta">selector</a></b></td>
         <td>LabelSelector</td>
@@ -215,7 +214,6 @@ Secret is a reference to a Secrets's `data` key, in the trust Namespace.
           Name is the name of the source object in the trust Namespace. If not set, `selector` must be set.<br/>
         </td>
         <td>false</td>
-      </tr></tbody>
       </tr><tr>
         <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#labelselector-v1-meta">selector</a></b></td>
         <td>LabelSelector</td>

--- a/content/docs/trust/trust-manager/api-reference.md
+++ b/content/docs/trust/trust-manager/api-reference.md
@@ -176,6 +176,14 @@ ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
         </td>
         <td>true</td>
       </tr></tbody>
+      </tr><tr>
+        <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#labelselector-v1-meta">selector</a></b></td>
+        <td>LabelSelector</td>
+        <td>
+          Name is the name of the source object in the trust Namespace.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
 </table>
 
 


### PR DESCRIPTION
This PR adds documentation for the `labelSelector` feature introduced by: https://github.com/cert-manager/trust-manager/issues/256

