### PR TITLE
On the approver-policy installation page, use the [[VAR::cert_manager_latest_version]] variable

### DIFF
--- a/content/docs/policy/approval/approver-policy/installation.md
+++ b/content/docs/policy/approval/approver-policy/installation.md
@@ -34,7 +34,7 @@ helm upgrade cert-manager jetstack/cert-manager \
   --install \
   --create-namespace \
   --namespace cert-manager \
-  --version REPLACE-WITH-YOUR-CERT-MANAGER-VERSION \
+  --version [[VAR::cert_manager_latest_version]] \
   --set installCRDs=true \
   --set extraArgs={--controllers='*\,-certificaterequests-approver'} # ⚠ Disable cert-manager's built-in approver
 ```


### PR DESCRIPTION
Instead of `REPLACE-WITH-YOUR-CERT-MANAGER-VERSION`, we can now use `[[VAR::cert_manager_latest_version]]` which is dynamically replaced with the latest cert-manager version.