### PR TITLE
Update documentation with new approval Helm chart options

### DIFF
--- a/content/docs/policy/approval/approver-policy/installation.md
+++ b/content/docs/policy/approval/approver-policy/installation.md
@@ -17,36 +17,31 @@ If you install cert-manager using `helm install` or `helm upgrade`,
 you can disable the default approver by [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing) using the `--set` or `--values` command line flags:
 
 ```
+# ⚠️ This Helm option is only available in cert-manager v1.15.0 and later.
+
 # Example --set value
---set extraArgs={--controllers='*\,-certificaterequests-approver'} # ⚠ Disable cert-manager's built-in approver
+--set disableAutoApproval=true
 ```
 
 ```yaml
+# ⚠️ This Helm option is only available in cert-manager v1.15.0 and later.
+
 # Example --values file content
-extraArgs:
- - "--controllers=*,-certificaterequests-approver" # ⚠ Disable cert-manager's built-in approver
+disableAutoApproval: true
 ```
 
 Here's a example which reconfigure an installed cert-manager to run without auto-approver:
 
 ```terminal
+# ⚠️ This Helm option is only available in cert-manager v1.15.0 and later.
+
 existing_cert_manager_version=$(helm get metadata -n cert-manager cert-manager | grep '^VERSION' | awk '{ print $2 }')
 helm upgrade cert-manager jetstack/cert-manager \
   --reuse-values \
   --namespace cert-manager \
   --version $existing_cert_manager_version \
-  --set extraArgs={--controllers='*\,-certificaterequests-approver'} # ⚠ Disable cert-manager's built-in approver
+  --set disableAutoApproval=true
 ```
-
-> ℹ️ Be sure to customize the cert-manager controller `extraArgs`,
-> which are at the top level of the values file.
-> *Do not* change the `webhook.extraArgs`, `startupAPICheck.extraArgs` or `cainjector.extraArgs` settings.
->
-> ⚠️ If you are reconfiguring an already installed cert-manager,
-> check whether the original installation already customized the `extraArgs` value
-> by running `helm get values cert-manager --namespace cert-manager`.
-> If there are already `extraArgs` values, merge those with the extra `--controllers` value.
-> Otherwise your original `extraArgs` values will be overwritten.
 
 ### 2. Install approver-policy
 

--- a/content/docs/usage/certificaterequest.md
+++ b/content/docs/usage/certificaterequest.md
@@ -162,47 +162,29 @@ automatically approve _all_ CertificateRequests that reference any internal
 issuer type in any namespace: `cert-manager.io/Issuer`,
 `cert-manager.io/ClusterIssuer`.
 
-To disable this controller, add the following argument to the
-cert-manager-controller: `--controllers=*,-certificaterequests-approver`. This
-can be achieved with helm by appending:
+**Disabling the internal auto approver:**
+
+To disable this controller, in the Helm chart set the `disableAutoApproval` value to `true`:
 
 ```bash
---set extraArgs={--controllers='*\,-certificaterequests-approver'}
+# ⚠️ This Helm option is only available in cert-manager v1.15.0 and later.
+--set disableAutoApproval=true
 ```
 
-Alternatively, in order for the internal approver controller to approve
-CertificateRequests that reference an external issuer, add the following RBAC to
-the cert-manager-controller Service Account. Please replace the given resource
-names with the relevant names:
+**Approving additional issuers using the internal auto approver:**
 
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-approve:my-issuer-example-com # edit
-rules:
-- apiGroups:
-  - cert-manager.io
-  resources:
-  - signers
-  verbs:
-  - approve
-  resourceNames:
-  - issuers.my-issuer.example.com/* # edit
-  - clusterissuers.my-issuer.example.com/* # edit
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-approve:my-issuer-example-com # edit
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-approve:my-issuer-example-com # edit
-subjects:
-- kind: ServiceAccount
-  name: cert-manager
-  namespace: cert-manager
+Alternatively, in order for the internal approver controller to approve
+CertificateRequests that reference an external issuer, in the Helm chart add the
+issuers to the `approveSignerNames` list, or set the `approveSignerNames` value
+to an empty list to approve all issuers (internal and external).
+
+```bash
+# ⚠️ This Helm option is only available in cert-manager v1.15.0 and later.
+--set approveSignerNames[0]="issuers.cert-manager.io/*" \
+--set approveSignerNames[1]="clusterissuers.cert-manager.io/*" \
+\
+--set approveSignerNames[2]="issuers.my-issuer.example.com/*" \
+--set approveSignerNames[3]="clusterissuers.my-issuer.example.com/*"
 ```
 
 #### RBAC Syntax

--- a/content/docs/usage/csi-driver-spiffe/installation.md
+++ b/content/docs/usage/csi-driver-spiffe/installation.md
@@ -18,15 +18,17 @@ race with cert-manager and policy enforcement will become useless.
 Policy enforcement is absolutely critical for using csi-driver-spiffe safely. See
 the [security considerations](./README.md#security-considerations) section for more details.
 
-Here's a example which reconfigure an installed cert-manager to run without auto-approver:
+Here's a example which reconfigure an installed cert-manager (v1.15.0+) to run without auto-approver:
 
 ```terminal
+# ⚠️ This Helm option is only available in cert-manager v1.15.0 and later.
+
 existing_cert_manager_version=$(helm get metadata -n cert-manager cert-manager | grep '^VERSION' | awk '{ print $2 }')
 helm upgrade cert-manager jetstack/cert-manager \
   --reuse-values \
   --namespace cert-manager \
   --version $existing_cert_manager_version \
-  --set extraArgs={--controllers='*\,-certificaterequests-approver'} # ⚠ Disable cert-manager's built-in approver
+  --set disableAutoApproval=true
 ```
 
 ### 2. Configure an Issuer / ClusterIssuer


### PR DESCRIPTION
In v1.15.0, we introduced new Helm chart options that can make configuring the build-in auto-approver much simpler.
This feature was added in https://github.com/cert-manager/cert-manager/pull/7049.