### PR TITLE
Resolve #5557  error instantiating route53 challenge solver

### DIFF
--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -167,7 +167,7 @@ spec:
         route53:
           region: us-east-1
           hostedZoneID: DIKER8JEXAMPLE # optional, see policy above
-
+        
     # this solver handles example.org challenges
     # and uses explicit credentials
     - selector:

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -18,38 +18,29 @@ DNS01 challenge. To enable this, create a IAM policy with the following
 permissions:
 
 ```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
     {
-      "Version" : "2012-10-17",
-      "Statement" : [
-        {
-          "Sid" : "VisualEditor0",
-          "Effect" : "Allow",
-          "Action" : "route53:GetChange",
-          "Resource" : "arn:aws:route53:::change/*"
-        },
-        {
-          "Sid" : "VisualEditor1",
-          "Effect" : "Allow",
-          "Action" : [
-            "route53:ListHostedZones",
-            "route53:ListHostedZonesByName"
-          ],
-          "Resource" : "*"
-        },
-        {
-          "Sid" : "VisualEditor2",
-          "Effect" : "Allow",
-          "Action" : "route53:ListResourceRecordSets",
-          "Resource" : "arn:aws:route53:::hostedzone/*"
-        },
-        {
-          "Sid" : "VisualEditor3",
-          "Effect" : "Allow",
-          "Action" : "route53:ChangeResourceRecordSets",
-          "Resource" : "arn:aws:route53:::hostedzone/*"
-        }
-      ]
+      "Effect": "Allow",
+      "Action": "route53:GetChange",
+      "Resource": "arn:aws:route53:::change/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": "arn:aws:route53:::hostedzone/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "route53:ListHostedZonesByName",
+      "Resource": "*"
     }
+  ]
+}
 ```
 
 > Note: The `route53:ListHostedZonesByName` statement can be removed if you
@@ -167,7 +158,7 @@ spec:
         route53:
           region: us-east-1
           hostedZoneID: DIKER8JEXAMPLE # optional, see policy above
-        
+
     # this solver handles example.org challenges
     # and uses explicit credentials
     - selector:

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -18,29 +18,38 @@ DNS01 challenge. To enable this, create a IAM policy with the following
 permissions:
 
 ```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
     {
-      "Effect": "Allow",
-      "Action": "route53:GetChange",
-      "Resource": "arn:aws:route53:::change/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets"
-      ],
-      "Resource": "arn:aws:route53:::hostedzone/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "route53:ListHostedZonesByName",
-      "Resource": "*"
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "VisualEditor0",
+          "Effect" : "Allow",
+          "Action" : "route53:GetChange",
+          "Resource" : "arn:aws:route53:::change/*"
+        },
+        {
+          "Sid" : "VisualEditor1",
+          "Effect" : "Allow",
+          "Action" : [
+            "route53:ListHostedZones",
+            "route53:ListHostedZonesByName"
+          ],
+          "Resource" : "*"
+        },
+        {
+          "Sid" : "VisualEditor2",
+          "Effect" : "Allow",
+          "Action" : "route53:ListResourceRecordSets",
+          "Resource" : "arn:aws:route53:::hostedzone/*"
+        },
+        {
+          "Sid" : "VisualEditor3",
+          "Effect" : "Allow",
+          "Action" : "route53:ChangeResourceRecordSets",
+          "Resource" : "arn:aws:route53:::hostedzone/*"
+        }
+      ]
     }
-  ]
-}
 ```
 
 > Note: The `route53:ListHostedZonesByName` statement can be removed if you
@@ -158,7 +167,6 @@ spec:
         route53:
           region: us-east-1
           hostedZoneID: DIKER8JEXAMPLE # optional, see policy above
-          role: arn:aws:iam::YYYYYYYYYYYY:role/dns-manager
 
     # this solver handles example.org challenges
     # and uses explicit credentials


### PR DESCRIPTION
Problem : https://github.com/cert-manager/cert-manager/issues/5557
Version validated on : v1.14.4
Fix: Incorrect value in Cluster Issuer section and missing IAM permission.

When using Route53 authentication, IAM RSA account is created and Cert-manager configured with respective ServiceAccount. Once this is done, there is no need to specify `role:` when creating ClusterIssuer as mentioned in the documentation. Adding Role will result in Access error.

"route53:GetChange" policy is required for Certmanager. Updated policy document with necessary permissions.

