### PR TITLE
New patch releases: `v1.12.8`, `v1.13.4` and `v1.14.3`

### DIFF
--- a/content/docs/installation/README.md
+++ b/content/docs/installation/README.md
@@ -12,7 +12,7 @@ Learn about the various ways you can install cert-manager and how to choose betw
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
 ```
 
 📖 Read more about [installing cert-manager using kubectl apply and static manifests](./kubectl.md).

--- a/content/docs/installation/code-signing.md
+++ b/content/docs/installation/code-signing.md
@@ -19,7 +19,7 @@ key.
 For all cert-manager versions from `v1.8.0` and later, cert-manager container images are signed and verifiable using [`cosign`](https://docs.sigstore.dev/cosign/overview).
 
 ```console
-IMAGE_TAG=v1.14.2  # change as needed
+IMAGE_TAG=v1.14.3  # change as needed
 KEY=https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
 cosign verify --signature-digest-algorithm sha512 --insecure-ignore-tlog --key $KEY quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --insecure-ignore-tlog --key $KEY quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG

--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -47,7 +47,7 @@ section below for details on each method.
 > Recommended for production installations
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.2/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -70,7 +70,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.2 \
+  --version v1.14.3 \
   # --set installCRDs=true
 ```
 
@@ -83,7 +83,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.2 \
+  --version v1.14.3 \
   # --set installCRDs=true
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
@@ -114,7 +114,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.14.2
+    version: v1.14.3
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -148,7 +148,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.2 \
+  --version v1.14.3 \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/docs/installation/kubectl.md
+++ b/content/docs/installation/kubectl.md
@@ -21,7 +21,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/docs/installation/operator-lifecycle-manager.md
+++ b/content/docs/installation/operator-lifecycle-manager.md
@@ -218,7 +218,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.14.2 \
+kubectl patch csv cert-manager.v1.14.3 \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```

--- a/content/docs/releases/release-notes/release-notes-1.12.md
+++ b/content/docs/releases/release-notes/release-notes-1.12.md
@@ -3,6 +3,24 @@ title: Release 1.12
 description: 'cert-manager release notes: cert-manager 1.12'
 ---
 
+## v1.12.8
+
+### Known Issues
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if preferredChain is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+
+### Changes
+
+#### Bug or Regression
+
+- BUGFIX: LiteralSubjects with a #= value can result in memory issues due to faulty BER parser (github.com/go-asn1-ber/asn1-ber). ([#6773](https://github.com/cert-manager/cert-manager/pull/6773), [@jetstack-bot](https://github.com/jetstack-bot))
+
+#### Other (Cleanup or Flake)
+
+- Bump go to 1.20.14 ([#6733](https://github.com/cert-manager/cert-manager/pull/6733), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Cert-manager is now built with Go 1.20.13 ([#6629](https://github.com/cert-manager/cert-manager/pull/6629), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Fix CVE 2023 48795 by upgrading to golang.org/x/crypto@v0.17.0 ([#6678](https://github.com/cert-manager/cert-manager/pull/6678), [@wallrj](https://github.com/wallrj))
+- Fix GHSA-7ww5-4wqc-m92c by upgrading to `github.com/containerd/containerd@v1.7.12` ([#6689](https://github.com/cert-manager/cert-manager/pull/6689), [@wallrj](https://github.com/wallrj))
+
 ## v1.12.7
 
 This patch release contains fixes for the following security vulnerabilities in the cert-manager-controller:
@@ -105,12 +123,12 @@ v1.12.6 fixes some CVE alerts and a Venafi issuer bug
 
 #### Bug or Regression
 
-- Bump `golang.org/x/net v0.15.0 => v0.17.0` as part of addressing `CVE-2023-44487` / `CVE-2023-39325` (#6431, @SgtCoDFish)
-- The Venafi issuer now properly resets the certificate and should no longer get stuck with `WebSDK CertRequest Module Requested Certificate` or `This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.`. (#6401, @jetstack-bot)
+- Bump `golang.org/x/net v0.15.0 => v0.17.0` as part of addressing `CVE-2023-44487` / `CVE-2023-39325` ([#6431](https://github.com/cert-manager/cert-manager/pull/6431), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- The Venafi issuer now properly resets the certificate and should no longer get stuck with `WebSDK CertRequest Module Requested Certificate` or `This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.`. ([#6401](https://github.com/cert-manager/cert-manager/pull/6401), [@jetstack-bot](https://github.com/jetstack-bot))
 
 #### Other (Cleanup or Flake)
 
-- Bump go to 1.20.10 to address `CVE-2023-39325`. Also bumps base images. (#6412, @SgtCoDFish)
+- Bump go to 1.20.10 to address `CVE-2023-39325`. Also bumps base images. ([#6412](https://github.com/cert-manager/cert-manager/pull/6412), [@SgtCoDFish](https://github.com/SgtCoDFish))
 
 ## v1.12.5
 
@@ -120,12 +138,12 @@ v1.12.5 contains a backport for a name collision bug that was found in v1.13.0
 
 #### Bug or Regression
 
-- BUGFIX: fix CertificateRequest name collision bug in StableCertificateRequestName feature. (#6359, @jetstack-bot)
+- BUGFIX: fix CertificateRequest name collision bug in StableCertificateRequestName feature. ([#6359](https://github.com/cert-manager/cert-manager/pull/6359), [@jetstack-bot](https://github.com/jetstack-bot))
 
 #### Other (Cleanup or Flake)
 
-- Updated base images to the latest version. (#6372, @inteon)
-- Upgrade Go from 1.20.7 to 1.20.8. (#6371, @jetstack-bot)
+- Updated base images to the latest version. ([#6372](https://github.com/cert-manager/cert-manager/pull/6372), [@inteon](https://github.com/inteon))
+- Upgrade Go from 1.20.7 to 1.20.8. ([#6371](https://github.com/cert-manager/cert-manager/pull/6371), [@jetstack-bot](https://github.com/jetstack-bot))
 
 ## v1.12.4
 
@@ -150,7 +168,7 @@ v1.12.3 contains a bug fix for the cainjector which addresses a memory leak!
 
 ### Changes
 
-- BUGFIX\[cainjector\]: 1-character bug was causing invalid log messages and a memory leak (#6235, @jetstack-bot)
+- BUGFIX\[cainjector\]: 1-character bug was causing invalid log messages and a memory leak ([#6235](https://github.com/cert-manager/cert-manager/pull/6235), [@jetstack-bot](https://github.com/jetstack-bot))
 
 ## v1.12.2
 
@@ -163,7 +181,7 @@ upgrading to the latest patch version available for 1.12.
 
 ### Changes
 
-- BUGFIX: `cmctl check api --wait 0` exited without output; we now make sure we perform the API check at least once (#6116, @jetstack-bot)
+- BUGFIX: `cmctl check api --wait 0` exited without output; we now make sure we perform the API check at least once ([#6116](https://github.com/cert-manager/cert-manager/pull/6116), [@jetstack-bot](https://github.com/jetstack-bot))
 
 ## v1.12.1
 

--- a/content/docs/releases/release-notes/release-notes-1.12.md
+++ b/content/docs/releases/release-notes/release-notes-1.12.md
@@ -3,25 +3,25 @@ title: Release 1.12
 description: 'cert-manager release notes: cert-manager 1.12'
 ---
 
-## v1.12.8
+## `v1.12.8`
 
 ### Known Issues
-- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if preferredChain is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
 
 ### Changes
 
 #### Bug or Regression
 
-- BUGFIX: LiteralSubjects with a #= value can result in memory issues due to faulty BER parser (github.com/go-asn1-ber/asn1-ber). ([#6773](https://github.com/cert-manager/cert-manager/pull/6773), [@jetstack-bot](https://github.com/jetstack-bot))
+- BUGFIX: `LiteralSubjects` with a #= value can result in memory issues due to faulty BER parser (`github.com/go-asn1-ber/asn1-ber`). ([#6773](https://github.com/cert-manager/cert-manager/pull/6773), [@jetstack-bot](https://github.com/jetstack-bot))
 
 #### Other (Cleanup or Flake)
 
 - Bump go to 1.20.14 ([#6733](https://github.com/cert-manager/cert-manager/pull/6733), [@SgtCoDFish](https://github.com/SgtCoDFish))
 - Cert-manager is now built with Go 1.20.13 ([#6629](https://github.com/cert-manager/cert-manager/pull/6629), [@SgtCoDFish](https://github.com/SgtCoDFish))
 - Fix CVE 2023 48795 by upgrading to golang.org/x/crypto@v0.17.0 ([#6678](https://github.com/cert-manager/cert-manager/pull/6678), [@wallrj](https://github.com/wallrj))
-- Fix GHSA-7ww5-4wqc-m92c by upgrading to `github.com/containerd/containerd@v1.7.12` ([#6689](https://github.com/cert-manager/cert-manager/pull/6689), [@wallrj](https://github.com/wallrj))
+- Fix `GHSA-7ww5-4wqc-m92c` by upgrading to `github.com/containerd/containerd@v1.7.12` ([#6689](https://github.com/cert-manager/cert-manager/pull/6689), [@wallrj](https://github.com/wallrj))
 
-## v1.12.7
+## `v1.12.7`
 
 This patch release contains fixes for the following security vulnerabilities in the cert-manager-controller:
 - [`GO-2023-2382`](https://pkg.go.dev/vuln/GO-2023-2382): Denial of service via chunk extensions in `net/http`
@@ -115,7 +115,7 @@ and these are included in this patch release.
 - `cloud.google.com/go/dataproc`: `v1.12.0`
 
 
-## v1.12.6
+## `v1.12.6`
 
 v1.12.6 fixes some CVE alerts and a Venafi issuer bug
 
@@ -130,7 +130,7 @@ v1.12.6 fixes some CVE alerts and a Venafi issuer bug
 
 - Bump go to 1.20.10 to address `CVE-2023-39325`. Also bumps base images. ([#6412](https://github.com/cert-manager/cert-manager/pull/6412), [@SgtCoDFish](https://github.com/SgtCoDFish))
 
-## v1.12.5
+## `v1.12.5`
 
 v1.12.5 contains a backport for a name collision bug that was found in v1.13.0
 
@@ -145,7 +145,7 @@ v1.12.5 contains a backport for a name collision bug that was found in v1.13.0
 - Updated base images to the latest version. ([#6372](https://github.com/cert-manager/cert-manager/pull/6372), [@inteon](https://github.com/inteon))
 - Upgrade Go from 1.20.7 to 1.20.8. ([#6371](https://github.com/cert-manager/cert-manager/pull/6371), [@jetstack-bot](https://github.com/jetstack-bot))
 
-## v1.12.4
+## `v1.12.4`
 
 v1.12.4 contains an important security fix that
 addresses [CVE-2023-29409](https://cve.report/CVE-2023-29409).
@@ -162,7 +162,7 @@ addresses [CVE-2023-29409](https://cve.report/CVE-2023-29409).
   ([#6318](https://github.com/cert-manager/cert-manager/pull/6318),
   [@maelvls](https://github.com/maelvls))
 
-## v1.12.3
+## `v1.12.3`
 
 v1.12.3 contains a bug fix for the cainjector which addresses a memory leak!
 
@@ -170,7 +170,7 @@ v1.12.3 contains a bug fix for the cainjector which addresses a memory leak!
 
 - BUGFIX\[cainjector\]: 1-character bug was causing invalid log messages and a memory leak ([#6235](https://github.com/cert-manager/cert-manager/pull/6235), [@jetstack-bot](https://github.com/jetstack-bot))
 
-## v1.12.2
+## `v1.12.2`
 
 v1.12.2 is a bugfix release, but includes a known issue. You should prefer
 upgrading to the latest patch version available for 1.12.
@@ -183,7 +183,7 @@ upgrading to the latest patch version available for 1.12.
 
 - BUGFIX: `cmctl check api --wait 0` exited without output; we now make sure we perform the API check at least once ([#6116](https://github.com/cert-manager/cert-manager/pull/6116), [@jetstack-bot](https://github.com/jetstack-bot))
 
-## v1.12.1
+## `v1.12.1`
 
 The v1.12.1 release contains a couple dependency bumps and changes to ACME
 external webhook library. Note that v1.12.1 contains a known issue, and you
@@ -206,7 +206,7 @@ See https://github.com/cert-manager/cert-manager/pull/6232 for context.
 - Updates Kubernetes libraries to `v0.27.2`. ([#6077](https://github.com/cert-manager/cert-manager/pull/6077), [@lucacome](https://github.com/lucacome))
 - Updates controller-runtime to `v0.15.0` ([#6098](https://github.com/cert-manager/cert-manager/pull/6098), [@lucacome](https://github.com/lucacome))
 
-## v1.12.0
+## `v1.12.0`
 
 cert-manager 1.12 brings support for JSON logging, a lower memory footprint, the
 support for ephemeral service account tokens with Vault, and the support of the

--- a/content/docs/releases/release-notes/release-notes-1.13.md
+++ b/content/docs/releases/release-notes/release-notes-1.13.md
@@ -3,6 +3,25 @@ title: Release 1.13
 description: 'cert-manager release notes: cert-manager 1.13'
 ---
 
+## v1.13.4
+
+### Known Issues
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if preferredChain is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+
+### Changes
+
+#### Bug or Regression
+
+- BUGFIX: LiteralSubjects with a #= value can result in memory issues due to faulty BER parser (github.com/go-asn1-ber/asn1-ber). ([#6772](https://github.com/cert-manager/cert-manager/pull/6772), [@jetstack-bot](https://github.com/jetstack-bot))
+
+#### Other (Cleanup or Flake)
+
+- Bump go to 1.20.14 ([#6736](https://github.com/cert-manager/cert-manager/pull/6736), [@jetstack-bot](https://github.com/jetstack-bot))
+- Cert-manager is now built with Go 1.20.12 ([#6544](https://github.com/cert-manager/cert-manager/pull/6544), [@wallrj](https://github.com/wallrj))
+- Cert-manager is now built with Go 1.20.13 ([#6630](https://github.com/cert-manager/cert-manager/pull/6630), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Fix CVE 2023 48795 by upgrading to golang.org/x/crypto@v0.17.0 ([#6675](https://github.com/cert-manager/cert-manager/pull/6675), [@wallrj](https://github.com/wallrj))
+- Fix GHSA-7ww5-4wqc-m92c by upgrading to `github.com/containerd/containerd@v1.7.12` ([#6684](https://github.com/cert-manager/cert-manager/pull/6684), [@wallrj](https://github.com/wallrj))
+
 ## v1.13.3
 
 This patch release contains fixes for the following security vulnerabilities in the cert-manager-controller:
@@ -78,14 +97,14 @@ v1.13.2 fixes some CVE alerts and contains fixes for:
 
 #### Bug or Regression
 
-- Bump `golang.org/x/net v0.15.0 => v0.17.0` as part of addressing `CVE-2023-44487` / `CVE-2023-39325` (#6432, @SgtCoDFish)
-- BUGFIX[helm]: Fix issue where webhook feature gates were only set if controller feature gates are set. (#6381, @jetstack-bot)
-- Fix runaway bug caused by multiple Certificate resources that point to the same Secret resource. (#6425, @jetstack-bot)
-- The Venafi issuer now properly resets the certificate and should no longer get stuck with `WebSDK CertRequest Module Requested Certificate` or `This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.`. (#6402, @jetstack-bot)
+- Bump `golang.org/x/net v0.15.0 => v0.17.0` as part of addressing `CVE-2023-44487` / `CVE-2023-39325` ([#6432](https://github.com/cert-manager/cert-manager/pull/6432), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- BUGFIX[helm]: Fix issue where webhook feature gates were only set if controller feature gates are set. ([#6381](https://github.com/cert-manager/cert-manager/pull/6381), [@jetstack-bot](https://github.com/jetstack-bot))
+- Fix runaway bug caused by multiple Certificate resources that point to the same Secret resource. ([#6425](https://github.com/cert-manager/cert-manager/pull/6425), [@jetstack-bot](https://github.com/jetstack-bot))
+- The Venafi issuer now properly resets the certificate and should no longer get stuck with `WebSDK CertRequest Module Requested Certificate` or `This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.`. ([#6402](https://github.com/cert-manager/cert-manager/pull/6402), [@jetstack-bot](https://github.com/jetstack-bot))
 
 #### Other (Cleanup or Flake)
 
-- Bump go to 1.20.10 to address `CVE-2023-39325`. Also bumps base images. (#6411, @SgtCoDFish)
+- Bump go to 1.20.10 to address `CVE-2023-39325`. Also bumps base images. ([#6411](https://github.com/cert-manager/cert-manager/pull/6411), [@SgtCoDFish](https://github.com/SgtCoDFish))
 
 ## v1.13.1
 
@@ -95,12 +114,12 @@ v1.13.1 contains a bugfix for a name collision bug in the StableCertificateReque
 
 #### Bug or Regression
 
-- BUGFIX: fix CertificateRequest name collision bug in StableCertificateRequestName feature. (#6358, @jetstack-bot)
+- BUGFIX: fix CertificateRequest name collision bug in StableCertificateRequestName feature. ([#6358](https://github.com/cert-manager/cert-manager/pull/6358), [@jetstack-bot](https://github.com/jetstack-bot))
 
 #### Other (Cleanup or Flake)
 
-- Upgrade `github.com/emicklei/go-restful/v3` to `v3.11.0` because `v3.10.2` is labeled as "DO NOT USE". (#6368, @inteon)
-- Upgrade Go from 1.20.7 to 1.20.8. (#6370, @jetstack-bot)
+- Upgrade `github.com/emicklei/go-restful/v3` to `v3.11.0` because `v3.10.2` is labeled as "DO NOT USE". ([#6368](https://github.com/cert-manager/cert-manager/pull/6368), [@inteon](https://github.com/inteon))
+- Upgrade Go from 1.20.7 to 1.20.8. ([#6370](https://github.com/cert-manager/cert-manager/pull/6370), [@jetstack-bot](https://github.com/jetstack-bot))
 
 ## v1.13.0
 

--- a/content/docs/releases/release-notes/release-notes-1.13.md
+++ b/content/docs/releases/release-notes/release-notes-1.13.md
@@ -3,16 +3,16 @@ title: Release 1.13
 description: 'cert-manager release notes: cert-manager 1.13'
 ---
 
-## v1.13.4
+## `v1.13.4`
 
 ### Known Issues
-- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if preferredChain is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
 
 ### Changes
 
 #### Bug or Regression
 
-- BUGFIX: LiteralSubjects with a #= value can result in memory issues due to faulty BER parser (github.com/go-asn1-ber/asn1-ber). ([#6772](https://github.com/cert-manager/cert-manager/pull/6772), [@jetstack-bot](https://github.com/jetstack-bot))
+- BUGFIX: `LiteralSubjects` with a #= value can result in memory issues due to faulty BER parser (`github.com/go-asn1-ber/asn1-ber`). ([#6772](https://github.com/cert-manager/cert-manager/pull/6772), [@jetstack-bot](https://github.com/jetstack-bot))
 
 #### Other (Cleanup or Flake)
 
@@ -20,9 +20,9 @@ description: 'cert-manager release notes: cert-manager 1.13'
 - Cert-manager is now built with Go 1.20.12 ([#6544](https://github.com/cert-manager/cert-manager/pull/6544), [@wallrj](https://github.com/wallrj))
 - Cert-manager is now built with Go 1.20.13 ([#6630](https://github.com/cert-manager/cert-manager/pull/6630), [@SgtCoDFish](https://github.com/SgtCoDFish))
 - Fix CVE 2023 48795 by upgrading to golang.org/x/crypto@v0.17.0 ([#6675](https://github.com/cert-manager/cert-manager/pull/6675), [@wallrj](https://github.com/wallrj))
-- Fix GHSA-7ww5-4wqc-m92c by upgrading to `github.com/containerd/containerd@v1.7.12` ([#6684](https://github.com/cert-manager/cert-manager/pull/6684), [@wallrj](https://github.com/wallrj))
+- Fix `GHSA-7ww5-4wqc-m92c` by upgrading to `github.com/containerd/containerd@v1.7.12` ([#6684](https://github.com/cert-manager/cert-manager/pull/6684), [@wallrj](https://github.com/wallrj))
 
-## v1.13.3
+## `v1.13.3`
 
 This patch release contains fixes for the following security vulnerabilities in the cert-manager-controller:
 - [`GO-2023-2334`](https://pkg.go.dev/vuln/GO-2023-2334): Decryption of malicious PBES2 JWE objects can consume unbounded system resources.
@@ -86,7 +86,7 @@ _Nothing has changed._
 #### Removed
 _Nothing has changed._
 
-## v1.13.2
+## `v1.13.2`
 
 v1.13.2 fixes some CVE alerts and contains fixes for:
 1. a CertificateRequest runaway situation in case two Certificate resources point to the same Secret target resource
@@ -106,7 +106,7 @@ v1.13.2 fixes some CVE alerts and contains fixes for:
 
 - Bump go to 1.20.10 to address `CVE-2023-39325`. Also bumps base images. ([#6411](https://github.com/cert-manager/cert-manager/pull/6411), [@SgtCoDFish](https://github.com/SgtCoDFish))
 
-## v1.13.1
+## `v1.13.1`
 
 v1.13.1 contains a bugfix for a name collision bug in the StableCertificateRequestName feature that was enabled by default in v1.13.0.
 
@@ -121,7 +121,7 @@ v1.13.1 contains a bugfix for a name collision bug in the StableCertificateReque
 - Upgrade `github.com/emicklei/go-restful/v3` to `v3.11.0` because `v3.10.2` is labeled as "DO NOT USE". ([#6368](https://github.com/cert-manager/cert-manager/pull/6368), [@inteon](https://github.com/inteon))
 - Upgrade Go from 1.20.7 to 1.20.8. ([#6370](https://github.com/cert-manager/cert-manager/pull/6370), [@jetstack-bot](https://github.com/jetstack-bot))
 
-## v1.13.0
+## `v1.13.0`
 
 cert-manager 1.13 brings support for DNS over HTTPS, support for loading options from a versioned
 config file for the cert-manager controller, and more. This release also includes the promotion of

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -61,7 +61,7 @@ without breaking users who have come to rely on the existing, documented behavio
 #### Bug or Regression
 
 - BUGFIX: Fixes issue with JSON-logging, where only a subset of the log messages were output as JSON. ([#6781](https://github.com/cert-manager/cert-manager/pull/6781), [@jetstack-bot](https://github.com/jetstack-bot))
-- BUGFIX: LiteralSubjects with a #= value can result in memory issues due to faulty BER parser (github.com/go-asn1-ber/asn1-ber). ([#6774](https://github.com/cert-manager/cert-manager/pull/6774), [@jetstack-bot](https://github.com/jetstack-bot))
+- BUGFIX: `LiteralSubjects` with a #= value can result in memory issues due to faulty BER parser (`github.com/go-asn1-ber/asn1-ber`). ([#6774](https://github.com/cert-manager/cert-manager/pull/6774), [@jetstack-bot](https://github.com/jetstack-bot))
 
 ## `v1.14.2`
 

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -14,10 +14,6 @@ support for creating [CA certificates with "Name Constraints" and "Authority Inf
 >
 > Read [The cert-manager Command Line Tool (cmctl) page](../../reference/cmctl.md) to learn more.
 
-## `v1.14.2`
-
-> 📢 When upgrading to cert-manager release 1.14, please skip `v1.14.0` and `v1.14.1` and install this patch version instead.
-
 ### Known Issues
 
 #### ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured - [#6755](https://github.com/cert-manager/cert-manager/pull/6755), [#6757](https://github.com/cert-manager/cert-manager/issues/6757)
@@ -56,6 +52,19 @@ without breaking users who have come to rely on the existing, documented behavio
 
   > ⚠️ There may be [clients that are incompatible with `DST Root CA X3`](https://github.com/mono/mono/issues/21233).
 
+## `v1.14.3`
+
+> 📢 When upgrading to cert-manager release 1.14, please skip `v1.14.0`, `v1.14.1` and `v1.14.2` and install this patch version instead.
+
+### Changes since `v1.14.2`
+
+#### Bug or Regression
+
+- BUGFIX: Fixes issue with JSON-logging, where only a subset of the log messages were output as JSON. ([#6781](https://github.com/cert-manager/cert-manager/pull/6781), [@jetstack-bot](https://github.com/jetstack-bot))
+- BUGFIX: LiteralSubjects with a #= value can result in memory issues due to faulty BER parser (github.com/go-asn1-ber/asn1-ber). ([#6774](https://github.com/cert-manager/cert-manager/pull/6774), [@jetstack-bot](https://github.com/jetstack-bot))
+
+## `v1.14.2`
+
 ### Changes since `v1.14.1`
 
 #### Bug or Regression
@@ -81,7 +90,7 @@ cert-manager `v1.14.1` fixes bugs found *during* the release of `v1.14.0`.
 
 ## `v1.14.0`
 
-> ⚠️ This version has known issues. Please install `v1.14.2` instead.
+> ⚠️ This version has known issues.
 >
 > During the release of `v1.14.0`, the Helm chart was found to use the wrong OCI image for the `cainjector` Deployment,
 > which caused the Helm installation and the static manifest based installation to fail.
@@ -99,7 +108,7 @@ cert-manager `v1.14.1` fixes bugs found *during* the release of `v1.14.0`.
 > and the working versions of the static manifest files attached to the draft `v1.14.0` GitHub release,
 > and that was then published.
 >
-> For these reasons, users are strongly advised to skip this version and install the `v1.14.1` Helm chart instead.
+> For these reasons, users are strongly advised to skip this version and install the latest patch Helm chart instead.
 
 ### Known Issues
 - During the release of `v1.14.0`, the Helm chart for this version was found to use the wrong OCI image for the `cainjector` Deployment,

--- a/content/docs/tutorials/certificate-defaults/README.md
+++ b/content/docs/tutorials/certificate-defaults/README.md
@@ -89,7 +89,7 @@ Once you have your cluster environment, install the required Kubernetes packages
 1. Set some environment variables for the helm chart versions:
 
     ```shell
-    export CERT_MANAGER_CHART_VERSION="v1.14.2" \
+    export CERT_MANAGER_CHART_VERSION="v1.14.3" \
         KYVERNO_CHART_VERSION="3.1.4" \
         INGRESS_NGINX_CHART_VERSION="4.9.0"
     ```


### PR DESCRIPTION
- updates references to the latest cert-manager version
- updates the release notes
- fixes missing links in existing release notes of these versions