### PR TITLE
Add more cross reference links to the Security items in the release notes

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -50,7 +50,7 @@ This will help mitigate denial-of-service attacks against those important servic
 All the cert-manager containers are now configured with read only root file system by default,
 to prevent unexpected changes to the file system of the OCI image.
 
-And it is now possible to configure the metrics server to use HTTPS rather than HTTP,
+And it is now possible to [configure the metrics server to use HTTPS](../../devops-tips/prometheus-metrics.md#tls) rather than HTTP,
 so that clients can verify the identity of the metrics server.
 
 #### Other

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -43,7 +43,7 @@ To know more details on name constraints check out RFC section https://datatrack
 
 #### Security
 
-An ongoing security audit of the cert-manager code revealed some weaknesses which we have addressed in this release,
+An [ongoing CNCF security audit of the cert-manager code](https://github.com/cert-manager/cert-manager/issues/6132) revealed some weaknesses which we have addressed in this release,
 such as using more secure default settings in the HTTP servers that serve metrics, healthz and pprof endpoints.
 This will help mitigate denial-of-service attacks against those important services.
 

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -47,7 +47,7 @@ An ongoing security audit of the cert-manager code revealed some weaknesses whic
 such as using more secure default settings in the HTTP servers that serve metrics, healthz and pprof endpoints.
 This will help mitigate denial-of-service attacks against those important services.
 
-All the cert-manager containers are now configured with read only root file system by default,
+All the cert-manager containers are now configured with [read only root file system](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) by default,
 to prevent unexpected changes to the file system of the OCI image.
 
 And it is now possible to [configure the metrics server to use HTTPS](../../devops-tips/prometheus-metrics.md#tls) rather than HTTP,


### PR DESCRIPTION
**Preview**: https://deploy-preview-1410--cert-manager-website.netlify.app/docs/releases/release-notes/release-notes-1.14#security

Adding more links to the release notes so that users can read more about the improvements and new features.

* https://github.com/cert-manager/cert-manager/pull/6453
* https://github.com/cert-manager/cert-manager/issues/5925
* https://github.com/cert-manager/cert-manager/issues/6591
* https://github.com/cert-manager/cert-manager/security/advisories/GHSA-vgf6-pvf4-34rq
* https://github.com/cert-manager/cert-manager/pull/6574
* https://github.com/cert-manager/website/pull/1376

/cc @hawksight 