### PR TITLE
Add release notes for v1.14.4, v1.13.5 and v1.12.9

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.12.md
+++ b/content/docs/releases/release-notes/release-notes-1.12.md
@@ -3,6 +3,25 @@ title: Release 1.12
 description: 'cert-manager release notes: cert-manager 1.12'
 ---
 
+## `v1.12.9`
+
+### Known Issues
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+
+### Changes
+
+#### Bug or Regression
+
+- Allow `cert-manager.io/allow-direct-injection` in annotations ([#6811](https://github.com/cert-manager/cert-manager/pull/6811), [@jetstack-bot](https://github.com/jetstack-bot))
+- BUGFIX: JKS and PKCS12 stores now contain the full set of CAs specified by an issuer ([#6813](https://github.com/cert-manager/cert-manager/pull/6813), [@inteon](https://github.com/inteon))
+- BUGFIX: fix race condition due to registering and using global `runtime.Scheme` variables ([#6833](https://github.com/cert-manager/cert-manager/pull/6833), [@inteon](https://github.com/inteon))
+
+#### Other (Cleanup or Flake)
+
+- Bump base images to the latest version. ([#6843](https://github.com/cert-manager/cert-manager/pull/6843), [@jetstack-bot](https://github.com/jetstack-bot))
+- Upgrade go to 1.21.8: fixes `CVE-2024-24783` ([#6826](https://github.com/cert-manager/cert-manager/pull/6826), [@jetstack-bot](https://github.com/jetstack-bot))
+- Upgrade `google.golang.org/protobuf`: fixing `GO-2024-2611` ([#6830](https://github.com/cert-manager/cert-manager/pull/6830), [@inteon](https://github.com/inteon))
+
 ## `v1.12.8`
 
 ### Known Issues

--- a/content/docs/releases/release-notes/release-notes-1.13.md
+++ b/content/docs/releases/release-notes/release-notes-1.13.md
@@ -3,6 +3,25 @@ title: Release 1.13
 description: 'cert-manager release notes: cert-manager 1.13'
 ---
 
+## `v1.13.5`
+
+### Known Issues
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+
+### Changes
+
+#### Bug or Regression
+
+- Allow `cert-manager.io/allow-direct-injection` in annotations ([#6810](https://github.com/cert-manager/cert-manager/pull/6810), [@jetstack-bot](https://github.com/jetstack-bot))
+- BUGFIX: JKS and PKCS12 stores now contain the full set of CAs specified by an issuer ([#6814](https://github.com/cert-manager/cert-manager/pull/6814), [@inteon](https://github.com/inteon))
+- BUGFIX: fix race condition due to registering and using global `runtime.Scheme` variables ([#6832](https://github.com/cert-manager/cert-manager/pull/6832), [@inteon](https://github.com/inteon))
+
+#### Other (Cleanup or Flake)
+
+- Bump base images to the latest version. ([#6841](https://github.com/cert-manager/cert-manager/pull/6841), [@inteon](https://github.com/inteon))
+- Upgrade go to 1.21.8: fixes `CVE-2024-24783` ([#6824](https://github.com/cert-manager/cert-manager/pull/6824), [@inteon](https://github.com/inteon))
+- Upgrade `google.golang.org/protobuf`: fixing `GO-2024-2611` ([#6828](https://github.com/cert-manager/cert-manager/pull/6828), [@inteon](https://github.com/inteon))
+
 ## `v1.13.4`
 
 ### Known Issues

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -52,9 +52,26 @@ without breaking users who have come to rely on the existing, documented behavio
 
   > ⚠️ There may be [clients that are incompatible with `DST Root CA X3`](https://github.com/mono/mono/issues/21233).
 
-## `v1.14.3`
+## `v1.14.4`
 
-> 📢 When upgrading to cert-manager release 1.14, please skip `v1.14.0`, `v1.14.1` and `v1.14.2` and install this patch version instead.
+> 📢 When upgrading to cert-manager release 1.14, please skip `v1.14.0`, `v1.14.1`, `v1.14.2` and `v1.14.3` and install this patch version instead.
+
+### Changes since `v1.14.3`
+
+#### Bug or Regression
+
+- Allow `cert-manager.io/allow-direct-injection` in annotations ([#6809](https://github.com/cert-manager/cert-manager/pull/6809), [@jetstack-bot](https://github.com/jetstack-bot))
+- BUGFIX: JKS and PKCS12 stores now contain the full set of CAs specified by an issuer ([#6812](https://github.com/cert-manager/cert-manager/pull/6812), [@jetstack-bot](https://github.com/jetstack-bot))
+- BUGFIX: cainjector leader election flag/ config option defaults are missing ([#6819](https://github.com/cert-manager/cert-manager/pull/6819), [@jetstack-bot](https://github.com/jetstack-bot))
+
+#### Other (Cleanup or Flake)
+
+- Bump base images. ([#6842](https://github.com/cert-manager/cert-manager/pull/6842), [@inteon](https://github.com/inteon))
+- Upgrade Helm: fix `CVE-2024-26147` alert ([#6834](https://github.com/cert-manager/cert-manager/pull/6834), [@inteon](https://github.com/inteon))
+- Upgrade go to 1.21.8: fixes `CVE-2024-24783` ([#6825](https://github.com/cert-manager/cert-manager/pull/6825), [@jetstack-bot](https://github.com/jetstack-bot))
+- Upgrade `google.golang.org/protobuf`: fixing `GO-2024-2611` ([#6829](https://github.com/cert-manager/cert-manager/pull/6829), [@inteon](https://github.com/inteon))
+
+## `v1.14.3`
 
 ### Changes since `v1.14.2`
 

--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,3 +1,3 @@
 {
-    "cert_manager_latest_version": "v1.14.3"
+    "cert_manager_latest_version": "v1.14.4"
 }


### PR DESCRIPTION
Adds release notes for:
https://github.com/cert-manager/cert-manager/releases/tag/v1.14.4
https://github.com/cert-manager/cert-manager/releases/tag/v1.13.5
https://github.com/cert-manager/cert-manager/releases/tag/v1.12.9

And bumps the latest cert-manager version to v1.14.4