### PR TITLE
Update install instructions for v1.15.0 due to new CRD behavior

### DIFF
--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -580,7 +580,7 @@ page if a step is missing or if it is outdated.
     4. Test the chart
         1. Download the chart tarball from the pull-request
         2. Start a new local Kind cluster `kind create cluster --name release`
-        3. Install the helm chart onto the kind cluster `helm install cert-manager ./cert-manager-v0.14.2.tgz --set installCRDs=true -n cert-manager`
+        3. Install the helm chart onto the kind cluster `helm install cert-manager ./cert-manager-v0.15.0.tgz --set crds.enabled=true -n cert-manager`
         4. Ensure install succeeds and all components are running
         5. Tear down the kind cluster `kind delete cluster --name release`
     5. Merge the PR

--- a/content/docs/installation/continuous-deployment-and-gitops.md
+++ b/content/docs/installation/continuous-deployment-and-gitops.md
@@ -57,11 +57,12 @@ flux create source helm cert-manager --url https://charts.jetstack.io
 ### Create a `HelmRelease` resource
 
 Put your Helm chart values in a `values.yaml` file.
-Use the `installCRDs` value, so that Flux can install and upgrade the CRD resources.
+Use the `crds.enabled` value, so that Flux can install and upgrade the CRD resources.
 
 ```yaml
 # values.yaml
-installCRDs: true
+crds:
+  enabled: true
 ```
 
 ```bash

--- a/content/docs/installation/upgrade.md
+++ b/content/docs/installation/upgrade.md
@@ -38,8 +38,7 @@ install.
 Add the Jetstack Helm repository (if you haven't already) and update it.
 
 ```bash
-helm repo add jetstack https://charts.jetstack.io
-helm repo update jetstack
+helm repo add jetstack https://charts.jetstack.io --force-update
 ```
 
 The helm upgrade command will upgrade cert-manager to the specified or latest version of cert-manager, as listed on the
@@ -47,9 +46,18 @@ The helm upgrade command will upgrade cert-manager to the specified or latest ve
 
 > Note: You can find out your release name using `helm list | grep cert-manager`.
 
+### CRDs managed using helm
+
+If you have installed the CRDs together with the helm install command (using `--set crds.enabled=true`),
+Helm will upgrade the CRDs automatically when you upgrade the cert-manager Helm chart:
+
+```bash
+helm upgrade --reset-then-reuse-values --version <version> <release_name> jetstack/cert-manager
+```
+
 ### CRDs managed separately
 
-If you have installed the CRDs separately (instead of with the `--set installCRDs=true`
+If you have installed the CRDs separately (instead of with the `--set crds.enabled=true`
 option added to your Helm install command), you should upgrade your CRD resources first:
 
 ```bash
@@ -59,16 +67,7 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 And then upgrade the Helm chart:
 
 ```bash
-helm upgrade --version <version> <release_name> jetstack/cert-manager
-```
-
-### CRDs managed using helm
-
-If you have installed the CRDs together with the helm install command, you should
-include CRD resources when upgrading the Helm chart:
-
-```bash
-helm upgrade --set installCRDs=true --version <version> <release_name> jetstack/cert-manager
+helm upgrade --reset-then-reuse-values --version <version> <release_name> jetstack/cert-manager
 ```
 
 ## Upgrading using static manifests

--- a/content/docs/reference/cmctl.md
+++ b/content/docs/reference/cmctl.md
@@ -318,7 +318,8 @@ cmctl x uninstall
 This command uninstalls any Helm-managed release of cert-manager.
 
 Starting from cmctl `v2.0.0`, the uninstall command is safe and will not delete the CRDs
-by default, even if they were installed with the Helm chart (using the option `--set installCRDs=true`).
+by default, even if they were installed with a cert-manager Helm chart before v1.15.0 (using the option `--set installCRDs=true`).
+Starting from cert-manager v1.15.0, the CRDs are not removed by default when uninstalling the Helm chart using Helm.
 
 > 🕐 Before `v2.0.0`, cmctl would remove the CRDs if they were installed with the Helm chart (similar to Helm's behavior).
 

--- a/content/docs/trust/trust-manager/installation.md
+++ b/content/docs/trust/trust-manager/installation.md
@@ -24,7 +24,7 @@ helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --version [[VAR::cert_manager_latest_version]] \
-  --set installCRDs=true
+  --set crds.enabled=true
 ```
 
 ```bash

--- a/content/docs/tutorials/certificate-defaults/README.md
+++ b/content/docs/tutorials/certificate-defaults/README.md
@@ -100,7 +100,7 @@ Once you have your cluster environment, install the required Kubernetes packages
     helm upgrade --install cert-manager cert-manager \
       --namespace cert-manager \
       --version $CERT_MANAGER_CHART_VERSION \
-      --set installCRDs=true \
+      --set crds.enabled=true \
       --set startupapicheck.enabled=false \
       --create-namespace \
       --repo https://charts.jetstack.io/

--- a/content/docs/tutorials/getting-started-aks-letsencrypt/README.md
+++ b/content/docs/tutorials/getting-started-aks-letsencrypt/README.md
@@ -158,7 +158,7 @@ helm install \
   --namespace cert-manager \
   --create-namespace \
   --version [[VAR::cert_manager_latest_version]] \
-  --set installCRDs=true
+  --set crds.enabled=true
 ```
 
 This will create three Deployments and some Services and Pods in a new namespace called `cert-manager`.

--- a/content/docs/tutorials/zerossl/zerossl.md
+++ b/content/docs/tutorials/zerossl/zerossl.md
@@ -41,7 +41,8 @@ ingressShim:
   defaultIssuerName: "zerossl-production"
   defaultIssuerKind: "ClusterIssuer"
 
-installCRDs: true
+crds:
+  enabled: true
 ```
 
 Install it using helm:

--- a/content/docs/usage/istio-csr/installation.md
+++ b/content/docs/usage/istio-csr/installation.md
@@ -33,14 +33,13 @@ kind create cluster
 # Helm setup
 helm repo add jetstack https://charts.jetstack.io --force-update
 
-# install cert-manager CRDs
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/[[VAR::cert_manager_latest_version]]/cert-manager.crds.yaml
-
 # install cert-manager; this might take a little time
-helm install cert-manager jetstack/cert-manager \
+helm install \
+  cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version [[VAR::cert_manager_latest_version]]
+  --version [[VAR::cert_manager_latest_version]] \
+  --set crds.enabled=true
 
 # We need this namespace to exist since our cert will be placed there
 kubectl create namespace istio-system

--- a/content/docs/usage/kube-csr.md
+++ b/content/docs/usage/kube-csr.md
@@ -47,7 +47,7 @@ $ helm install \
   --namespace cert-manager \
   --create-namespace \
   --set featureGates="ExperimentalCertificateSigningRequestControllers=true" \
-  # --set installCRDs=true
+  --set crds.enabled=true
 ```
 
 > Note: cert-manager supports signing CertificateSigningRequests

--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,3 +1,3 @@
 {
-    "cert_manager_latest_version": "v1.14.5"
+    "cert_manager_latest_version": "v1.15.0"
 }


### PR DESCRIPTION
- replaces `installCRDs` with `crds.enabled` in our docs
- removes the advise to install CRDs separately using kubectl
- adds some extra info about the CRDs still existing after Helm uninstall