### PR TITLE
Explain why to use priorityClassName: system-cluster-critical in production

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -288,6 +288,7 @@ YAMLs
 accessors
 acme-dns
 ad-hoc
+add-ons
 allowlist
 alrs
 analyse

--- a/public/docs/installation/best-practice/values.best-practice.yaml
+++ b/public/docs/installation/best-practice/values.best-practice.yaml
@@ -4,6 +4,8 @@
 #
 # Read the rationale for these values in:
 # * https://cert-manager.io/docs/installation/best-practice/
+global:
+  priorityClassName: system-cluster-critical
 
 replicaCount: 2
 podDisruptionBudget:


### PR DESCRIPTION
**Preview**: https://deploy-preview-1444--cert-manager-website.netlify.app/docs/installation/best-practice/#priority-class-name

I've done some research into the use-cases for setting priorityClassName and what priority class to use.
I think cert-manager should use  the built in priority class `system-cluster-critical`,
and I've tried to justify that in the document.

It turns out that if you want to use that built in priority class, you (always?) also have to create a ResourceQuota resource, and I've tried to explain that too.

@hawksight interested to know what you think about this new recommendation.

Links:
* https://github.com/cert-manager/cert-manager/pull/1190
* https://github.com/cert-manager/trust-manager/pull/176
* https://github.com/cert-manager/approver-policy/pull/403
* https://github.com/cert-manager/csi-driver/pull/124
* https://github.com/cert-manager/csi-driver-spiffe/pull/20
* https://github.com/jetstack/google-cas-issuer/pull/96
* https://github.com/cert-manager/aws-privateca-issuer/pull/286
* https://linkerd.io/2.15/tasks/customize-install/#add-priorityclass
* https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/pod-priority-resourcequota.md
* https://github.com/fluxcd/flux2/pull/3802
* https://goteleport.com/docs/reference/helm-reference/teleport-cluster/#priorityclassname
* https://github.com/argoproj/argo-helm/pull/1212