### PR TITLE
Update install instructions, making them consistent for all sub-projects

### DIFF
--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -28,13 +28,7 @@ Notably, the "Helm stable repository" version of cert-manager is deprecated and 
 helm repo add jetstack https://charts.jetstack.io --force-update
 ```
 
-#### 2. Update your local Helm chart repository cache:
-
-```bash
-helm repo update
-```
-
-#### 3. Install `CustomResourceDefinitions`
+#### 2. Install `CustomResourceDefinitions`
 
 cert-manager requires a number of CRD resources, which can  be installed manually using `kubectl`,
 or using the `installCRDs` option when installing the Helm chart. Both options
@@ -61,7 +55,7 @@ Uncomment the relevant line in the next steps to enable this.
 
 Note that if you're using a `helm` version based on Kubernetes `v1.18` or below (Helm `v3.2`), `installCRDs` will not work with cert-manager `v0.16`. See the [v0.16 upgrade notes](../releases/upgrading/upgrading-0.15-0.16.md#helm) for more details.
 
-#### 4. Install cert-manager
+#### 3. Install cert-manager
 
 To install the cert-manager Helm chart, use the [Helm install command](https://helm.sh/docs/helm/helm_install/) as described below.
 

--- a/content/docs/policy/approval/approver-policy/installation.md
+++ b/content/docs/policy/approval/approver-policy/installation.md
@@ -30,9 +30,11 @@ extraArgs:
 Here's a example which reconfigure an installed cert-manager to run without auto-approver:
 
 ```terminal
+existing_cert_manager_version=$(helm get metadata -n cert-manager cert-manager | grep '^VERSION' | awk '{ print $2 }')
 helm upgrade cert-manager jetstack/cert-manager \
   --reuse-values \
   --namespace cert-manager \
+  --version $existing_cert_manager_version \
   --set extraArgs={--controllers='*\,-certificaterequests-approver'} # ⚠ Disable cert-manager's built-in approver
 ```
 

--- a/content/docs/policy/approval/approver-policy/installation.md
+++ b/content/docs/policy/approval/approver-policy/installation.md
@@ -27,22 +27,15 @@ extraArgs:
  - "--controllers=*,-certificaterequests-approver" # ⚠ Disable cert-manager's built-in approver
 ```
 
-Here's a full example which will install cert-manager or reconfigure it if it is already installed:
+Here's a example which reconfigure an installed cert-manager to run without auto-approver:
 
 ```terminal
 helm upgrade cert-manager jetstack/cert-manager \
-  --install \
-  --create-namespace \
+  --reuse-values \
   --namespace cert-manager \
-  --version [[VAR::cert_manager_latest_version]] \
-  --set installCRDs=true \
   --set extraArgs={--controllers='*\,-certificaterequests-approver'} # ⚠ Disable cert-manager's built-in approver
 ```
 
-> ℹ️ The `--set installCRDs=true` setting is a convenient way to install the
-> cert-manager CRDS, but it is optional and has some drawbacks.
-> Read [Helm: Installing Custom Resource Definitions](https://deploy-preview-1216--cert-manager-website.netlify.app/docs/installation/helm/#3-install-customresourcedefinitions) to learn more.
->
 > ℹ️ Be sure to customize the cert-manager controller `extraArgs`,
 > which are at the top level of the values file.
 > *Do not* change the `webhook.extraArgs`, `startupAPICheck.extraArgs` or `cainjector.extraArgs` settings.

--- a/content/docs/trust/trust-manager/installation.md
+++ b/content/docs/trust/trust-manager/installation.md
@@ -10,18 +10,24 @@ description: 'Installation guide for trust-manager'
 Helm is the easiest way to install trust-manager and comes with a publicly trusted certificate bundle package
 (for the`useDefaultCAs` source) derived from Debian containers.
 
-When installed via Helm, trust-manager has a dependency on cert-manager for provisioning an application certificate,
-and as such trust-manager is also installed into the cert-manager namespace.
-
 ```bash
 helm repo add jetstack https://charts.jetstack.io --force-update
+```
 
-helm upgrade cert-manager jetstack/cert-manager \
-  --install \
-  --create-namespace \
+When installed via Helm, trust-manager has a dependency on cert-manager for provisioning an application certificate,
+and as such cert-manager must also be installed into the cert-manager namespace.
+If you have not already installed cert-manager, you can install it using the following command:
+
+```bash
+# Run this command only if you haven't installed cert-manager already
+helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
+  --create-namespace \
+  --version [[VAR::cert_manager_latest_version]] \
   --set installCRDs=true
+```
 
+```bash
 helm upgrade trust-manager jetstack/trust-manager \
   --install \
   --namespace cert-manager \

--- a/content/docs/tutorials/getting-started-aks-letsencrypt/README.md
+++ b/content/docs/tutorials/getting-started-aks-letsencrypt/README.md
@@ -152,14 +152,13 @@ Now you can install and configure cert-manager.
 Install cert-manager using `helm` as follows:
 
 ```bash
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-helm upgrade cert-manager jetstack/cert-manager \
-    --install \
-    --create-namespace \
-    --wait \
-    --namespace cert-manager \
-    --set installCRDs=true
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version [[VAR::cert_manager_latest_version]] \
+  --set installCRDs=true
 ```
 
 This will create three Deployments and some Services and Pods in a new namespace called `cert-manager`.
@@ -396,10 +395,12 @@ The labels can be configured using the Helm values file below:
 🔗 <a href="values.yaml">`values.yaml`</a>
 
 ```bash
+existing_cert_manager_version=$(helm get metadata -n cert-manager cert-manager | grep '^VERSION' | awk '{ print $2 }')
 helm upgrade cert-manager jetstack/cert-manager \
-    --namespace cert-manager \
-    --reuse-values \
-    --values values.yaml
+  --reuse-values \
+  --namespace cert-manager \
+  --version $existing_cert_manager_version \
+  --values values.yaml
 ```
 
 The newly rolled out cert-manager Pod will have some new environment variables set,

--- a/content/docs/usage/csi-driver-spiffe/installation.md
+++ b/content/docs/usage/csi-driver-spiffe/installation.md
@@ -21,9 +21,11 @@ the [security considerations](./README.md#security-considerations) section for m
 Here's a example which reconfigure an installed cert-manager to run without auto-approver:
 
 ```terminal
+existing_cert_manager_version=$(helm get metadata -n cert-manager cert-manager | grep '^VERSION' | awk '{ print $2 }')
 helm upgrade cert-manager jetstack/cert-manager \
   --reuse-values \
   --namespace cert-manager \
+  --version $existing_cert_manager_version \
   --set extraArgs={--controllers='*\,-certificaterequests-approver'} # ⚠ Disable cert-manager's built-in approver
 ```
 

--- a/content/docs/usage/csi-driver-spiffe/installation.md
+++ b/content/docs/usage/csi-driver-spiffe/installation.md
@@ -18,17 +18,13 @@ race with cert-manager and policy enforcement will become useless.
 Policy enforcement is absolutely critical for using csi-driver-spiffe safely. See
 the [security considerations](./README.md#security-considerations) section for more details.
 
-```bash
-helm repo add jetstack https://charts.jetstack.io --force-update
+Here's a example which reconfigure an installed cert-manager to run without auto-approver:
 
-# NOTE: This isn't the usual cert-manager install process;
-# we're disabling the cert-manager approver.
-# See explanation above!
-
-helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager \
-  --set extraArgs={--controllers='*\,-certificaterequests-approver'} \
-  --set installCRDs=true \
-  --create-namespace
+```terminal
+helm upgrade cert-manager jetstack/cert-manager \
+  --reuse-values \
+  --namespace cert-manager \
+  --set extraArgs={--controllers='*\,-certificaterequests-approver'} # ⚠ Disable cert-manager's built-in approver
 ```
 
 ### 2. Configure an Issuer / ClusterIssuer
@@ -110,12 +106,17 @@ Note that the `issuer.name`, `issuer.kind` and `issuer.group` will need to be ch
 the issuer you're actually using!
 
 ```bash
-helm upgrade -i -n cert-manager cert-manager-csi-driver-spiffe jetstack/cert-manager-csi-driver-spiffe --wait \
- --set "app.logLevel=1" \
- --set "app.trustDomain=my.trust.domain" \
- --set "app.issuer.name=csi-driver-spiffe-ca" \
- --set "app.issuer.kind=ClusterIssuer" \
- --set "app.issuer.group=cert-manager.io"
+helm repo add jetstack https://charts.jetstack.io --force-update
+
+helm upgrade cert-manager-csi-driver-spiffe jetstack/cert-manager-csi-driver-spiffe \
+  --install \
+  --namespace cert-manager \
+  --wait \
+  --set "app.logLevel=1" \
+  --set "app.trustDomain=my.trust.domain" \
+  --set "app.issuer.name=csi-driver-spiffe-ca" \
+  --set "app.issuer.kind=ClusterIssuer" \
+  --set "app.issuer.group=cert-manager.io"
 ```
 
 ## Usage

--- a/content/docs/usage/csi-driver/installation.md
+++ b/content/docs/usage/csi-driver/installation.md
@@ -13,16 +13,12 @@ To install csi-driver, use helm:
 
 ```terminal
 helm repo add jetstack https://charts.jetstack.io --force-update
-helm upgrade -i -n cert-manager cert-manager-csi-driver jetstack/cert-manager-csi-driver --wait
+
+helm upgrade cert-manager-csi-driver jetstack/cert-manager-csi-driver \
+  --install \
+  --namespace cert-manager \
+  --wait
 ```
-
-Or apply the static manifests to your cluster:
-
-```terminal
-helm repo add jetstack https://charts.jetstack.io --force-update
-helm template jetstack/cert-manager-csi-driver | kubectl apply -n cert-manager -f -
-```
-
 
 You can verify the installation has completed correctly by checking the presence
 of the CSIDriver resource as well as a CSINode resource present for each node,


### PR DESCRIPTION
*Goal:*
Reach base level of consistency for installation commands across all installation pages.
Once we reach consistency, we can think about improving these instructions (keeping in mind the CRD changes coming in 1.15).

Next steps:
1. Prepare 1.15 release (drastically simplify the CRD install section & use the single fool-proof install command everywhere)