### PR TITLE
Fixing minor typo in trust-manager documentation

### DIFF
--- a/content/docs/trust/trust-manager/README.md
+++ b/content/docs/trust/trust-manager/README.md
@@ -317,7 +317,7 @@ to a working state.
 
 TLS can be complicated and there are many ways to misuse TLS certificates.
 
-Here are some potential gotchas here to be aware of before running trust-manager in production.
+Here are some potential gotchas to be aware of before running trust-manager in production.
 
 If you're planning on running trust-manager in production and you're using more than just the default CA package,
 we **strongly** advise you to read and understand this section. It could save you from causing an outage later.

--- a/content/docs/trust/trust-manager/api-reference.md
+++ b/content/docs/trust/trust-manager/api-reference.md
@@ -243,7 +243,7 @@ Target is the target location in all namespaces to sync source data to.
         <td><b><a href="#bundlespectargetadditionalformats">additionalFormats</a></b></td>
         <td>object</td>
         <td>
-          AdditionalFormats specifies any additional formats to write to the target<br/>
+          AdditionalFormats specifies any additional formats to write to the target.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -274,7 +274,7 @@ Target is the target location in all namespaces to sync source data to.
 ### `Bundle.spec.target.additionalFormats`
 
 
-AdditionalFormats specifies any additional formats to write to the target
+AdditionalFormats specifies any additional formats to write to the target.
 
 <table>
     <thead>
@@ -549,7 +549,7 @@ Target is the current Target that the Bundle is attempting or has completed sync
         <td><b><a href="#bundlestatustargetadditionalformats">additionalFormats</a></b></td>
         <td>object</td>
         <td>
-          AdditionalFormats specifies any additional formats to write to the target<br/>
+          AdditionalFormats specifies any additional formats to write to the target.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -580,7 +580,7 @@ Target is the current Target that the Bundle is attempting or has completed sync
 ### `Bundle.status.target.additionalFormats`
 
 
-AdditionalFormats specifies any additional formats to write to the target
+AdditionalFormats specifies any additional formats to write to the target.
 
 <table>
     <thead>


### PR DESCRIPTION
Minor typo corrected to improve readability.