### PR TITLE
Add release notes for v1.12.12 and v1.14.7

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.12.md
+++ b/content/docs/releases/release-notes/release-notes-1.12.md
@@ -217,6 +217,16 @@ time and resources towards the continued maintenance of cert-manager projects. V
 cert-manager 1.12 as a long term support release, meaning it will be maintained for much longer
 than other releases to provide a stable platform for enterprises to build upon.
 
+## `v1.12.12`
+
+### Bugfixes
+
+- BUGFIX: fix issue that caused Vault issuer to not retry signing when an error was encountered. ([#7113](https://github.com/cert-manager/cert-manager/pull/7113), [@cert-manager-bot](https://github.com/cert-manager-bot))
+
+### Other (Cleanup or Flake)
+
+- Update `github.com/Azure/azure-sdk-for-go/sdk/azidentity` to address `CVE-2024-35255` ([#7093](https://github.com/cert-manager/cert-manager/pull/7093), [@ThatsMrTalbot](https://github.com/ThatsMrTalbot))
+
 ## `v1.12.11`
 
 ### Other (Cleanup or Flake)

--- a/content/docs/releases/release-notes/release-notes-1.14.md
+++ b/content/docs/releases/release-notes/release-notes-1.14.md
@@ -52,6 +52,17 @@ without breaking users who have come to rely on the existing, documented behavio
 
   > ⚠️ There may be [clients that are incompatible with `DST Root CA X3`](https://github.com/mono/mono/issues/21233).
 
+## `v1.14.7`
+
+### Bugfixes
+
+- BUGFIX: fix issue that caused Vault issuer to not retry signing when an error was encountered. ([#7114](https://github.com/cert-manager/cert-manager/pull/7114), [@cert-manager-bot](https://github.com/cert-manager-bot))
+
+### Other (Cleanup or Flake)
+
+- Upgrade `go-jose` library to fix `CVE-2024-28180` trivy alert. ([#7109](https://github.com/cert-manager/cert-manager/pull/7109), [@inteon](https://github.com/inteon))
+- Update `github.com/Azure/azure-sdk-for-go/sdk/azidentity` to address `CVE-2024-35255` ([#7099](https://github.com/cert-manager/cert-manager/pull/7099), [@ThatsMrTalbot](https://github.com/ThatsMrTalbot))
+
 ## `v1.14.6`
 
 ## Changes by Kind


### PR DESCRIPTION
Add release notes for cert-manager [v1.12.12](https://github.com/cert-manager/cert-manager/releases/tag/v1.12.12) and [v1.14.7](https://github.com/cert-manager/cert-manager/releases/tag/v1.14.7).