### PR TITLE
Remove approver-policy versions from install instructions

### DIFF
--- a/content/docs/policy/approval/approver-policy/installation.md
+++ b/content/docs/policy/approval/approver-policy/installation.md
@@ -63,7 +63,6 @@ helm repo add jetstack https://charts.jetstack.io --force-update
 helm upgrade cert-manager-approver-policy jetstack/cert-manager-approver-policy \
   --install \
   --namespace cert-manager \
-  --version [[VAR::approver_policy_latest_version]] \
   --wait
 ```
 
@@ -81,7 +80,6 @@ set the following values when installing:
 helm upgrade cert-manager-approver-policy jetstack/cert-manager-approver-policy \
   --install \
   --namespace cert-manager \
-  --version [[VAR::approver_policy_latest_version]] \
   --wait \
   --set app.approveSignerNames="{\
 issuers.cert-manager.io/*,clusterissuers.cert-manager.io/*,\

--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,4 +1,3 @@
 {
-    "cert_manager_latest_version": "v1.14.5",
-    "approver_policy_latest_version": "v0.13.0"
+    "cert_manager_latest_version": "v1.14.5"
 }


### PR DESCRIPTION
@wallrj requested these versions to be removed, see https://github.com/cert-manager/website/pull/1439#pullrequestreview-1933998056.