### PR TITLE
Updates following releases of 1.12.10, 1.13.6, 1.14.5

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -89,6 +89,7 @@ BasicConstraints
 BKPR
 Bazel
 Bitnami
+BobyMCbobs
 Bugfixes
 bugfix
 BundleSource

--- a/content/docs/cli/cainjector.md
+++ b/content/docs/cli/cainjector.md
@@ -28,11 +28,11 @@ Flags:
                                                             ServerSideApply=true|false (ALPHA - default=false)
   -h, --help                                                help for cainjector
       --kubeconfig string                                   Paths to a kubeconfig. Only required if out-of-cluster.
-      --leader-elect                                        If true, cainjector will perform leader election between instances to ensure no more than one instance of cainjector operates at a time
-      --leader-election-lease-duration duration             The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.
-      --leader-election-namespace string                    Namespace used to perform leader election. Only used if leader election is enabled
-      --leader-election-renew-deadline duration             The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.
-      --leader-election-retry-period duration               The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.
+      --leader-elect                                        If true, cainjector will perform leader election between instances to ensure no more than one instance of cainjector operates at a time (default true)
+      --leader-election-lease-duration duration             The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. (default 1m0s)
+      --leader-election-namespace string                    Namespace used to perform leader election. Only used if leader election is enabled (default "kube-system")
+      --leader-election-renew-deadline duration             The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled. (default 40s)
+      --leader-election-retry-period duration               The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 15s)
       --log-flush-frequency duration                        Maximum number of seconds between log flushes (default 5s)
       --logging-format string                               Sets the log format. Permitted formats: "json" (gated by LoggingBetaOptions), "text". (default "text")
       --namespace string                                    If set, this limits the scope of cainjector to a single namespace. If set, cainjector will not update resources with certificates outside of the configured namespace.

--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -407,7 +407,7 @@ page if a step is missing or if it is outdated.
      go get github.com/cert-manager/cert-manager@$RELEASE_VERSION
      cd ../..
 
-     find . -name go.mod -not -path ./_bin/\* -exec dirname '{}' \; | xargs -L1 -I@ sh -c 'cd @; go mod tidy'
+     make tidy
      git add "**/go.mod" "**/go.sum"
      git commit --signoff -m"Update cmd/ctl's go.mod to $RELEASE_VERSION"
      ```

--- a/content/docs/releases/release-notes/release-notes-1.12.md
+++ b/content/docs/releases/release-notes/release-notes-1.12.md
@@ -3,9 +3,25 @@ title: Release 1.12
 description: 'cert-manager release notes: cert-manager 1.12'
 ---
 
+## `v1.12.10`
+
+Special thanks to [@BobyMCbobs](https://github.com/BobyMCbobs) for reporting and testing the DigitalOcean issue!
+
+### Known Issues
+
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+
+### Changes
+
+#### Bug or Regression
+
+- DigitalOcean: Ensure that only TXT records are considered for deletion when cleaning up after an ACME challenge ([#6894](https://github.com/cert-manager/cert-manager/pull/6894), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Bump `golang.org/x/net` to address [`CVE-2023-45288`](https://nvd.nist.gov/vuln/detail/CVE-2023-45288) ([#6933](https://github.com/cert-manager/cert-manager/pull/6933), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
 ## `v1.12.9`
 
 ### Known Issues
+
 - ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
 
 ### Changes
@@ -25,6 +41,7 @@ description: 'cert-manager release notes: cert-manager 1.12'
 ## `v1.12.8`
 
 ### Known Issues
+
 - ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
 
 ### Changes

--- a/content/docs/releases/release-notes/release-notes-1.13.md
+++ b/content/docs/releases/release-notes/release-notes-1.13.md
@@ -3,6 +3,22 @@ title: Release 1.13
 description: 'cert-manager release notes: cert-manager 1.13'
 ---
 
+## `v1.13.6`
+
+Special thanks to [@BobyMCbobs](https://github.com/BobyMCbobs) for reporting and testing the DigitalOcean issue!
+
+### Known Issues
+
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+
+### Changes
+
+#### Bug or Regression
+
+- DigitalOcean: Ensure that only TXT records are considered for deletion when cleaning up after an ACME challenge ([#6892](https://github.com/cert-manager/cert-manager/pull/6892), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Bump `golang.org/x/net` to address [`CVE-2023-45288`](https://nvd.nist.gov/vuln/detail/CVE-2023-45288) ([#6932](https://github.com/cert-manager/cert-manager/pull/6932), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
+
 ## `v1.13.5`
 
 ### Known Issues

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -52,6 +52,22 @@ without breaking users who have come to rely on the existing, documented behavio
 
   > ⚠️ There may be [clients that are incompatible with `DST Root CA X3`](https://github.com/mono/mono/issues/21233).
 
+## `v1.14.5`
+
+Special thanks to [@BobyMCbobs](https://github.com/BobyMCbobs) for reporting and testing the DigitalOcean issue!
+
+### Known Issues
+
+- ACME Issuer (Let's Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.
+
+### Changes
+
+#### Bug or Regression
+
+- DigitalOcean: Ensure that only TXT records are considered for deletion when cleaning up after an ACME challenge ([#6893](https://github.com/cert-manager/cert-manager/pull/6893), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Bump `golang.org/x/net` to address [`CVE-2023-45288`](https://nvd.nist.gov/vuln/detail/CVE-2023-45288) ([#6931](https://github.com/cert-manager/cert-manager/pull/6931), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
+
 ## `v1.14.4`
 
 > 📢 When upgrading to cert-manager release 1.14, please skip `v1.14.0`, `v1.14.1`, `v1.14.2` and `v1.14.3` and install this patch version instead.

--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,4 +1,4 @@
 {
-    "cert_manager_latest_version": "v1.14.4",
+    "cert_manager_latest_version": "v1.14.5",
     "approver_policy_latest_version": "v0.13.0"
 }

--- a/content/v1.12-docs/variables.json
+++ b/content/v1.12-docs/variables.json
@@ -1,3 +1,3 @@
 {
-    "cert_manager_latest_version": "v1.12.9"
+    "cert_manager_latest_version": "v1.12.10"
 }

--- a/content/v1.13-docs/variables.json
+++ b/content/v1.13-docs/variables.json
@@ -1,3 +1,3 @@
 {
-    "cert_manager_latest_version": "v1.13.5"
+    "cert_manager_latest_version": "v1.13.6"
 }


### PR DESCRIPTION
This updates the release notes, runs the `./scripts/gendocs/generate` command which updated some cainjector docs, and simplifies a line in the release process.