### PR TITLE
Add boilerplate for the cert-manager 1.16 release

### DIFF
--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -20,6 +20,14 @@
               "path": "/docs/releases/README.md"
           },
             {
+              "title": "1.16",
+              "path": "/docs/releases/release-notes/release-notes-1.16.md"
+            },
+            {
+              "title": "Upgrade 1.15 to 1.16",
+              "path": "/docs/releases/upgrading/upgrading-1.15-1.16.md"
+            },
+            {
               "title": "1.15",
               "path": "/docs/releases/release-notes/release-notes-1.15.md"
             },

--- a/content/docs/releases/release-notes/release-notes-1.16.md
+++ b/content/docs/releases/release-notes/release-notes-1.16.md
@@ -1,0 +1,22 @@
+---
+title: Release 1.16
+description: 'cert-manager release notes: cert-manager 1.16'
+---
+
+cert-manager 1.16 ...TODO
+
+## Community
+
+Thanks again to all open-source contributors with commits in this release, including: TODO
+
+Thanks also to the following cert-manager maintainers for their contributions during this release: TODO
+
+Equally thanks to everyone who provided feedback, helped users and raised issues on GitHub and Slack and joined our meetings!
+
+Thanks also to the CNCF, which provides resources and support, and to the AWS open source team for being good community members and for their maintenance of the PrivateCA Issuer.
+
+In addition, massive thanks to Venafi for contributing developer time and resources towards the continued maintenance of cert-manager projects.
+
+## `v1.16.0`
+
+TODO

--- a/content/docs/releases/upgrading/upgrading-1.15-1.16.md
+++ b/content/docs/releases/upgrading/upgrading-1.15-1.16.md
@@ -1,0 +1,12 @@
+---
+title: Upgrading from v1.15 to v1.16
+description: 'cert-manager installation: Upgrading v1.15 to v1.16'
+---
+
+Before upgrading cert-manager from 1.15 to 1.16 please read the following important notes about breaking changes in 1.16:
+
+TODO
+
+## Next Steps
+
+From here on you can follow the [regular upgrade process](../../installation/upgrade.md).

--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,3 +1,3 @@
 {
-    "cert_manager_latest_version": "v1.15.1"
+    "cert_manager_latest_version": "v1.16.0-alpha.0"
 }


### PR DESCRIPTION
**Preview**: https://deploy-preview-1521--cert-manager.netlify.app/

I've added some boilerplate release notes and upgrade notes for cert-manager 1.16, 
to make it easier for people writing release notes and documentation for  new features in 1.16