### PR TITLE
Add redirects for cert-manager.dev, trust-manager.io and trust-manager.dev

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,9 @@
 # Redirect domain aliases to primary domain
 https://netlify.cert-manager.io/* https://cert-manager.io/:splat 301!
 https://cert-manager.netlify.com/* https://cert-manager.io/:splat 301!
+https://cert-manager.dev/* https://cert-manager.io/:splat 301!
+https://trust-manager.io/* https://cert-manager.io/:splat 301!
+https://trust-manager.dev/* https://cert-manager.io/:splat 301!
 
 # Redirect all next-docs on the main site to the release-next preview
 https://cert-manager.io/next-docs/* https://release-next--cert-manager-website.netlify.app/docs/:splat 301!


### PR DESCRIPTION
This will change the url from eg. trust-manager.io to cert-manager.io which will help prevent eg. google from thinking that these are different sites.