### PR TITLE
chore: Tutorial component install version increments

### DIFF
--- a/content/docs/tutorials/certificate-defaults/README.md
+++ b/content/docs/tutorials/certificate-defaults/README.md
@@ -4,7 +4,7 @@ description: |
   Learn how to use Kyverno ClusterPolicy to set default values for cert-manager Certificates cluster wide.
 ---
 
-*Last Verified: 05 January 2024*
+*Last Verified: 19 January 2024*
 
 # Objective
 
@@ -89,8 +89,8 @@ Once you have your cluster environment, install the required Kubernetes packages
 1. Set some environment variables for the helm chart versions:
 
     ```shell
-    export CERT_MANAGER_CHART_VERSION="v1.14.0-alpha.0" \
-        KYVERNO_CHART_VERSION="3.1.1" \
+    export CERT_MANAGER_CHART_VERSION="v1.14.0-alpha.1" \
+        KYVERNO_CHART_VERSION="3.1.4" \
         INGRESS_NGINX_CHART_VERSION="4.9.0"
     ```
 


### PR DESCRIPTION
A [Slack announcement](https://cloud-native.slack.com/archives/C02CEARLA3D/p1705656920359229) from Kyverno about [#9119](https://github.com/kyverno/kyverno/pull/9119) prompted me to check the version I deployed here.

Although I didn't use the features expressed, it'd be better to release this with a version that doesn't have a potential issue.
Also we have a new [cert-manager v1.14.0-alpha.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.14.0-alpha.1) release as well, so a  good time to increment that too.
