### PR TITLE
Release notes for v1.14.1 including explanation for the failed v1.14.0 release

### DIFF
--- a/content/docs/installation/README.md
+++ b/content/docs/installation/README.md
@@ -12,7 +12,7 @@ Learn about the various ways you can install cert-manager and how to choose betw
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/cert-manager.yaml
 ```
 
 📖 Read more about [installing cert-manager using kubectl apply and static manifests](./kubectl.md).

--- a/content/docs/installation/code-signing.md
+++ b/content/docs/installation/code-signing.md
@@ -19,7 +19,7 @@ key.
 For all cert-manager versions from `v1.8.0` and later, cert-manager container images are signed and verifiable using [`cosign`](https://docs.sigstore.dev/cosign/overview).
 
 ```console
-IMAGE_TAG=v1.14.0  # change as needed
+IMAGE_TAG=v1.14.1  # change as needed
 KEY=https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
 cosign verify --signature-digest-algorithm sha512 --insecure-ignore-tlog --key $KEY quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --insecure-ignore-tlog --key $KEY quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG

--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -47,7 +47,7 @@ section below for details on each method.
 > Recommended for production installations
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.0/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -70,7 +70,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.0 \
+  --version v1.14.1 \
   # --set installCRDs=true
 ```
 
@@ -83,7 +83,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.0 \
+  --version v1.14.1 \
   # --set installCRDs=true
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
@@ -114,7 +114,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.14.0
+    version: v1.14.1
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -148,7 +148,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.0 \
+  --version v1.14.1 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/docs/installation/kubectl.md
+++ b/content/docs/installation/kubectl.md
@@ -21,7 +21,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/docs/installation/operator-lifecycle-manager.md
+++ b/content/docs/installation/operator-lifecycle-manager.md
@@ -218,7 +218,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.14.0 \
+kubectl patch csv cert-manager.v1.14.1 \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -3,11 +3,11 @@ title: Release 1.14
 description: 'cert-manager release notes: cert-manager 1.14'
 ---
 
-## `v1.14.1`
-
 cert-manager 1.14 brings a variety of features, security improvements and bug fixes, including:
 support for creating X.509 certificates with "Other Name" fields, and
 support for creating CA certificates with "Name Constraints" and "Authority Information Accessors" extensions.
+
+## `v1.14.1`
 
 cert-manager `v1.14.1` fixes bugs found *during* the release of `v1.14.0`.
 
@@ -22,10 +22,6 @@ cert-manager `v1.14.1` fixes bugs found *during* the release of `v1.14.0`.
 - Fix bug in cmctl which caused `cmctl experimental install` to panic. ([#6706](https://github.com/cert-manager/cert-manager/pull/6706), [@inteon](https://github.com/inteon))
 
 ## `v1.14.0`
-
-cert-manager 1.14 brings a variety of features, security improvements and bug fixes, including:
-support for creating X.509 certificates with "Other Name" fields, and
-support for creating CA certificates with "Name Constraints" and "Authority Information Accessors" extensions.
 
 > ⚠️ This version has known issues. Please install `v1.14.1` instead.
 >

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -5,7 +5,13 @@ description: 'cert-manager release notes: cert-manager 1.14'
 
 ## `v1.14.1`
 
+cert-manager 1.14 brings a variety of features, security improvements and bug fixes, including:
+support for creating X.509 certificates with "Other Name" fields, and
+support for creating CA certificates with "Name Constraints" and "Authority Information Accessors" extensions.
+
 cert-manager `v1.14.1` fixes bugs found *during* the release of `v1.14.0`.
+
+> 📢 When upgrading to cert-manager release 1.14, please skip v1.14.0 and install this patch version instead.
 
 ### Changes since `v1.14.0`
 
@@ -32,6 +38,35 @@ _Nothing has changed._
 cert-manager 1.14 brings a variety of features, security improvements and bug fixes, including:
 support for creating X.509 certificates with "Other Name" fields, and
 support for creating CA certificates with "Name Constraints" and "Authority Information Accessors" extensions.
+
+> ⚠️ This version has known issues. Please install `v1.14.1` instead.
+>
+> During the release of `v1.14.0`, the Helm chart was found to use the wrong OCI image for the `cainjector` Deployment,
+> which caused the Helm installation and the static manifest based installation to fail.
+> Upon discovery of this bug, the release of `v1.14.0` was paused before the Helm chart or GitHub release were published;
+> but the Git tag and the OCI images had already been published.
+>
+> The cert-manager team next fixed the Helm chart and two other bugs which are listed in the "Known Issues" section below,
+> and then released `v1.14.1`, which is the version that users are strongly advised to install when they upgrade to 1.14.
+>
+> In order to complete the stalled `v1.14.0` release,
+> the Helm chart and static YAML installation files were regenerated on a team member's laptop,
+> using exactly the same build scripts as are used in the automated release process,
+> and using the `v1.14.1` version of the code.
+> The working  `v1.14.0` Helm chart was published,
+> and the working versions of the static manifest files attached to the draft `v1.14.0` GitHub release,
+> and that was then published.
+>
+> For these reasons, users are strongly advised to skip this version and install the `v1.14.1` Helm chart instead.
+
+### Known Issues
+- During the release of `v1.14.0`, the Helm chart for this version was found to use the wrong OCI image for the `cainjector` Deployment,
+  which caused the Helm installation to fail.
+  In order to complete the release, the cert-manager team have manually updated the Helm chart for this version,
+  which contains all the Helm chart fixes which are in `v1.14.1`.
+  But users are strongly advised to skip this version and install the `v1.14.1` Helm chart instead.
+- A bug in cmctl namespace detection prevents it being used as a `startupapicheck` image in namespaces other than cert-manager.
+- A bug in cmctl causes `cmctl experimental install` to panic.
 
 ### Breaking Changes
 

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -21,18 +21,6 @@ cert-manager `v1.14.1` fixes bugs found *during* the release of `v1.14.0`.
 - Fix bug in cmctl namespace detection which prevented it being used as a startupapicheck image in namespaces other than cert-manager. ([#6706](https://github.com/cert-manager/cert-manager/pull/6706), [@inteon](https://github.com/inteon))
 - Fix bug in cmctl which caused `cmctl experimental install` to panic. ([#6706](https://github.com/cert-manager/cert-manager/pull/6706), [@inteon](https://github.com/inteon))
 
-### Dependencies
-
-#### Added
-_Nothing has changed._
-
-#### Changed
-_Nothing has changed._
-
-#### Removed
-_Nothing has changed._
-
-
 ## `v1.14.0`
 
 cert-manager 1.14 brings a variety of features, security improvements and bug fixes, including:

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -3,6 +3,10 @@ title: Release 1.14
 description: 'cert-manager release notes: cert-manager 1.14'
 ---
 
+## `v1.14.1`
+
+cert-manager `v1.14.1` is patch release to fix bugs found *during* the release of `v1.14.0`.
+
 ## `v1.14.0`
 
 cert-manager 1.14 brings a variety of features, security improvements and bug fixes, including:

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -11,7 +11,7 @@ support for creating CA certificates with "Name Constraints" and "Authority Info
 
 cert-manager `v1.14.1` fixes bugs found *during* the release of `v1.14.0`.
 
-> 📢 When upgrading to cert-manager release 1.14, please skip v1.14.0 and install this patch version instead.
+> 📢 When upgrading to cert-manager release 1.14, please skip `v1.14.0` and install this patch version instead.
 
 ### Changes since `v1.14.0`
 

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -5,7 +5,27 @@ description: 'cert-manager release notes: cert-manager 1.14'
 
 ## `v1.14.1`
 
-cert-manager `v1.14.1` is patch release to fix bugs found *during* the release of `v1.14.0`.
+cert-manager `v1.14.1` fixes bugs found *during* the release of `v1.14.0`.
+
+### Changes since `v1.14.0`
+
+#### Bug or Regression
+
+- Fix broken cainjector image value in Helm chart ([#6693](https://github.com/cert-manager/cert-manager/pull/6693), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Fix bug in cmctl namespace detection which prevented it being used as a startupapicheck image in namespaces other than cert-manager. ([#6706](https://github.com/cert-manager/cert-manager/pull/6706), [@inteon](https://github.com/inteon))
+- Fix bug in cmctl which caused `cmctl experimental install` to panic. ([#6706](https://github.com/cert-manager/cert-manager/pull/6706), [@inteon](https://github.com/inteon))
+
+### Dependencies
+
+#### Added
+_Nothing has changed._
+
+#### Changed
+_Nothing has changed._
+
+#### Removed
+_Nothing has changed._
+
 
 ## `v1.14.0`
 

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -3,9 +3,9 @@ title: Release 1.14
 description: 'cert-manager release notes: cert-manager 1.14'
 ---
 
-cert-manager 1.14 brings a variety of features, security improvements and bug fixes, including:
-support for creating X.509 certificates with "Other Name" fields, and
-support for creating CA certificates with "Name Constraints" and "Authority Information Accessors" extensions.
+cert-manager 1.14 brings a variety of [features](#feature), [security improvements](#security) and [bug fixes](#bug-or-regression-1), including:
+support for creating [X.509 certificates with "Other Name" fields](#new-x509-features), and
+support for creating [CA certificates with "Name Constraints" and "Authority Information Accessors" extensions](#new-ca-certificate-features).
 
 ## `v1.14.1`
 

--- a/content/docs/releases/upgrading/upgrading-1.13-1.14.md
+++ b/content/docs/releases/upgrading/upgrading-1.13-1.14.md
@@ -3,7 +3,18 @@ title: Upgrading from v1.13 to v1.14
 description: 'cert-manager installation: Upgrading v1.13 to v1.14'
 ---
 
-When upgrading cert-manager from 1.13 to 1.14, in few cases you might need to take additional steps to ensure a smooth upgrade.
+Before upgrading cert-manager from 1.13 to 1.14 please read the following important notes about breaking changes in 1.14:
+
+## Please install the latest patch release: `v1.14.1`
+
+The following bugs were found during the release of `v1.14.0` and have been fixed in `v1.14.1`:
+
+- During the release of `v1.14.0`, the Helm chart was found to use the wrong OCI image for the `cainjector` Deployment,
+  which caused the Helm installation to fail.
+- A bug in cmctl namespace detection prevents it being used as a startupapicheck image in namespaces other than cert-manager.
+- A bug in cmctl causes `cmctl experimental install` to panic.
+
+Read the [`v1.14.1` release notes](../release-notes/release-notes-1.14.md#v1.14.1) for more information.
 
 ## New startupapicheck image
 

--- a/content/docs/tutorials/certificate-defaults/README.md
+++ b/content/docs/tutorials/certificate-defaults/README.md
@@ -89,7 +89,7 @@ Once you have your cluster environment, install the required Kubernetes packages
 1. Set some environment variables for the helm chart versions:
 
     ```shell
-    export CERT_MANAGER_CHART_VERSION="v1.14.0" \
+    export CERT_MANAGER_CHART_VERSION="v1.14.1" \
         KYVERNO_CHART_VERSION="3.1.4" \
         INGRESS_NGINX_CHART_VERSION="4.9.0"
     ```


### PR DESCRIPTION
**Preview**: https://deploy-preview-1411--cert-manager-website.netlify.app/docs/releases/release-notes/release-notes-1.14

Updating versions for forthcoming patch release  v1.14.1

Part of:
 * https://github.com/cert-manager/cert-manager/issues/6710

/hold until release is published.