### PR TITLE
Remove config-sync from cert-manager website

### DIFF
--- a/content/docs/devops-tips/syncing-secrets-across-namespaces.md
+++ b/content/docs/devops-tips/syncing-secrets-across-namespaces.md
@@ -2,7 +2,7 @@
 title: Syncing Secrets Across Namespaces
 description: |
     Learn how to synchronize Kubernetes Secret resources across namespaces
-    using extensions such as: reflector, kubed and kubernetes-replicator.
+    using extensions such as: reflector and kubernetes-replicator.
 ---
 
 It may be required for multiple components across namespaces to consume the same

--- a/content/docs/devops-tips/syncing-secrets-across-namespaces.md
+++ b/content/docs/devops-tips/syncing-secrets-across-namespaces.md
@@ -10,8 +10,6 @@ It may be required for multiple components across namespaces to consume the same
 do this is to use extensions such as:
   - [reflector](https://github.com/emberstack/kubernetes-reflector) with support
    for auto secret reflection
-  - [kubed](https://github.com/appscode/kubed) with its
-  [secret syncing feature](https://appscode.com/products/kubed/v0.11.0/guides/config-syncer/intra-cluster/)
   - [kubernetes-replicator](https://github.com/mittwald/kubernetes-replicator) secret replication
 
 ## Serving a wildcard to ingress resources in different namespaces (default SSL certificate)
@@ -67,38 +65,6 @@ spec:
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true" # Auto create reflection for matching namespaces
       reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "dev,staging,prod" # Control auto-reflection namespaces
 ```
-
-
-### Using `kubed`
- The example below shows syncing
-a certificate belonging to the `sandbox` Certificate from the `cert-manager`
-namespace, into the `sandbox` namespace.
-
-```yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: sandbox
-  labels:
-    cert-manager-tls: sandbox # Define namespace label for kubed
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: sandbox
-  namespace: cert-manager
-spec:
-  secretName: sandbox-tls
-  commonName: sandbox
-  issuerRef:
-    name: sandbox-ca
-    kind: Issuer
-    group: cert-manager.io
-  secretTemplate:
-    annotations:
-      kubed.appscode.com/sync: "cert-manager-tls=sandbox" # Sync certificate to matching namespaces
-```
-
 
 ### Using `kubernetes-replicator`
 Replicator supports both push- and pull-based replication. Push-based


### PR DESCRIPTION
I submit this PR to remove the config-syncer project from the website documentation for cert-manager.

Config-syncer (previously kubed) from appscode has changed their licensing, and pulled all their old container images from docker hub. You can no longer deploy this software without a license from their license server. They list Apache 2.0 on their github repo:
https://github.com/config-syncer/config-syncer

But the documentation and code do not match this license:
https://config-syncer.com/docs/v0.14.6/setup/install/
![image](https://github.com/cert-manager/website/assets/3159463/e22a02f7-b0cc-4cfd-852d-5960a5ff698a)
License server offline instructions for CI/CD:
https://github.com/bytebuilders/offline-license-server#offline-license-server

Which doesn't work because they now only issue enterprise license and enterprise license trials:
https://github.com/bytebuilders/offline-license-server/issues/83
https://github.com/bytebuilders/offline-license-server/pull/81

