### PR TITLE
releases: Move v1.14 to "Currently supported"

### DIFF
--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -18,6 +18,7 @@ and other world events.
 
 |   Release    | Release Date |      End of Life       | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |--------------|:------------:|:----------------------:|:----------------------------------:|:---------------------------------:|
+|     [1.14][] | Feb 02, 2024 |     June 03, 2024      |            1.24 → 1.29             |           4.11 → 4.15             |
 |     [1.13][] | Sep 12, 2023 |    Release of 1.15     |            1.23 → 1.28             |           4.10 → 4.15             |
 | [1.12 LTS][] | May 19, 2023 |      May 19, 2025      |            1.22 → 1.28             |            4.9 → 4.15             |
 
@@ -27,7 +28,6 @@ cert-manager 1.12 is a Long Term Support (LTS) release sponsored by [Venafi](htt
 
 | Release  | Release Date | End of Life            | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |----------|:------------:|:----------------------:|:----------------------------------:|:---------------------------------:|
-| [1.14][] | Jan 31, 2024 | ~4 months post release |             1.24 → 1.29            |           4.11 → 4.15             |
 | [1.15][] | TBD          | TBD                    | TBD                                | TBD                               |
 
 Dates in the future are uncertain and might change.


### PR DESCRIPTION
Release 1.14 has been officially tagged.

Tags [v1.14.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.14.0) and [v1.14.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.14.1) (hotfix) were released on Feb 2, 2024. The releases document is updated to reflect this, and the provisional End of Life date is marked as four months in the future, falling on the nearest working day to allow for a last minute release without risk of breaking someone's weekend.

Closes #1416.