### PR TITLE
docs: GatewayAPI has been promoted to beta

### DIFF
--- a/content/docs/configuration/acme/http01/README.md
+++ b/content/docs/configuration/acme/http01/README.md
@@ -195,7 +195,7 @@ No other fields of the ingress can be edited.
 
 ## Configuring the HTTP-01 Gateway API solver
 
-**FEATURE STATE**: cert-manager 1.5 [alpha]
+**FEATURE STATE**: cert-manager 1.15 [beta]
 
 The Gateway and HTTPRoute resources are part of the [Gateway API][gwapi], a set
 of CRDs that you install on your Kubernetes cluster that provide various
@@ -205,8 +205,8 @@ improvements over the Ingress API.
 
 <div className="info">
 
-📌  This feature requires the installation of the [Gateway API bundle](https://gateway-api.sigs.k8s.io/guides/#installing-a-gateway-controller) and passing a
-feature flag to the cert-manager controller.
+📌  This feature requires the installation of the [Gateway API bundle](https://gateway-api.sigs.k8s.io/guides/#installing-a-gateway-controller) and passing an
+additional flag to the cert-manager controller.
 
 To install v1.5.1 Gateway API bundle (Gateway CRDs and webhook), run the following command:
 
@@ -220,7 +220,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 
   ```sh
   helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager \
-    --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
+    --set "extraArgs={--enable-gateway-api}"
   ```
 
 - If you are using the raw cert-manager manifests, add the following flag to the
@@ -228,7 +228,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 
   ```yaml
   args:
-    - --feature-gates=ExperimentalGatewayAPISupport=true
+    - --enable-gateway-api
   ```
 
 The Gateway API CRDs should either be installed before cert-manager starts or
@@ -246,8 +246,8 @@ kubectl rollout restart deployment cert-manager -n cert-manager
 
 <div className="info">
 
-🚧   cert-manager 1.8+ is tested with v1alpha2 Kubernetes Gateway API. It should also work
-with v1beta1 because of resource conversion, but has not been tested with it.
+🚧   cert-manager 1.14+ is tested with v1 Kubernetes Gateway API. It should also work
+with v1beta1 and v1alpha2 because of resource conversion, but has not been tested with it.
 </div>
 
 The Gateway API HTTPRoute HTTP-01 solver creates a temporary HTTPRoute using the

--- a/content/docs/installation/configuring-components.md
+++ b/content/docs/installation/configuring-components.md
@@ -45,10 +45,11 @@ kubernetesAPIBurst: 50
 
 numberOfConcurrentWorkers: 200
 
+enableGatewayAPI: true
+
 featureGates:
   AdditionalCertificateOutputFormats: true
   ExperimentalCertificateSigningRequestControllers: true
-  ExperimentalGatewayAPISupport: true
   ServerSideApply: true
   LiteralCertificateSubject: true
   UseCertificateRequestBasicConstraints: true

--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -20,6 +20,10 @@
               "path": "/docs/releases/README.md"
             },
             {
+              "title": "Upgrade 1.14 to 1.15",
+              "path": "/docs/releases/upgrading/upgrading-1.14-1.15.md"
+            },
+            {
               "title": "1.14",
               "path": "/docs/releases/release-notes/release-notes-1.14.md"
             },

--- a/content/docs/releases/upgrading/upgrading-1.14-1.15.md
+++ b/content/docs/releases/upgrading/upgrading-1.14-1.15.md
@@ -1,0 +1,16 @@
+---
+title: Upgrading from v1.14 to v1.15
+description: 'cert-manager installation: Upgrading v1.14 to v1.15'
+---
+
+Before upgrading cert-manager from 1.14 to 1.15 please read the following important notes about breaking changes in 1.15:
+
+## GatewayAPI promotion to beta
+
+GatewayAPI support has been promoted to beta, and thus the feature flag `ExperimentalGatewayAPISupport` is now enabled by default. 
+
+If you had previously enabled this feature flag you will now need to pass the flag `--enable-gateway-api` instead. This is because while the feature is now enabled by default, we still need to gate it behind a flag so cert-manager will not crash if the GatewayAPI CRDs are not installed.
+
+## Next Steps
+
+From here on you can follow the [regular upgrade process](../../installation/upgrade.md).

--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -10,7 +10,7 @@ description: 'cert-manager usage: Kubernetes Gateways'
 <object data="/images/request-certificate-overview/request-certificate-gateway.svg"></object>
 </div>
 
-**FEATURE STATE**: cert-manager 1.5 [alpha]
+**FEATURE STATE**: cert-manager 1.15 [beta]
 
 <div className="info">
 
@@ -24,7 +24,7 @@ HTTP-01](../configuration/acme/http01/README.md).
 <div className="info">
 
 🚧   cert-manager 1.14+ is tested with v1 Kubernetes Gateway API. It should also work
-with v1beta1 because of resource conversion, but has not been tested with it.
+with v1beta1 and v1alpha2 because of resource conversion, but has not been tested with it.
 
 </div>
 
@@ -45,8 +45,8 @@ following diagram (source: https://gateway-api.sigs.k8s.io):
 
 <div className="info">
 
-📌  This feature requires the installation of the [Gateway API bundle](https://gateway-api.sigs.k8s.io/guides/#installing-a-gateway-controller) and passing a
-feature flag to the cert-manager controller.
+📌  This feature requires the installation of the [Gateway API bundle](https://gateway-api.sigs.k8s.io/guides/#installing-a-gateway-controller) and passing an
+additional flag to the cert-manager controller.
 
 To install v1.5.1 Gateway API bundle (Gateway CRDs and webhook), run the following command:
 
@@ -60,7 +60,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 
   ```sh
   helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager \
-    --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
+    --set "extraArgs={--enable-gateway-api}"
   ```
 
 - If you are using the raw cert-manager manifests, add the following flag to the
@@ -68,7 +68,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 
   ```yaml
   args:
-    - --feature-gates=ExperimentalGatewayAPISupport=true
+    - --enable-gateway-api
   ```
 
 The Gateway API CRDs should either be installed before cert-manager starts or


### PR DESCRIPTION
Document the changes in 1.15 that promotes GatewayAPI support to beta and adds the additional config flag