### PR TITLE
Document new releases of istio-csr and trust-manager

### DIFF
--- a/content/docs/reference/api-docs.md
+++ b/content/docs/reference/api-docs.md
@@ -6787,5 +6787,5 @@ description: >-
 </table>
 <hr />
 <p>
-  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>3403251</code>. </em>
+  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>35e27b7</code>. </em>
 </p>

--- a/content/docs/usage/istio-csr/installation.md
+++ b/content/docs/usage/istio-csr/installation.md
@@ -9,6 +9,18 @@ This guide will run through installing and using istio-csr from scratch. We'll u
 
 Note that if you're following the Platform Setup guide for OpenShift, do not run the `istioctl install` command listed in that guide; we'll run our own command later.
 
+### 0. Background
+
+istio-csr uses cert-manager to issue Istio certificates, and needs to be able to reference an issuer resource to do this.
+
+You can choose to configure a an issuer when installing with the Helm chart, or to configure a ConfigMap to watch which can then be used to configure an issuer at runtime.
+
+If you configure an issuer in the chart, you'll be able to start issuing as soon as the istio-csr pods come online but you'll need to have already installed cert-manager and created the issuer.
+
+If you don't set an issuer in the chart, istio-csr will be unable to issue until an issuer is specified via runtime configuration, but you'll be able to install cert-manager and istio-csr concurrently.
+
+Note that the chart contains a default issuer name and so using runtime configuration requires an explicit opt-in. The guide below assumes you'll install istio-csr after an issuer is configured. A future release of istio-csr will improve runtime configuration support and a guide will be added for runtime-configured installation along with that release. Until then, there are some notes at the bottom of this page.
+
 ### 1. Initial Setup
 
 You'll need the following tools installed on your machine:
@@ -277,6 +289,89 @@ Assuming your running inside kind, you can simply remove the cluster:
 ```shell
 kind delete cluster
 ```
+
+## Installation with Runtime Configuration
+
+There are two options for installing with runtime configuration:
+
+1. Install after cert-manager and pass an explicit `issuerRef` in the Helm chart
+2. Blank out the `issuerRef` in the Helm chart and use pure runtime configuration
+
+Both options will require a ConfigMap to be created to point at an issuer. This ConfigMap can be created
+before or after installation, and must be created in the same namespace as the istio-csr pods.
+
+### Creating the ConfigMap
+
+Three keys are required, specifying the issuer name, kind and group. Any method of creating a ConfigMap will work. For example:
+
+```bash
+kubectl create configmap -n cert-manager istio-issuer \
+  --from-literal=issuer-name=my-issuer-name \
+  --from-literal=issuer-kind=ClusterIssuer \
+  --from-literal=issuer-group=cert-manager.io
+```
+
+### Option 1: Installation after cert-manager
+
+If cert-manager is already installed, you can use the same `helm upgrade` command as above but also specifying the name of the runtime configuration ConfigMap:
+
+```bash
+helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
+  --install \
+  --namespace cert-manager \
+  --wait \
+  ...
+  --set "app.runtimeIssuanceConfigMap=istio-issuer"
+```
+
+In this scenario, the issuer defined in `app.certmanager.issuer` will be used at startup and to create the `istiod` certificate.
+
+When istio-csr detects the runtime ConfigMap, it'll use the issuer configured there. If the ConfigMap is updated, istio-csr will respect the update dynamically.
+
+If the runtime ConfigMap is deleted, istio-csr will revert to using the value from `app.certmanager.issuer`.
+
+### Option 2: Pure Runtime Configuration
+
+Pure runtime configuration requires more values to be set:
+
+1. The `app.certmanager.issuer` values must be blanked out (as they're set to a default value in the chart)
+2. `istiod` certificate generation must be disabled. A future update to istio-csr will remove this requirement.
+3. The `istiod` certificate must be manually created before installing Istio, with DNS names corresponding to the required services. [This cert-manager Certificate](https://github.com/cert-manager/istio-csr/blob/v0.10.0/deploy/charts/istio-csr/templates/certificate.yaml) may help. A future update to istio-csr will remove this requirement,.
+4. The `app.runtimeIssuanceConfigMap` must be set.
+
+An example `values.yaml` file for pure runtime configuration is as follows:
+
+```yaml
+app:
+  runtimeIssuanceConfigMap: istio-issuer
+  certmanager:
+    issuer:
+      name: ""  # explicitly blanked out
+      kind: ""  # explicitly blanked out
+      group: "" # explicitly blanked out
+  tls:
+    rootCAFile: "/var/run/secrets/istio-csr/ca.pem"
+    istiodCertificateEnable: false # will not be required in a future release
+volumeMounts:
+- name: root-ca
+  mountPath: /var/run/secrets/istio-csr
+volumes:
+- name: root-ca
+  secret:
+    secretName: istio-root-ca
+```
+
+This file could then be used with the following command:
+
+```bash
+helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
+  --install \
+  --namespace cert-manager \
+  --wait \
+  --values values.yaml
+```
+
+We don't recommend using pure runtime configuration until a future release adds support for dynamic `istiod` certificate generation.
 
 ## Usage
 

--- a/scripts/gendocs/generate-trust-manager
+++ b/scripts/gendocs/generate-trust-manager
@@ -59,6 +59,6 @@ gendocs() {
 echo "+++ Cloning trust-manager repository..."
 git clone "https://github.com/cert-manager/trust-manager.git" "$tmpdir"
 
-checkout "v0.10.1"
+checkout "v0.12.0"
 
 gendocs "$REPO_ROOT/content/docs/trust/trust-manager/api-reference.md"


### PR DESCRIPTION
There are some new features in istio-csr v0.10.0 and trust-manager v0.12.0 which need some docs. This PR adds docs, and slightly restructures the trust-manager installation docs.

This also bumps the trust-manager api reference version, which produced no changes in the actual api reference docs.