### PR TITLE
Fix release next link

### DIFF
--- a/components/docs/VersionSelect.jsx
+++ b/components/docs/VersionSelect.jsx
@@ -55,7 +55,7 @@ export default function VersionSelect({
           ))}
           <div className="block px-2">
             <SidebarLink
-              href="https://release-next--cert-manager-website.netlify.app/docs/"
+              href="https://release-next--cert-manager.netlify.app/docs/"
               caption="next release"
               setSidebarCollapsed={setSidebarCollapsed}
               setParentOpen={setParentOpen}

--- a/components/docs/VersionSelect.jsx
+++ b/components/docs/VersionSelect.jsx
@@ -2,12 +2,12 @@ import { Listbox } from '@headlessui/react'
 import { useState } from 'react'
 import SidebarLink from './Sidebar/SidebarLink'
 
-import { compareVersions } from 'compare-versions';
+import { compareVersions } from 'compare-versions'
 
 function labelFromVersion(version) {
-    return version === 'docs'
-        ? 'latest'
-        : version.replace(/-docs$/, '').replace(/^v/, '');
+  return version === 'docs'
+    ? 'latest'
+    : version.replace(/-docs$/, '').replace(/^v/, '')
 }
 
 export default function VersionSelect({
@@ -25,7 +25,7 @@ export default function VersionSelect({
     .reverse()
 
   return (
-      <div className="bg-gray-1 rounded-md border-2 border-gray-2/50">
+    <div className="bg-gray-1 rounded-md border-2 border-gray-2/50">
       <Listbox value={selectedVersion} onChange={setSelectedVersion}>
         <Listbox.Button className="w-full">
           version: {labelFromVersion(version)}
@@ -64,5 +64,5 @@ export default function VersionSelect({
         </Listbox.Options>
       </Listbox>
     </div>
-  );
+  )
 }

--- a/public/_redirects
+++ b/public/_redirects
@@ -6,7 +6,7 @@ https://trust-manager.io/* https://cert-manager.io/:splat 301!
 https://trust-manager.dev/* https://cert-manager.io/:splat 301!
 
 # Redirect all next-docs on the main site to the release-next preview
-https://cert-manager.io/next-docs/* https://release-next--cert-manager-website.netlify.app/docs/:splat 301!
+https://cert-manager.io/next-docs/* https://release-next--cert-manager.netlify.app/docs/:splat 301!
 
 # Various older renamed pages
 /docs/configuration/externalloadbalancer/ /docs/configuration/acme/http01/externalloadbalancer/ 301!


### PR DESCRIPTION
This PR fixes the release-next link in the website version selector and in the HTTP redirect config file.

When cert-manager.io was moved to new [CNCF cert-manager owned Netlify account](https://github.com/cert-manager/infrastructure#netlify), the preview URL changed.

We discussed this on #cert-manager-dev 
 * https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1721316161085529