### PR TITLE
BUGFIX: javascript bug causing incorrect date in URL

### DIFF
--- a/lib/announcements.js
+++ b/lib/announcements.js
@@ -145,7 +145,7 @@ export async function pageProps({params}) {
 function getSlug(date, slug) {
   return [
     '' + date.getFullYear(),
-    ('0' + date.getMonth()+1).slice(-2),
+    ('0' + (date.getMonth()+1)).slice(-2),
     ('0' + date.getDate()).slice(-2),
     slug,
   ]

--- a/public/_redirects
+++ b/public/_redirects
@@ -228,3 +228,6 @@ https://docs.cert-manager.io/* https://cert-manager.io/docs/:splat 302!
 
 # Moved the istio-csr tutorial to its own installation page
 /docs/tutorials/istio-csr/istio-csr/ /docs/usage/istio-csr/installation/ 301!
+
+# Redirect page with incorrect date in URL
+/announcements/2024/21/18/cert-manager-security-audit/ /announcements/2024/03/18/cert-manager-security-audit/ 301!


### PR DESCRIPTION
The url for the blogpost is `https://cert-manager.io/announcements/2024/21/18/cert-manager-security-audit/` instead of `https://cert-manager.io/announcements/2024/03/18/cert-manager-security-audit/`.
This is due to type casting and an incorrect order of operations.
This PR fixes the bug and adds a redirect such that the old URL keeps working.