### PR TITLE
`route53.role` can be omitted when using IRSA

### DIFF
--- a/content/v1.13-docs/configuration/acme/dns01/route53.md
+++ b/content/v1.13-docs/configuration/acme/dns01/route53.md
@@ -184,6 +184,8 @@ spec:
 
 Note that, as mentioned above, the pod is using `arn:aws:iam::XXXXXXXXXXX:role/cert-manager` as a credentials source in Account X, but the `ClusterIssuer` ultimately assumes the `arn:aws:iam::YYYYYYYYYYYY:role/dns-manager` role to actually make changes in Route53 zones located in Account Y.
 
+**Note:** If you are using IRSA, omit `route53.role`. See [#4053](https://github.com/cert-manager/cert-manager/issues/4053).
+
 ## EKS IAM Role for Service Accounts (IRSA)
 
 While [`kiam`](https://github.com/uswitch/kiam) / [`kube2iam`](https://github.com/jtblin/kube2iam) work directly with cert-manager, some special attention is needed for using the [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) feature available on EKS.

--- a/content/v1.13-docs/configuration/acme/dns01/route53.md
+++ b/content/v1.13-docs/configuration/acme/dns01/route53.md
@@ -134,7 +134,7 @@ And the following trust relationship (Add AWS `Service`s as needed):
 }
 ```
 
-## Creating an Issuer (or `ClusterIssuer`)
+## Creating an `Issuer` (or `ClusterIssuer`)
 
 Here is an example configuration for a `ClusterIssuer`:
 


### PR DESCRIPTION
It's the documentation https://github.com/cert-manager/cert-manager/issues/4053's comment section is asking for.