### PR TITLE
Add release notes for cert-manager v1.15.1 and bump latest version

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.15.md
+++ b/content/docs/releases/release-notes/release-notes-1.15.md
@@ -33,7 +33,18 @@ Thanks also to the CNCF, which provides resources and support, and to the AWS op
 
 In addition, massive thanks to Venafi for contributing developer time and resources towards the continued maintenance of cert-manager projects.
 
-## Changes by Kind
+## `v1.15.1`
+
+### Bug or Regression
+
+- BUGFIX: fix issue that caused Vault issuer to not retry signing when an error was encountered. ([#7111](https://github.com/cert-manager/cert-manager/pull/7111), [@inteon](https://github.com/inteon))
+
+### Other (Cleanup or Flake)
+
+- Update github.com/Azure/azure-sdk-for-go/sdk/azidentity to address CVE-2024-35255 ([#7092](https://github.com/cert-manager/cert-manager/pull/7092), [@ThatsMrTalbot](https://github.com/ThatsMrTalbot))
+- Bump the go-retryablehttp dependency to fix CVE-2024-6104 ([#7130](https://github.com/cert-manager/cert-manager/pull/7130), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
+## `v1.15.0`
 
 ### Feature
 

--- a/content/docs/releases/release-notes/release-notes-1.15.md
+++ b/content/docs/releases/release-notes/release-notes-1.15.md
@@ -41,8 +41,8 @@ In addition, massive thanks to Venafi for contributing developer time and resour
 
 ### Other (Cleanup or Flake)
 
-- Update github.com/Azure/azure-sdk-for-go/sdk/azidentity to address CVE-2024-35255 ([#7092](https://github.com/cert-manager/cert-manager/pull/7092), [@ThatsMrTalbot](https://github.com/ThatsMrTalbot))
-- Bump the go-retryablehttp dependency to fix CVE-2024-6104 ([#7130](https://github.com/cert-manager/cert-manager/pull/7130), [@SgtCoDFish](https://github.com/SgtCoDFish))
+- Update `github.com/Azure/azure-sdk-for-go/sdk/azidentity` to address `CVE-2024-35255` ([#7092](https://github.com/cert-manager/cert-manager/pull/7092), [@ThatsMrTalbot](https://github.com/ThatsMrTalbot))
+- Bump the `go-retryablehttp` dependency to fix `CVE-2024-6104` ([#7130](https://github.com/cert-manager/cert-manager/pull/7130), [@SgtCoDFish](https://github.com/SgtCoDFish))
 
 ## `v1.15.0`
 

--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,3 +1,3 @@
 {
-    "cert_manager_latest_version": "v1.15.0"
+    "cert_manager_latest_version": "v1.15.1"
 }


### PR DESCRIPTION
Part of the release process.