### PR TITLE
Document known issue: wrong certificate chain is used if preferredChain is configured

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -20,7 +20,7 @@ support for creating [CA certificates with "Name Constraints" and "Authority Inf
 
 ### Known Issues
 
-#### ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured
+#### ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured - [#6755](https://github.com/cert-manager/cert-manager/pull/6755), [#6757](https://github.com/cert-manager/cert-manager/issues/6757)
 
 On Thursday, Feb 8th, 2024, [Let's Encrypt stopped providing their cross-signed certificate chain by default](https://letsencrypt.org/2023/07/10/cross-sign-expiration), in requests made to their `/acme/certificate` API endpoint.
 Instead the short-chain is returned by default and the long-chain (cross-signed) certificate chain is now included among the ["alternate" chains](https://www.rfc-editor.org/rfc/rfc8555#section-7.4.2).

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -27,7 +27,7 @@ On Thursday, Feb 8th, 2024, [Let's Encrypt stopped providing their cross-signed 
 **Some** users who set `Isser.spec.acme.preferredChain: ISRG Root X1` in order to get early access to the Let's Encrypt short-chain certificates, will now get long-chain (cross-signed) certificates when they renew.
 **Most** users will not be affected. Their new certificates will contain the short-chain (not cross-signed) which terminates at `ISRG Root X1`.
 
-> 🔖 Read [cert-manager PR 6755 (bugfix: wrong certificate chain is used if preferredChain is configured)](https://github.com/cert-manager/cert-manager/pull/6755) to learn about the bug and to see the proposed fix.
+> 🔖 Read [cert-manager PR 6755 (bugfix: wrong certificate chain is used if `preferredChain` is configured)](https://github.com/cert-manager/cert-manager/pull/6755) to learn about the bug and to see the proposed fix.
 >
 > 🔖 Read [Let’s Encrypt: chain of trust](https://letsencrypt.org/certificates/) to learn about the hierarchy of root and intermediate certificates.
 


### PR DESCRIPTION
**Preview**: https://deploy-preview-1429--cert-manager-website.netlify.app/docs/releases/release-notes/release-notes-1.14#known-issues

In https://github.com/cert-manager/cert-manager/pull/6755#issuecomment-1944231410 we agreed to:
> update existing release notes with a note that explains that this is a known issue and that the immediate fix is to remove the preferredChain: ISRG Root X1 property
* https://github.com/cert-manager/cert-manager/pull/6755

I'm struggling to make the situation clear so happy to receive any suggestions.

