### PR TITLE
Fix broken link in istio-csr docs

### DIFF
--- a/content/docs/usage/istio-csr/README.md
+++ b/content/docs/usage/istio-csr/README.md
@@ -38,12 +38,12 @@ Running istio-csr requires a few steps and preconditions in order:
 3. An `Issuer` or `ClusterIssuer` which will be used to issue Istio certificates
 4. istio-csr installed (likely via helm)
 5. Istio [installed](https://istio.io/latest/docs/setup/install/istioctl/) with
-   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/hack).
+   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio).
 
 ### Why Custom Istio Install Manifests?
 
 If you take a look at the contents of [the example Istio install
-manifests](https://github.com/cert-manager/istio-csr/tree/main/hack)
+manifests](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio)
 there are a few custom configuration options which are important.
 
 Required changes include setting `ENABLE_CA_SERVER` to `false` and setting the `caAddress` from which Istio will

--- a/content/docs/usage/istio-csr/README.md
+++ b/content/docs/usage/istio-csr/README.md
@@ -38,12 +38,12 @@ Running istio-csr requires a few steps and preconditions in order:
 3. An `Issuer` or `ClusterIssuer` which will be used to issue Istio certificates
 4. istio-csr installed (likely via helm)
 5. Istio [installed](https://istio.io/latest/docs/setup/install/istioctl/) with
-   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio).
+   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/5d2e629f9f9aec7f476337d6ae69482cea9a7a71/make/config/istio).
 
 ### Why Custom Istio Install Manifests?
 
 If you take a look at the contents of [the example Istio install
-manifests](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio)
+manifests](https://github.com/cert-manager/istio-csr/tree/5d2e629f9f9aec7f476337d6ae69482cea9a7a71/make/config/istio)
 there are a few custom configuration options which are important.
 
 Required changes include setting `ENABLE_CA_SERVER` to `false` and setting the `caAddress` from which Istio will

--- a/content/v1.11-docs/projects/istio-csr.md
+++ b/content/v1.11-docs/projects/istio-csr.md
@@ -32,12 +32,12 @@ Running istio-csr requires a few steps and preconditions in order:
 3. An `Issuer` or `ClusterIssuer` which will be used to issue Istio certificates
 4. istio-csr installed (likely via helm)
 5. Istio [installed](https://istio.io/latest/docs/setup/install/istioctl/) with
-   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio).
+   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/5d2e629f9f9aec7f476337d6ae69482cea9a7a71/make/config/istio).
 
 ### Why Custom Istio Install Manifests?
 
 If you take a look at the contents of [the example Istio install
-manifests](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio)
+manifests](https://github.com/cert-manager/istio-csr/tree/5d2e629f9f9aec7f476337d6ae69482cea9a7a71/make/config/istio)
 there are a few custom configuration options which are important.
 
 Required changes include setting `ENABLE_CA_SERVER` to `false` and setting the `caAddress` from which Istio will

--- a/content/v1.11-docs/projects/istio-csr.md
+++ b/content/v1.11-docs/projects/istio-csr.md
@@ -32,12 +32,12 @@ Running istio-csr requires a few steps and preconditions in order:
 3. An `Issuer` or `ClusterIssuer` which will be used to issue Istio certificates
 4. istio-csr installed (likely via helm)
 5. Istio [installed](https://istio.io/latest/docs/setup/install/istioctl/) with
-   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/hack).
+   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio).
 
 ### Why Custom Istio Install Manifests?
 
 If you take a look at the contents of [the example Istio install
-manifests](https://github.com/cert-manager/istio-csr/tree/main/hack)
+manifests](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio)
 there are a few custom configuration options which are important.
 
 Required changes include setting `ENABLE_CA_SERVER` to `false` and setting the `caAddress` from which Istio will

--- a/content/v1.14-docs/usage/istio-csr/README.md
+++ b/content/v1.14-docs/usage/istio-csr/README.md
@@ -38,12 +38,12 @@ Running istio-csr requires a few steps and preconditions in order:
 3. An `Issuer` or `ClusterIssuer` which will be used to issue Istio certificates
 4. istio-csr installed (likely via helm)
 5. Istio [installed](https://istio.io/latest/docs/setup/install/istioctl/) with
-   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/hack).
+   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio).
 
 ### Why Custom Istio Install Manifests?
 
 If you take a look at the contents of [the example Istio install
-manifests](https://github.com/cert-manager/istio-csr/tree/main/hack)
+manifests](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio)
 there are a few custom configuration options which are important.
 
 Required changes include setting `ENABLE_CA_SERVER` to `false` and setting the `caAddress` from which Istio will

--- a/content/v1.14-docs/usage/istio-csr/README.md
+++ b/content/v1.14-docs/usage/istio-csr/README.md
@@ -38,12 +38,12 @@ Running istio-csr requires a few steps and preconditions in order:
 3. An `Issuer` or `ClusterIssuer` which will be used to issue Istio certificates
 4. istio-csr installed (likely via helm)
 5. Istio [installed](https://istio.io/latest/docs/setup/install/istioctl/) with
-   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio).
+   some custom config required, e.g. using the example config from the [repository](https://github.com/cert-manager/istio-csr/tree/5d2e629f9f9aec7f476337d6ae69482cea9a7a71/make/config/istio).
 
 ### Why Custom Istio Install Manifests?
 
 If you take a look at the contents of [the example Istio install
-manifests](https://github.com/cert-manager/istio-csr/tree/main/make/config/istio)
+manifests](https://github.com/cert-manager/istio-csr/tree/5d2e629f9f9aec7f476337d6ae69482cea9a7a71/make/config/istio)
 there are a few custom configuration options which are important.
 
 Required changes include setting `ENABLE_CA_SERVER` to `false` and setting the `caAddress` from which Istio will


### PR DESCRIPTION
The link `https://github.com/cert-manager/istio-csr/tree/main/hack` is no longer valid, instead `https://github.com/cert-manager/istio-csr/tree/5d2e629f9f9aec7f476337d6ae69482cea9a7a71/make/config/istio` can be used.