### PR TITLE
Update Name constraints docs and release notes

### DIFF
--- a/content/docs/installation/configuring-components.md
+++ b/content/docs/installation/configuring-components.md
@@ -53,6 +53,7 @@ featureGates:
   LiteralCertificateSubject: true
   UseCertificateRequestBasicConstraints: true
   OtherNames: true
+  NameConstraints: true
 ```
 
 > **Note:** This is included as an example only and not intended to be used as default settings.
@@ -78,13 +79,14 @@ featureGates:
   AdditionalCertificateOutputFormats: true
   LiteralCertificateSubject: true
   OtherNames: true
+  NameConstraints: true
 ```
 
 > **Note:** This is included as an example only and not intended to be used as default settings.
 
 ## Feature gates
 
-Feature gates can be used to enable or disable experimental features in cert-manager. 
+Feature gates can be used to enable or disable experimental features in cert-manager.
 
 There are 2 levels of feature gates (more details in [Kubernetes definition of feature stages](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages)):
 - **Alpha:** feature is not yet stable and might be removed or changed in the future. Alpha features are disabled by default and need to be explicitly enabled by the user (to test the feature).

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -102,8 +102,8 @@ You can now specify the [X.509 v3 Authority Information Accessors](https://www.r
 with URLs for certificates issued by the [CA Issuer](../../configuration/ca.md),
 using the new [`issuingCertificateURLs` field](../../reference/api-docs.md#cert-manager.io/v1.CAIssuer).
 
-Users can now use name constraints in CA certificates.
-To know more details on name constraints check out RFC section https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
+Users can now [use name constraints in CA certificates](../../usage/certificate.md#creating-certificate-with-name-constraints).
+To know more details on name constraints check out [RFC5280 section 4.2.1.10](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10).
 
 #### Security
 

--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -96,12 +96,12 @@ spec:
     # This is optional since cert-manager will default to this value however
     # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io
-  
+
   # keystores allows adding additional output formats. This is an example for reference only.
   keystores:
-    pkcs12: 
+    pkcs12:
       create: true
-      passwordSecretRef: 
+      passwordSecretRef:
         name: example-com-tls-keystore
         key: password
       profile: Modern2023
@@ -281,7 +281,7 @@ Checkout https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10 for more
 `--feature-gates` flag on the cert-manager controller and webhook components:
 
 ```bash
---feature-gates=useCertificateRequestNameConstraints=true
+--feature-gates=NameConstraints=true
 ```
 
 </div>


### PR DESCRIPTION
**Preview**: https://deploy-preview-1422--cert-manager-website.netlify.app/docs/releases/release-notes/release-notes-1.14/#new-ca-certificate-features

Fixes: #1405 

@hawksight and I noticed that the Name constraints documentation used an out of date feature gate name and that the feature gate was missing from the two example configuration files (which contain all the other feature gates).

/cc @hawksight 