### PR TITLE
Use version variables for the 1.12 and 1.13 docs

### DIFF
--- a/content/v1.12-docs/installation/README.md
+++ b/content/v1.12-docs/installation/README.md
@@ -12,7 +12,7 @@ Learn about the various ways you can install cert-manager and how to choose betw
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.7/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.yaml
 ```
 
 📖 Read more about [installing cert-manager using kubectl apply and static manifests](./kubectl.md).

--- a/content/v1.12-docs/installation/helm.md
+++ b/content/v1.12-docs/installation/helm.md
@@ -44,7 +44,7 @@ or using the `installCRDs` option when installing the Helm chart.
 
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.7/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -65,7 +65,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.12.7 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set installCRDs=true
 ```
 
@@ -78,7 +78,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.12.7 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set installCRDs=true
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
@@ -109,7 +109,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.12.7
+    version: [[VAR::cert_manager_latest_version]]
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -140,7 +140,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.12.7 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/v1.12-docs/installation/kubectl.md
+++ b/content/v1.12-docs/installation/kubectl.md
@@ -19,7 +19,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.7/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/v1.12-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.12-docs/installation/operator-lifecycle-manager.md
@@ -217,7 +217,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.12.7 \
+kubectl patch csv cert-manager.[[VAR::cert_manager_latest_version]] \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```

--- a/content/v1.12-docs/variables.json
+++ b/content/v1.12-docs/variables.json
@@ -1,0 +1,3 @@
+{
+    "cert_manager_latest_version": "v1.12.9"
+}

--- a/content/v1.13-docs/installation/README.md
+++ b/content/v1.13-docs/installation/README.md
@@ -12,7 +12,7 @@ Learn about the various ways you can install cert-manager and how to choose betw
 The default static configuration can be installed as follows:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.yaml
 ```
 
 📖 Read more about [installing cert-manager using kubectl apply and static manifests](./kubectl.md).

--- a/content/v1.13-docs/installation/code-signing.md
+++ b/content/v1.13-docs/installation/code-signing.md
@@ -22,7 +22,7 @@ The simplest way to verify signatures is to download the public key and then pas
 
 ```console
 curl -sSOL https://cert-manager.io/public-keys/cert-manager-pubkey-2021-09-20.pem
-IMAGE_TAG=v1.13.3  # change as needed
+IMAGE_TAG=[[VAR::cert_manager_latest_version]]  # change as needed
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-acmesolver:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-cainjector:$IMAGE_TAG
 cosign verify --signature-digest-algorithm sha512 --key cert-manager-pubkey-2021-09-20.pem quay.io/jetstack/cert-manager-ctl:$IMAGE_TAG

--- a/content/v1.13-docs/installation/helm.md
+++ b/content/v1.13-docs/installation/helm.md
@@ -47,7 +47,7 @@ section below for details on each method.
 > Recommended for production installations
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.crds.yaml
 ```
 
 ##### Option 2: install CRDs as part of the Helm release
@@ -70,7 +70,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.3 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set installCRDs=true
 ```
 
@@ -83,7 +83,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.3 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set installCRDs=true
   --set prometheus.enabled=false \  # Example: disabling prometheus using a Helm parameter
   --set webhook.timeoutSeconds=4   # Example: changing the webhook timeout using a Helm parameter
@@ -114,7 +114,7 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
-    version: v1.13.3
+    version: [[VAR::cert_manager_latest_version]]
     repository: https://charts.jetstack.io
     alias: cert-manager
     condition: cert-manager.enabled
@@ -148,7 +148,7 @@ helm template \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.3 \
+  --version [[VAR::cert_manager_latest_version]] \
   # --set prometheus.enabled=false \   # Example: disabling prometheus using a Helm parameter
   # --set installCRDs=true \           # Uncomment to also template CRDs
   > cert-manager.custom.yaml

--- a/content/v1.13-docs/installation/kubectl.md
+++ b/content/v1.13-docs/installation/kubectl.md
@@ -19,7 +19,7 @@ are included in a single YAML manifest file:
 Install all cert-manager components:
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.yaml
 ```
 
 By default, cert-manager will be installed into the `cert-manager`

--- a/content/v1.13-docs/installation/operator-lifecycle-manager.md
+++ b/content/v1.13-docs/installation/operator-lifecycle-manager.md
@@ -217,7 +217,7 @@ The following JSON patch will append `-v=6` to command line arguments of the cer
 (the first container of the first Deployment).
 
 ```bash
-kubectl patch csv cert-manager.v1.13.3 \
+kubectl patch csv cert-manager.[[VAR::cert_manager_latest_version]] \
   --type json \
   -p '[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-", "value": "-v=6" }]'
 ```

--- a/content/v1.13-docs/variables.json
+++ b/content/v1.13-docs/variables.json
@@ -1,0 +1,3 @@
+{
+    "cert_manager_latest_version": "v1.13.5"
+}


### PR DESCRIPTION
Similar to https://github.com/cert-manager/website/pull/1436, but for the 1.12 and 1.13 docs.