### PR TITLE
Add --force-update flag to 'helm repo add' command

### DIFF
--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -25,7 +25,7 @@ This repository is the only supported source of cert-manager charts. There are s
 Notably, the "Helm stable repository" version of cert-manager is deprecated and should not be used.
 
 ```bash
-helm repo add jetstack https://charts.jetstack.io
+helm repo add jetstack https://charts.jetstack.io --force-update
 ```
 
 #### 2. Update your local Helm chart repository cache:


### PR DESCRIPTION
For users, it is almost always desirable to fetch the latest Helm chart index.
This will help users to stay up-to-date with the latest releases of cert-manager and components.