### PR TITLE
Document External Vault secretless auth options (v2)

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -222,6 +222,7 @@ kuard
 k8s
 KubeCon
 Kubernetes
+Openshift
 Kyverno
 Learnk8s
 LuCI

--- a/.spelling
+++ b/.spelling
@@ -705,6 +705,9 @@ structs
 klog
 relabelings
 kustomize
+TokenReview
+JWTs
+TTLs
 
 FlorianLiebhart
 cypres

--- a/content/docs/configuration/vault.md
+++ b/content/docs/configuration/vault.md
@@ -257,7 +257,14 @@ In order to request signing of certificates by Vault, the issuer must be able to
 properly authenticate against it. cert-manager provides multiple approaches to
 authenticating to Vault which are detailed below.
 
-### Authenticating via an AppRole
+| Vault auth type                                                          | cert-manager issuer configuration |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| [AppRole](https://developer.hashicorp.com/vault/docs/auth/approle)       | [A. Authenticating with a Vault AppRole](#a-authenticating-via-an-approle)   |
+| [Token](https://developer.hashicorp.com/vault/docs/auth/token)           | [B. Authenticating with a Vault Token](#b-authenticating-with-a-token)       |
+| [JWT/OIDC](https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/kubernetes) | [C. Authenticating with Kubernetes Service Accounts](#c-authenticating-with-kubernetes-service-accounts) > [Use JWT/OIDC Auth](#option-1-vault-authentication-method-use-jwtoidc-auth)              |
+| [Kubernetes](https://developer.hashicorp.com/vault/docs/auth/kubernetes)                  | [C. Authenticating with Kubernetes Service Accounts](#c-authenticating-with-kubernetes-service-accounts) > [Use Kubernetes Auth](#option-2-vault-authentication-method-use-kubernetes-auth) |
+
+### A. Authenticating via an AppRole
 
 An [AppRole](https://www.vaultproject.io/docs/auth/approle.html) is a method of
 authenticating to Vault through use of its internal role policy system. This
@@ -302,7 +309,7 @@ spec:
           key: secretId
 ```
 
-### Authenticating with a Token
+### B. Authenticating with a Token
 
 This method of authentication uses a token string that has been generated from
 one of the many authentication backends that Vault supports. These tokens have
@@ -348,36 +355,60 @@ spec:
           key: token
 ```
 
-<a id="authenticating-with-kubernetes-service-accounts"></a>
+### C. Authenticating with Kubernetes Service Accounts
 
-### Authenticating with Kubernetes Service Accounts
+ℹ️ This documentation works for cert-manager >= v1.12.0.
 
-The [Vault Kubernetes
-Auth](https://developer.hashicorp.com/vault/docs/auth/kubernetes) allows
+The [Vault JWT/OIDC Auth](https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/kubernetes) and the [Vault Kubernetes Auth](https://developer.hashicorp.com/vault/docs/auth/kubernetes) allow
 cert-manager to authenticate to Vault using a Kubernetes Service Account Token
-in order to issue certificates using Vault as a certification authority. The
-Kubernetes service account token can be provided in two ways:
+in order to issue certificates using Vault as a certification authority.
 
-- [Secretless Authentication with a Service Account](#secretless-authentication-with-a-service-account) (recommended),
-- [Authentication with a Static Service Account Token](#static-service-account-token).
+Vault Authentication Method:
+- [Option 1. Use JWT/OIDC Auth](#option-1-vault-authentication-method-use-jwtoidc-auth)
+- [Option 2. Use Kubernetes Auth](#option-2-vault-authentication-method-use-kubernetes-auth)
 
-<a name="static-service-account-token"></a>
+#### Option 1. Vault Authentication Method: Use JWT/OIDC Auth
 
-#### Secretless Authentication with a Service Account (In-Cluster Vault)
+The [JWT/OIDC auth method](https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/kubernetes) should be used instead of the [Kubernetes auth method](#option-2-vault-authentication-method-use-kubernetes-auth) when:
+- Your Kubernetes' cluster OIDC discovery endpoint is reachable from the Vault server.
+- Your Vault server is not running inside the Kubernetes cluster.
 
-ℹ️ This feature is available in cert-manager >= v1.12.0.
+> **Note:** By using the JWT auth instead of the Kubernetes auth, the revocation of tokens will no longer be checked:  
+> *"Note: The JWT auth engine does not use Kubernetes' TokenReview API during authentication, and instead uses public key cryptography to verify the contents of JWTs. This means tokens that have been revoked by Kubernetes will still be considered valid by Vault until their expiry time. To mitigate this risk, use short TTLs for service account tokens or use Kubernetes auth which does use the TokenReview API."*  
+> That's not a problem because cert-manager uses short-lived tokens that expire after 10 minutes.
 
-With the secretless authentication with a service account, cert-manager creates
-an ephemeral service account token using the TokenRequest API and uses it to
-authenticate with Vault. These tokens are short-lived (10 minutes) and are
-never stored to disk.
+The steps below will guide you through the configuration of the JWT auth method (based on [the Vault documentation](https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/kubernetes)) and how to use it with cert-manager.
 
-This is the recommended authentication method because it does not rely on the
-deprecated static service account tokens. The static service account tokens pose
-a threat due to their infinite lifetime. Static service account tokens have been
-disabled by default on Kubernetes 1.24.
+To configure Vault's JWT auth, you will need to fetch the issuer URL.
 
-The first step is to create a `ServiceAccount` resource:
+```bash
+ISSUER="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
+```
+
+Check that the URL works and is accessible from the Vault server. For example, the response should look something like this:
+
+```console
+$ curl "$ISSUER/.well-known/openid-configuration"
+{
+  "issuer": "https://container.googleapis.com/v1/projects/project001/locations/europe-west1-b/clusters/cert-manager-cluster",
+  "jwks_uri": "https://container.googleapis.com/v1/projects/project001/locations/europe-west1-b/clusters/cert-manager-cluster/jwks",
+  ...
+}
+```
+
+The next step is to configure the JWT auth in Vault. You will need to create one JWT auth path per Kubernetes cluster since each cluster has its own JSON Web Key Set and OIDC discovery endpoint.
+
+```bash
+vault auth enable -path=jwt-cluster001 jwt
+kubectl config view --minify --flatten -ojson \
+  | jq -r '.clusters[].cluster."certificate-authority-data"' \
+  | base64 -d >/tmp/cacrt
+vault write auth/jwt-cluster001/config \
+    oidc_discovery_url="${ISSUER}" \
+    oidc_discovery_ca_pem=@/tmp/cacrt
+```
+
+Then, create a Kubernetes Service Account and a matching Vault role:
 
 ```sh
 kubectl create serviceaccount -n sandbox vault-issuer
@@ -413,75 +444,25 @@ roleRef:
   name: vault-issuer
 ```
 
-Next, you can either use `JWT` or `kubernetes` auth method in Vault.
-This depends on several factors, for example:
-- Whether Vault is running outside the cluster or not
-- Whether you're running on a public cloud distribution of Kubernetes with `OIDC` discovery support
-- If not, In Openshift for example whether the `apiserver` already exposes or can be configured to expose the `OIDC` discovery endpoint
-
-| Vault deployment | Cloud managed K8s (EKS,GKE,AKS) | Admin platform rights | Best method                                                             |
-| ---------------- | -------------------------- | ---------------------      | ------------                                                            |
-| External         | Yes                        | Yes                        | [JWT auth](#jwt-auth-for-cloud-kubernetes-clusters)                     |
-| External         | No                         | No                         | [Static token](#authentication-with-a-static-service-account-token)     |
-| Internal         | Yes                        | No                         | [Kubernetes auth](#use-kubernetes-auth)                                 |
-| Internal         | Yes                        | Yes                        | [Kubernetes auth](#use-kubernetes-auth)                                 |
-| External         | No  (e.g. Openshift)       | Yes                        | [JWT pre-requisites + JWT auth](#jwt-auth-pre-requisites-e.g.-openshift)|
-
-##### JWT auth for cloud Kubernetes clusters
-
-> **Note:** This setup guide is also valid for any cluster with OIDC bound service account issuer configured to allow external usage.
-
-Given Vault is external to your Kubernetes cluster, you can't use Vault's Kubernetes auth as explained in [this issue](https://github.com/cert-manager/cert-manager/issues/6150).
-
-> **Note:** By using the JWT auth instead of the Kubernetes auth, the revocation of tokens will no longer be checked. That's not a problem because cert-manager uses short-lived tokens that expire after 10 minutes.
-
-To configure Vault's JWT auth, you will need to fetch the JWKS URL:
+Then, create the Vault role:
 
 ```bash
-JWKS_URL=$(curl -sS $(kubectl get --raw /.well-known/openid-configuration | jq .issuer -r)/.well-known/openid-configuration \
-  | jq .jwks_uri -r)
-```
-
-> **Note:** The reason we get `/.well-known/openid-configuration` twice in a row is because `kubectl get` performs an HTTP call from within the cluster, which means the JWKS URL uses an internal domain or IP.
-
-Check that the URL works. For example, it should look something like this:
-
-```console
-$ curl $JWKS_URL
-{
-  "keys": [
-    {
-      "kty": "RSA",
-      "alg": "RS256",
-      "use": "sig",
-      ...
-    }
-  ]
-}
-```
-
-The next step is to configure the JWT auth in Vault. You will need to create one JWT auth path per Kubernetes cluster since each cluster has its own JSON Web Key Set.
-
-```bash
-vault auth enable -path=jwt jwt
-kubectl config view --minify --flatten -ojson \
-  | jq -r '.clusters[].cluster."certificate-authority-data"' \
-  | base64 -d >/tmp/cacrt
-vault write auth/jwt/config \
-    jwks_url="$JWKS_URL" \
-    jwks_ca_pem=@/tmp/cacrt
-```
-
-Then, create a role:
-
-```bash
-vault write auth/jwt/role/vault-issuer \
+vault write auth/jwt-cluster001/role/vault-issuer-role \
    role_type="jwt" \
-   bound_audiences="<AUDIENCE-FROM-PREVIOUS-STEP>" \
+   bound_audiences="vault://sandbox/vault-issuer" \
    user_claim="sub" \
    bound_subject="system:serviceaccount:sandbox:vault-issuer" \
    policies="default" \
-   ttl="1h"
+   ttl=1m
+```
+
+It is recommended to use a different Vault role each per Issuer or
+ClusterIssuer. The `audience` allows you to restrict the Vault role to a single
+Issuer or ClusterIssuer. The syntax is the following:
+
+```yaml
+"vault://<namespace>/<issuer-name>"   # For an Issuer.
+"vault://<cluster-issuer-name>"       # For a ClusterIssuer.
 ```
 
 Finally, you can create your Issuer:
@@ -498,243 +479,99 @@ spec:
     server: https://vault.local
     auth:
       kubernetes:
-        role: my-app-1
-        mountPath: /v1/auth/jwt
+        role: vault-issuer-role
+        mountPath: /v1/auth/jwt-cluster001
         serviceAccountRef:
           name: vault-issuer
 ```
 
-##### JWT auth pre-requisites (e.g Openshift).
+#### Option 2. Vault Authentication Method: Use Kubernetes Auth
 
-In the case of some Openshift installations for example, the cluster's `OIDC` provider may not be readily accessible to your external Vault instance.
-This depends on many factors such as what kind of installer and where it's deployed.
+The [Kubernetes auth method](https://developer.hashicorp.com/vault/docs/auth/kubernetes) should be used when:
+- Your Vault server is running inside the Kubernetes cluster.
+- Or, your Kubernetes' cluster OIDC discovery endpoint is not reachable from the Vault server, but Vault can reach the Kubernetes API server.
 
-You can manually configure service account issuer URL to generate your service accounts from a publicly exposed cluster `OIDC` provider.
-You will need a few RBAC and potentially `apiserver` configurations to be applied to the cluster in order to allow you to use the JWT method in Vault.
+The steps below will guide you through the configuration of the Kubernetes auth method (based on [the Vault documentation](https://developer.hashicorp.com/vault/docs/auth/kubernetes)) and how to use it with cert-manager.
 
-> **Note:** If changes are required, it will likely need admin level permissions. 
-Depending on your installation configuration you may not need to do all the changes below so make sure to check carefully before attempting any change.
-
-For the examples below we have used an OpenShift Code Ready Containers (CRC) environment to represent the OpenShift environment.
-
-###### 1) Openshift JWT Requirement: *OIDC Issuer* URL should be reachable:
-
-First run the following to check your current clusters settings.
-
-```bash
-oc get --raw '/.well-known/openid-configuration' | jq .
-```
-
-Alternatively you can retrieve the cluster URI and use curl as follows:
+The Kubernetes auth method requires a `token_reviewer_jwt`, which is a JWT token that is used
+by Vault to call the TokenReview API of the Kubernetes API server. This endpoint is then used to verify the
+JWT token that is provided by cert-manager. There are three ways to provide this `token_reviewer_jwt` token:
+1. When running Vault inside the Kubernetes cluster, you can use the Kubernetes service account token that is mounted
+   into the Vault pod.  
+   ✅ is enabled when Vault auto-detects that it is running in a Kubernetes cluster
+2. When running Vault outside the Kubernetes cluster, you can create a long-lived service account token and provide
+   it to Vault.  
+   ✅ is enabled when you set the `token_reviewer_jwt` parameter
+3. When running Vault outside the Kubernetes cluster, you can re-use the JWT token that is provided by cert-manager
+   to authenticate to Vault. In this case, the audiences of that JWT token must also include the Kubernetes API server audience.  
+   ✅ is enabled when the `token_reviewer_jwt` parameter is omitted and Vault is not running in a Kubernetes cluster
 
 ```bash
-oc cluster-info
+vault auth enable -path=kubernetes-cluster001 kubernetes
+kubectl config view --minify --flatten -ojson \
+  | jq -r '.clusters[].cluster."certificate-authority-data"' \
+  | base64 -d >/tmp/cacrt
+vault write auth/kubernetes-cluster001/config \
+    kubernetes_host=<kubernetes-api-server-url> \
+    kubernetes_ca_cert=@/tmp/cacrt
 ```
 
-Example Output:
+> **Note**: If vault is running outside the Kubernetes cluster, you can provide a `token_reviewer_jwt` token which will
+> be used by Vault to authenticate to the Kubernetes API server. This token can be a long-lived service account token
+> that can [be obtained as explained here](https://kubernetes.io/docs/concepts/configuration/secret/#serviceaccount-token-secrets).
+> Make sure the token is linked to a service account that has the necessary permissions to call the TokenReview API.
+> The vault command will look like this:
+> ```bash
+> vault write auth/kubernetes-cluster001/config \
+>    token_reviewer_jwt="<TokenReview API SA token>"
+>    kubernetes_host=<kubernetes-api-server-url> \
+>    kubernetes_ca_cert=@/tmp/cacrt 
+> ```
 
-Kubernetes control plane is running at https://api.crc.testing:6443
+Then, create a Kubernetes Service Account and a matching Vault role:
 
-```bash
-curl -v -k https://api.crc.testing:6443/.well-known/openid-configuration | jq .
+```sh
+kubectl create serviceaccount -n sandbox vault-issuer
 ```
 
-Your output might be similar to this:
+Then add an RBAC Role so that cert-manager can get tokens for the
+ServiceAccount:
 
 ```yaml
-{
-  "issuer": "https://kubernetes.default.svc", # <- internal apiserver "kubernetes" service 
-  "jwks_uri": "https://api-int.crc.testing:6443/openid/v1/jwks",
-  "response_types_supported": [
-    "id_token"
-  ],
-  "subject_types_supported": [
-    "public"
-  ],
-  "id_token_signing_alg_values_supported": [
-    "RS256"
-  ]
-}
-```
-
-If you see the above, especially the line: `"issuer": "https://kubernetes.default.svc"`, then your Issuer URI may only be accessible from within the OpenShift cluster and therefore may not work with JWT authentication for Vault. The result will depend on the configuration of your OpenShift environment.
-
-In order to set the issuer URI, which may be blank, please refer to the following Red Hat Documentation. Specifically see step b where the `serviceAccountIssuer` field is being set: https://docs.openshift.com/container-platform/4.13/authentication/bound-service-account-tokens.html
-
-For example, you can use the following to set the issuer URI:
-
-```bash
-oc edit authentications cluster
-```
-
-In a CRC cluster the spec may look something like:
-
-```yaml
-spec:
-  oauthMetadata:
-    name: ""
-  serviceAccountIssuer: https://api.crc.testing:6443 # <- This is the reachable FQDN
-                                                     #    of the apiserver we set as
-                                                     #    service account token issuer URL.
-  type: ""
-  webhookTokenAuthenticator:
-    kubeConfig:
-      name: webhook-authentication-integrated-oauth
-```
-
-Once configured, an example of a response to the original curl command would work is something like:
-
-```json
-{
-  "issuer": "https://api.crc.testing:6443", // This is the reachable apiserver FQDN
-  "jwks_uri": "https://api-int.crc.testing:6442/openid/v1/jwks", 
-  "response_types_supported": [
-    "id_token"
-  ],
-  "subject_types_supported": [
-    "public"
-  ],
-  "id_token_signing_alg_values_supported": [
-    "RS256"
-  ]
-}
-```
-
-In that example the issuer field has a route-able DNS name that can be called from outside of the OpenShift cluster. You can test this manually with curl:
-
-```bash
-curl -s https://api.crc.testing:6443/.well-known/openid-configuration | jq .
-```
-
-###### 2) Openshift JWT Requirement: Vault should be authorized to use OIDC discovery 
-
-You may be reading the correct `jwks_uri` from outside the cluster, but getting a 403 instead.
-In this case you've hit another issue. An example might be:
-
-```yaml
-{
-  "kind": "Status",
-  "apiVersion": "v1",
-  "metadata": {},
-  "status": "Failure",
-  "message": "forbidden: User \"system:anonymous\" cannot get path \"/openid/v1/jwk\"",
-  "reason": "Forbidden",
-  "details": {},
-  "code": 403
-}
-```
-
-If you see this, then non-authenticated users are not able to call that API endpoint. You will need to allow unauthenticated users to access this endpoint.
-
-Note: The YAML provided is an example and you should review fully before implementing.
-
-Here is an example `ClusterRoleBinding` that would allow anyone to access that API endpoint:
-
-```yaml
----
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: crb:oidc-viewer
-subjects:
-  - kind: Group
-    name: system:unauthenticated
-    apiGroup: rbac.authorization.k8s.io
-roleRef:
-  kind: ClusterRole
-  name: system:service-account-issuer-discovery
-  apiGroup: rbac.authorization.k8s.io
-```
-
-Once applied try the `jwks_uri` again and validate you receive a JSON response.
-
-
-###### 3) Openshift JWT Requirement: *JWKS* URI presented in discovery endpoint should be reachable:
-
-Assuming you now get a response, you will want to ensure that the `jwks_uri` is also accessible from outside of the cluster. For example in CRC this might be configured to an internally routable DNS name only by default.
-
-From your previous output try curl to access the endpoint:
-
-```bash
-curl -v -k https://api.crc.testing:6443/openid/v1/jwks | jq .
-```
-
-A successful response will return a JSON output with public keys, such as:
-
-```json
-{
-  "keys": [
-    {
-      "use": "sig",
-      "kty": "RSA",
-      "kid": "JDH_TRZxYQt_C4h00XIty8lC73TI3eJ9GXCI0vsb_lw",
-      ...
-    }
-  ]
-}
-```
-
-If you do not get this response it is likely you will not be successful setting up a JWT mapping in Vault .
-
-In case you still do not see a valid JWKS URI, you can try the following remediation.
-
-> **Note:** Reconfiguring the `apiserver` as shown below should be carefully evaluated before use. This may not be a suitable solution for some production environment. 
-
-You may need to manually override the `service-account-jwks-uri` field within the `kubeapiservers.operator.openshift.io` configuration for the cluster:
-
-```yaml
-spec:
-  unsupportedConfigOverrides:
-    apiServerArguments:
-      service-account-jwks-uri:
-      - https://api.crc.testing:6443/openid/v1/jwks
-```
-
-For example adding this via the `unsupportedConfigOverrides` field in the spec is possible. You will need to wait a few minutes for these changes to propagate and be ready for use. The domain would be one you own and currently use to access the OpenShift environment. Do not use the CRC domain in a real OpenShift environment.
-
-###### Openshift JWT: Configure JWT auth in Openshift
-
-Once the 3 above pre-requisites are fulfilled, you can follow [the exact same steps as the JWT method](#jwt-auth-for-cloud-kubernetes-clusters) for the public clouds using the issuer URL, which for example in our case is: `https://api.crc.testing:6443`
-
-## Use Kubernetes auth
-
-You can only use `serviceAccountRef` with Vault's Kubernetes auth when Vault is
-installed in the same cluster as cert-manager, otherwise you would use the [JWT Vault auth](#jwt-auth-for-cloud-kubernetes-clusters).
-
-To use the Kubernetes auth with `serviceAccountRef`, configure your issuer with
-the following:
-
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: Role
 metadata:
   name: vault-issuer
   namespace: sandbox
-spec:
-  vault:
-    path: pki_int/sign/example-dot-com
-    server: https://vault.local
-    auth:
-      kubernetes:
-        role: my-app-1
-        mountPath: /v1/auth/kubernetes
-        serviceAccountRef:
-          name: vault-issuer
+rules:
+  - apiGroups: ['']
+    resources: ['serviceaccounts/token']
+    resourceNames: ['vault-issuer']
+    verbs: ['create']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-issuer
+  namespace: sandbox
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vault-issuer
 ```
 
-> **Issuer vs. ClusterIssuer:** With an Issuer resource, you can only refer to a
-> service account located in the same namespace as the Issuer. With a
-> ClusterIssuer, the service account must be located in the namespace that is
-> configured by the flag `--cluster-resource-namespace`.
-
-To create the role in Vault, you can use the following command:
+Then, create the Vault role:
 
 ```bash
-vault write auth/kubernetes/role/vault-issuer \
+vault write auth/kubernetes/role/vault-issuer-role \
     bound_service_account_names=vault-issuer \
     bound_service_account_namespaces=sandbox \
     audience="vault://sandbox/vault-issuer" \
-    policies=vault-issuer \
+    policies=default \
     ttl=1m
 ```
 
@@ -747,30 +584,7 @@ Issuer or ClusterIssuer. The syntax is the following:
 "vault://<cluster-issuer-name>"       # For a ClusterIssuer.
 ```
 
-The expiration duration for the Kubernetes tokens that are requested is
-hard-coded to 10 minutes (that's the minimum accepted). The `ttl` field can be
-as short as possible, since cert-manager requests a new token every time it
-needs to talks to Vault.
-
-Although it is not recommended, you can also use the same Vault role for all of
-your Issuers and ClusterIssuers by omitting the `audience` field and re-using
-the same service account.
-
-#### Secretless Authentication with a Service Account (External Vault)
-
-ℹ️ This feature is available in cert-manager >= v1.15.0.
-
-If you are using a Vault instance external to your cluster, you will need to set
-the `audiences` to an audience accepted by your Kubernetes cluster. When using
-an external Vault instance, the short-lived token created by cert-manager to
-authenticate to Vault will be used by Vault for authenticating to Kubernetes.
-First, find what your cluster's issuer is:
-
-```sh
-kubectl get --raw /.well-known/openid-configuration | jq .issuer -r
-```
-
-Then, set the `audiences` field to the issuer URL:
+Finally, you can create your Issuer:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -784,124 +598,32 @@ spec:
     server: https://vault.local
     auth:
       kubernetes:
-        role: my-app-1
-        mountPath: /v1/auth/kubernetes
+        role: vault-issuer-role
+        mountPath: /v1/auth/kubernetes-cluster001
         serviceAccountRef:
           name: vault-issuer
-          audiences: [https://kubernetes.default.svc.cluster.local]
 ```
 
-When using `audiences`, the JWT will still include the generated audience
-`vault://namespace/issuer-name` or `vault://cluster-issuer`. The generated
-audience is useful for restricting access to a Vault role to a certain issuer.
-
-When configuring the Kubernetes Vault auth method, omit the `token_reviewer_jwt`
-parameter so that Vault uses the token provided by cert-manager to authenticate
-with the Kubernetes API server when reviewing the token.
-
-#### Authentication with a Static Service Account Token
-
-For the Vault issuer to use this authentication, cert-manager must get access to
-the token that is stored in a Kubernetes `Secret`. Kubernetes Service Account
-Tokens are already stored in `Secret` resources however, you must ensure that
-it is present in the same namespace as the `Issuer`, or otherwise in the
-`Cluster Resource Namespace` in the case of using a `ClusterIssuer`.
-
-> **Note**: In Kubernetes 1.24 onwards, the token secret is no longer created
-> by default for the Service Account. In this case you need to manually create
-> the secret resource. See [this guide](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets)
-> for more details.
-
-This authentication method also expects a `role` field which is the Vault role
-that the Service Account is to assume, as well as an optional `mountPath` field which
-is the authentication mount path, defaulting to `kubernetes`.
-
-#### Kubernetes version less than 1.24
-
-The following example will be making use of the Service Account
-`my-service-account`. The secret data field key will be `token` if the `Secret`
-has been created by Kubernetes. The Vault role used is `my-app-1`, using the
-default mount path of `/v1/auth/kubernetes`
-
-1) Create the Service Account:
-
-    ```shell
-    kubectl create serviceaccount -n sandbox vault-issuer
-    ```
-
-1) Get the auto-generated Secret name:
-
-    ```shell
-    kubectl get secret -o json | jq -r '.items[] | select(.metadata.annotations["kubernetes.io/service-account.name"] == "vault-issuer") | .metadata.name'
-    ```
-
-1) Create the Issuer using that Secret name retrieved from the previous step:
-
-    ```yaml
-    apiVersion: cert-manager.io/v1
-    kind: Issuer
-    metadata:
-      name: vault-issuer
-      namespace: sandbox
-    spec:
-      vault:
-        path: pki_int/sign/example-dot-com
-        server: https://vault.local
-        caBundle: <base64 encoded caBundle PEM file>
-        auth:
-          kubernetes:
-            role: my-app-1
-            mountPath: /v1/auth/kubernetes
-            secretRef:
-              name: <auto-generated secret name>
-              key: token
-    ```
-
-#### Kubernetes version 1.24 and greater
-
-This example is almost the same as above but adjusted for the change in
-Kubernetes 1.24 and above.
-
-1) Create the Service Account:
-
-    ```shell
-    kubectl create serviceaccount -n sandbox vault-issuer
-    ```
-
-1) Create the Secret resource for Kubernetes to populate the `token` value:
-
-    ```yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: vault-issuer-token
-      annotations:
-        kubernetes.io/service-account.name: "vault-issuer"
-    type: kubernetes.io/service-account-token
-    data: {}
-    ```
-
-1) Create the Issuer resource referencing the Secret resource:
-  
-    ```yaml
-    apiVersion: cert-manager.io/v1
-    kind: Issuer
-    metadata:
-      name: vault-issuer
-      namespace: sandbox
-    spec:
-      vault:
-        path: pki_int/sign/example-dot-com
-        server: https://vault.local
-        caBundle: <base64 encoded caBundle PEM file>
-        auth:
-          kubernetes:
-            role: my-app-1
-            mountPath: /v1/auth/kubernetes
-            secretRef:
-              name: vault-issuer-token
-              key: token
-    ```
+> **Note**: If you are re-using the JWT token that is provided by cert-manager to authenticate to Vault, you
+> can omit the `token_reviewer_jwt` parameter when configuring the Kubernetes Vault auth method. But you must
+> additionally configure cert-manager to include the Kubernetes API server audience in the JWT token. This is
+> done by setting the `audiences` field in the `serviceAccountRef` field.
+> ```bash
+> KUBE_API_AUDIENCE="$(kubectl create token default | jq -R 'gsub("-";"+") | gsub("_";"/") | split(".") | .[1] | @base64d | fromjson | .aud[0]')"
+> ```
+>
+> ```yaml
+> ...
+>       kubernetes:
+>         ...
+>         serviceAccountRef:
+>           name: vault-issuer
+>           audiences: [ $KUBE_API_AUDIENCE ]
+> ```
+>
+> When using `audiences`, the JWT will still include the generated audience
+> `vault://namespace/issuer-name` or `vault://cluster-issuer`. The generated
+> audience is useful for restricting access to a Vault role to a certain issuer.
 
 ## Verifying the issuer Deployment
 

--- a/content/docs/configuration/vault.md
+++ b/content/docs/configuration/vault.md
@@ -370,7 +370,7 @@ Vault Authentication Method:
 #### Option 1. Vault Authentication Method: Use JWT/OIDC Auth
 
 The [JWT/OIDC auth method](https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/kubernetes) should be used instead of the [Kubernetes auth method](#option-2-vault-authentication-method-use-kubernetes-auth) when:
-- Your Kubernetes' cluster OIDC discovery endpoint is reachable from the Vault server.
+- Your Kubernetes' cluster OIDC discovery endpoint is reachable from the Vault server (this is likely not the case if you are running a self-hosted Kubernetes or OpenShift cluster).
 - Your Vault server is not running inside the Kubernetes cluster.
 
 > **Note:** By using the JWT auth instead of the Kubernetes auth, the revocation of tokens will no longer be checked:  
@@ -393,6 +393,20 @@ $ curl "$ISSUER/.well-known/openid-configuration"
   "issuer": "https://container.googleapis.com/v1/projects/project001/locations/europe-west1-b/clusters/cert-manager-cluster",
   "jwks_uri": "https://container.googleapis.com/v1/projects/project001/locations/europe-west1-b/clusters/cert-manager-cluster/jwks",
   ...
+}
+
+$ curl "<jwks_uri value>"
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "key-id",
+      "alg": "RS256",
+      "n": "..."
+    }
+  ]
 }
 ```
 

--- a/content/docs/configuration/vault.md
+++ b/content/docs/configuration/vault.md
@@ -607,7 +607,9 @@ spec:
 > **Note**: If you are re-using the JWT token that is provided by cert-manager to authenticate to Vault, you
 > can omit the `token_reviewer_jwt` parameter when configuring the Kubernetes Vault auth method. But you must
 > additionally configure cert-manager to include the Kubernetes API server audience in the JWT token. This is
-> done by setting the `audiences` field in the `serviceAccountRef` field.
+> done by setting the `audiences` field in the `serviceAccountRef` field. This option is only available in
+> cert-manager >= v1.15.0.
+>
 > ```bash
 > KUBE_API_AUDIENCE="$(kubectl create token default | jq -R 'gsub("-";"+") | gsub("_";"/") | split(".") | .[1] | @base64d | fromjson | .aud[0]')"
 > ```


### PR DESCRIPTION
I reviewed https://github.com/cert-manager/website/pull/1397 and simplified the documentation, while trying to maintain as much of the valuable insights as possible.