### PR TITLE
Introduce variables for versions

### DIFF
--- a/content/docs/contributing/policy.md
+++ b/content/docs/contributing/policy.md
@@ -108,7 +108,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.8.0
+    version: [[VAR::cert_manager_latest_version]]
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled

--- a/content/docs/installation/README.md
+++ b/content/docs/installation/README.md
@@ -12,7 +12,7 @@ Learn about the various ways you can install cert-manager and how to choose betw
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.yaml
 ```
 
 📖 Read more about [installing cert-manager using kubectl apply and static manifests](./kubectl.md).

--- a/content/docs/installation/code-signing.md
+++ b/content/docs/installation/code-signing.md
@@ -19,7 +19,7 @@ key.
 For all cert-manager versions from `v1.8.0` and later, cert-manager container images are signed and verifiable using [`cosign`](https://docs.sigstore.dev/cosign/overview).
 
 ```console
-IMAGE_TAG=v1.14.3  # change as needed
+IMAGE_TAG=[[VAR::cert_manager_latest_version]]  # change as needed
 KEY=https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
 cosign verify --signature-digest-algorithm sha512 --insecure-ignore-tlog --key $KEY quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --insecure-ignore-tlog --key $KEY quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG

--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -47,7 +47,7 @@ section below for details on each method.
 > Recommended for production installations
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -70,7 +70,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.3 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set installCRDs=true
 ```
 
@@ -83,7 +83,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.3 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set installCRDs=true
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
@@ -114,7 +114,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.14.3
+    version: [[VAR::cert_manager_latest_version]]
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -148,7 +148,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.14.3 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/docs/installation/kubectl.md
+++ b/content/docs/installation/kubectl.md
@@ -21,7 +21,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/docs/installation/operator-lifecycle-manager.md
+++ b/content/docs/installation/operator-lifecycle-manager.md
@@ -75,7 +75,7 @@ spec:
   name: cert-manager
 ...
 status:
-  currentCSV: cert-manager.v1.7.1
+  currentCSV: cert-manager.[[VAR::cert_manager_latest_version]]
   state: AtLatestKnown
 ...
 ```
@@ -218,7 +218,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.14.3 \
+kubectl patch csv cert-manager.[[VAR::cert_manager_latest_version]] \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```

--- a/content/docs/troubleshooting/webhook.md
+++ b/content/docs/troubleshooting/webhook.md
@@ -466,7 +466,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.8.0 \
+  --version [[VAR::cert_manager_latest_version]] \
   --set webhook.securePort=10260
 ```
 

--- a/content/docs/tutorials/acme/pomerium-ingress.md
+++ b/content/docs/tutorials/acme/pomerium-ingress.md
@@ -65,7 +65,7 @@ This tutorial covers installing the [Pomerium Ingress Controller](https://pomeri
 Install cert-manager using any of the methods documented in the [Installation](https://cert-manager.io/docs/installation/) section of the cert-manager docs. The simplest method is to download and apply the provided manifest:
 
 ```sh
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.yaml
 ```
 
 ## Configure Let's Encrypt Issuer

--- a/content/docs/tutorials/certificate-defaults/README.md
+++ b/content/docs/tutorials/certificate-defaults/README.md
@@ -89,7 +89,7 @@ Once you have your cluster environment, install the required Kubernetes packages
 1. Set some environment variables for the helm chart versions:
 
     ```shell
-    export CERT_MANAGER_CHART_VERSION="v1.14.3" \
+    export CERT_MANAGER_CHART_VERSION="[[VAR::cert_manager_latest_version]]" \
         KYVERNO_CHART_VERSION="3.1.4" \
         INGRESS_NGINX_CHART_VERSION="4.9.0"
     ```

--- a/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
+++ b/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
@@ -295,7 +295,7 @@ So finally we are ready to start creating an SSL certificate for our website.
 The first thing you need to do is install cert-manager, and we'll install it the easy using `kubectl` as follows:
 
 ```
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.yaml
 ```
 
 This will create three Deployments, and a bunch of Services and Pods in a new namespace called `cert-manager`.

--- a/content/docs/tutorials/zerossl/zerossl.md
+++ b/content/docs/tutorials/zerossl/zerossl.md
@@ -46,7 +46,7 @@ installCRDs: true
 
 Install it using helm:
 ```
-helm upgrade  --install --namespace cert-manager  --version v1.8.2 cert-manager jetstack/cert-manager -f values.yaml 
+helm upgrade  --install --namespace cert-manager  --version [[VAR::cert_manager_latest_version]] cert-manager jetstack/cert-manager -f values.yaml 
 ```
 
 ## Configure your DNS records

--- a/content/docs/usage/istio-csr/installation.md
+++ b/content/docs/usage/istio-csr/installation.md
@@ -35,13 +35,13 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 
 # install cert-manager CRDs
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.crds.yaml
 
 # install cert-manager; this might take a little time
 helm install cert-manager jetstack/cert-manager \
 	--namespace cert-manager \
 	--create-namespace \
-	--version v1.8.0
+	--version [[VAR::cert_manager_latest_version]]
 
 # We need this namespace to exist since our cert will be placed there
 kubectl create namespace istio-system

--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,0 +1,3 @@
+{
+    "cert_manager_latest_version": "v1.14.3"
+}

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -29,6 +29,12 @@ export async function fetchDocsManifest(docsFolder) {
   return JSON.parse(res)
 }
 
+export async function fetchDocsVariables(docsFolder) {
+  const path = `/${docsFolder}/variables.json`
+  const res = await getRawFile(path)
+  return JSON.parse(res)
+}
+
 export function findRouteByPath(path, routes) {
   for (const route of routes) {
     if (route.path && removeFromLast(route.path, DOCS_EXTENSION) === path) {

--- a/lib/remark-plugins/variable/index.js
+++ b/lib/remark-plugins/variable/index.js
@@ -1,0 +1,39 @@
+// This file originates from https://github.com/facebook/docusaurus/issues/395#issuecomment-1727777067
+
+import { visit } from 'unist-util-visit'
+
+export default function plugin(options) {
+    return async (ast) => {
+        visit(ast, ['text', 'code', 'inlineCode', 'link'], (node) => {
+            // Replace all occurrences of VAR::varName with the value of varName
+            let value;
+            switch (node.type) {
+                case "link":
+                    value = node.url;
+                    break;
+
+                case "text":
+                case "code":
+                case "inlineCode":
+                    value = node.value;
+                break;
+            }
+
+            value = value.replace(/\[\[VAR::([a-zA-Z_]+)\]\]/ig, (match, varName) => {
+                return options.replacements[varName] || match;
+            });
+
+            switch (node.type) {
+                case "link":
+                    node.url = value;
+                    break;
+
+                case "text":
+                case "code":
+                case "inlineCode":
+                    node.value = value;
+                    break;
+            }
+        });
+    }
+}

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -19,12 +19,14 @@ import remarkHeadingId from 'lib/remark-plugins/heading-ids'
 import remarkExternalLinks from 'remark-external-links'
 import remarkInternalLinks from 'lib/remark-plugins/links'
 import remarkRewriteImages from 'lib/remark-plugins/images'
+import remarkVariable from 'lib/remark-plugins/variable'
 import {
   findRouteByPath,
   replaceDefaultPath,
   getSlug,
   getPaths,
-  fetchDocsManifest
+  fetchDocsManifest,
+  fetchDocsVariables
 } from 'lib/docs'
 import { getRawFile } from 'lib/files'
 
@@ -36,7 +38,11 @@ export async function pageProps({ params }) {
 
   const slugger = new GithubSlugger()
   const manifest = await fetchDocsManifest(docsFolder).catch((error) => {
-    if (error.status === 404) return
+    if (error.status === 404 || error.code === 'ENOENT') return
+    throw error
+  })
+  const variables = await fetchDocsVariables(docsFolder).catch((error) => {
+    if (error.status === 404 || error.code === 'ENOENT') return
     throw error
   })
   const { slug } = getSlug(params)
@@ -121,6 +127,12 @@ export async function pageProps({ params }) {
               trailingSlash: trailingSlash,
               rootPath: route.path,
               debug: (process.env.DEBUG === 'true')
+            }
+          ],
+          [
+            remarkVariable,
+            {
+              replacements: variables,
             }
           ]
         ]


### PR DESCRIPTION
Introduces a new variable format `[[VAR::cert_manager_latest_version]]` which can be used inside codeblocks and reads variables from the `variables.json` file.
The solution is based on https://github.com/facebook/docusaurus/issues/395#issuecomment-1727777067 and works around an issue with MDX which does not allow you to have variables in codeblocks (https://github.com/orgs/mdx-js/discussions/2288).