### PR TITLE
Update supported releases to reflect actual tests

### DIFF
--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -25,9 +25,9 @@ should be stable enough to run.
 
 | Release      | Release Date | End of Life            | [Supported Kubernetes versions][s] | [Supported OpenShift versions][s] |
 |--------------|:------------:|:----------------------:|:----------------------------------:|:---------------------------------:|
-| [1.14][]     | Feb 3, 2024  | Release of 1.16        | 1.24 → 1.30                        | 4.11 → 4.15                       |
-| [1.13][]     | Sep 12, 2023 | Release of 1.15        | 1.23 → 1.30                        | 4.10 → 4.15                       |
-| [1.12 LTS][] | May 19, 2023 | May 19, 2025           | 1.22 → 1.30                        | 4.9 → 4.15                        |
+| [1.14][]     | Feb 3, 2024  | Release of 1.16        | 1.24 → 1.29                        | 4.11 → 4.15                       |
+| [1.13][]     | Sep 12, 2023 | Release of 1.15        | 1.23 → 1.29                        | 4.10 → 4.15                       |
+| [1.12 LTS][] | May 19, 2023 | May 19, 2025           | 1.22 → 1.29                        | 4.9 → 4.15                        |
 
 cert-manager 1.12 is a Long Term Support (LTS) release sponsored by [Venafi](https://www.venafi.com/). It will continue to be supported for at least 2 years from release.
 


### PR DESCRIPTION
We're not currently testing older versions with k8s 1.30, because of complexities with what versions kind supports. For reference:

```text
Kind v0.23.0: K8s v1.25 - v1.30
Kind v0.22.0: K8s v1.23 - v1.29
Kind v0.20.0: K8s v1.21 - v1.29 (used by cert-manager 1.13.x and 1.14.x and will be used by 1.12.11 and newer)
Kind v0.18.0: K8s v1.21 - v1.27 (used by cert-manager 1.12.10 and earlier)
```

(Kind v0.21.0 ignored, it was buggy and fixed by v0.22.0)

Related: https://github.com/cert-manager/cert-manager/pull/7029 updates the version of kind on release-1.12

Testing v1.30 with older cert-manager versions will require more engineering, which means that this page is incorrect. I'm updating this page to be correct.