### PR TITLE
Update AWS Route53 documentation to better explain the authentication options

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -86,6 +86,8 @@ APIService
 APIServices
 APIs
 AWS
+SDK
+SDKs
 Akamai
 Anthos
 AppRole

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -228,9 +228,22 @@ A mutating webhook will automatically setup a mounted service account volume in 
 
    > ℹ️ If you're following the Cross Account example, modify the `ClusterIssuer` with the role from Account Y.
 
-3. **(optional) Update file system permissions**
+4. **(optional) Update file system permissions**
 
-   You may also need to modify the cert-manager `Deployment` with the correct file system permissions, so the `ServiceAccount` token can be read.
+   > 📢 **Please help us improve this documentation**
+   >
+   > The reason for this optional step is that on EKS Fargate and on some
+   > older versions of EKS you may observe errors such as:
+   > - `unable to read file at /var/run/secrets/eks.amazonaws.com/serviceaccount/token`
+   > - `open /var/run/secrets/eks.amazonaws.com/serviceaccount/token: permission denied`
+   >
+   > In this case, you can change the user and group of the cert-manager process
+   > so that it is able to read the mounted ServiceAccount token.
+   >
+   > Read [`cert-manager/website#697`: IRSA Needs `runAsUser: 1001`](https://github.com/cert-manager/website/issues/697)
+   > and tell us whether this step is still necessary or obsolete.
+
+   You may also need to modify the cert-manager `Deployment` with a different user and group, so the `ServiceAccount` token can be read.
 
    ```yaml
    spec:
@@ -238,6 +251,7 @@ A mutating webhook will automatically setup a mounted service account volume in 
        spec:
          securityContext:
            fsGroup: 1001
+           runAsUser: 1001
    ```
 
    The cert-manager Helm chart provides a variable for modifying cert-manager's `Deployment` like so:
@@ -245,14 +259,15 @@ A mutating webhook will automatically setup a mounted service account volume in 
    ```yaml
    securityContext:
      fsGroup: 1001
+     runAsUser: 1001
    ```
 
-4. **Restart the cert-manager Deployment**
+5. **Restart the cert-manager Deployment**
 
     Restart the cert-manager Deployment, so that the webhook can inject the
     necessary `volume`, `volumemount`, and environment variables into the Pods.
 
-5. **Create a `ClusterIssuer` resource**
+6. **Create a `ClusterIssuer` resource**
 
    ```yaml
    apiVersion: cert-manager.io/v1

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -98,7 +98,7 @@ environment, any tenant who has permission to create Issuer or ClusterIssuer may
 use the ambient credentials and gain the permissions granted to that account.
 
 > 📖 Read [AWS SDKs and Tools standardized credential providers](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html)
-> to learn how cert-manager, which uses the AWS SDK for Go V2, supports all these ambient credential sources.
+> to learn how cert-manager supports all these ambient credential sources.
 >
 > ⚠️ By default, cert-manager will only use ambient credentials for
 > `ClusterIssuer` resources, not `Issuer` resources.
@@ -157,7 +157,7 @@ It is a four step process:
 
 #### EKS IAM Role for Service Accounts (IRSA)
 
-IAM Roles for Service Accounts (IRSA) is another way to use ambient credentials,
+[IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) is another way to use ambient credentials,
 if you deploy cert-manager on EKS.
 It is more complicated than Pod Identity and requires coordination between the Kubernetes cluster administrator and the AWS account manager.
 It involves annotating the `cert-manager` ServiceAccount in Kubernetes, and setting up an IAM role, a trust policy and a trust relationship in AWS.

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -15,7 +15,7 @@ how cert-manager handles DNS01 challenges.
 > [Tutorial: Deploy cert-manager on Amazon Elastic Kubernetes (EKS) and use Let's Encrypt to sign a certificate for an HTTPS website](../../../tutorials/getting-started-aws-letsencrypt/README.md),
 > which contains end-to-end instructions for those who are new to cert-manager and AWS.
 
-## Set up an IAM Role
+## Set up an IAM Policy
 
 cert-manager needs to be able to add records to Route53 in order to solve the
 DNS01 challenge. To enable this, create a IAM policy with the following

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -125,7 +125,7 @@ spec:
     ...
     solvers:
     - dns01:
-        route53 {}:
+        route53: {}
 ```
 
 > ℹ️ Regardless of which ambient mechanism you use, the `route53` section is left empty,

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -47,7 +47,7 @@ permissions:
 }
 ```
 
-> Note: The `route53:ListHostedZonesByName` statement can be removed if you
+> ℹ️ The `route53:ListHostedZonesByName` statement can be removed if you
 > specify the (optional) `hostedZoneID`. You can further tighten the policy by
 > limiting the hosted zone that cert-manager has access to (e.g.
 > `arn:aws:route53:::hostedzone/DIKER8JEXAMPLE`).

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -51,6 +51,11 @@ permissions:
 > specify the (optional) `hostedZoneID`. You can further tighten the policy by
 > limiting the hosted zone that cert-manager has access to (e.g.
 > `arn:aws:route53:::hostedzone/DIKER8JEXAMPLE`).
+>
+> 📖 Read about [actions supported by Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/APIReference/API_Operations_Amazon_Route_53.html),
+> in the [Amazon Route 53 API Reference](https://docs.aws.amazon.com/Route53/latest/APIReference/Welcome.html).
+>
+> 📖 Learn how [`eksctl` can automatically create the cert-manager IAM policy](https://eksctl.io/usage/iam-policies/#cert-manager-policy), if you use EKS.
 
 ## Credentials
 

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -11,9 +11,9 @@ how cert-manager handles DNS01 challenges.
 > ℹ️ This guide assumes that your cluster is hosted on Amazon Web Services
 > (AWS) and that you already have a hosted zone in Route53.
 >
-> 📖 Read
-> [Tutorial: Deploy cert-manager on Amazon Elastic Kubernetes (EKS) and use Let's Encrypt to sign a certificate for an HTTPS website](../../../tutorials/getting-started-aws-letsencrypt/README.md),
-> which contains end-to-end instructions for those who are new to cert-manager and AWS.
+> 📖 Read the [AWS + LoadBalancer + Let's Encrypt](../../../tutorials/getting-started-aws-letsencrypt/README.md)
+> tutorial, which contains end-to-end instructions for those who are new to
+> cert-manager and AWS.
 
 ## Set up an IAM Policy
 
@@ -90,8 +90,8 @@ Ambient credentials are credentials which are made available in the cert-manager
 - [**Shared config and credentials files**](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html):<br/>
   where cert-manager loads credentials from files (`~/.aws/config` and `~/.aws/credentials`) which are mounted into the cert-manager controller Pod.
 
-The advantage of ambient credentials is that they are easier to set up, well
-documented, and AWS provides ways to automate the configuration.
+The advantage of ambient credentials is that they are easier to set up and
+extensively documented by Amazon AWS.
 The disadvantage of ambient credentials is that they are globally available to
 all ClusterIssuer and all Issuer resources, which means that in a multi-tenant
 environment, any tenant who has permission to create Issuer or ClusterIssuer may
@@ -150,10 +150,9 @@ It is a four step process:
      name: letsencrypt-prod
    spec:
      acme:
-       ...
        solvers:
        - dns01:
-           route53 {}:
+           route53: {}
    ```
 
 #### EKS IAM Role for Service Accounts (IRSA)
@@ -260,10 +259,9 @@ A mutating webhook will automatically setup a mounted service account volume in 
      name: letsencrypt-prod
    spec:
      acme:
-       ...
        solvers:
        - dns01:
-           route53 {}:
+           route53: {}
    ```
 
 ### Non-ambient Credentials
@@ -280,6 +278,9 @@ The advantage of non-ambient credentials is that cert-manager can perform Route5
 Each tenant can be granted permission to create and update Issuer resources in their namespace and they can provide their own AWS credentials in their namespace.
 
 #### Referencing your own ServiceAccount within in an Issuer or ClusterIssuer
+
+> 📖 Read the [AWS + LoadBalancer + Let's Encrypt tutorial](../../../tutorials/getting-started-aws-letsencrypt/README.md)
+> to learn how to deploy cert-manager on EKS and use this authentication mechanism.
 
 In this configuration you can reference your own `ServiceAccounts` in your `Issuer` or `ClusterIssuer`
 and cert-manager will get a ServiceAccount token from the Kubernetes API which it will send to STS in exchange for AWS temporary credentials.

--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -488,3 +488,40 @@ And the following trust relationship (Add AWS `Service`s as needed):
   ]
 }
 ```
+
+## Region
+
+If you omit the `.spec.acme.solvers.dns01.route53.region` field, cert-manager
+will get the region from the `AWS_REGION` and `AWS_DEFAULT_REGION` environment
+variables if they are set in the cert-manager controller Pod.
+
+If you use [ambient credentials](#ambient-credentials), the `AWS_REGION` and
+`AWS_DEFAULT_REGION` environment variables have a higher priority, and the
+`.spec.acme.solvers.dns01.route53.region` field will only be used if the
+environment variables are not set.
+
+The `.spec.acme.solvers.dns01.route53.region` field is ignored if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html),
+because an `AWS_REGION` environment variable is added to the cert-manager controller Pod by
+the [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent).
+
+The `.spec.acme.solvers.dns01.route53.region` field is ignored if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html),
+because an `AWS_REGION` environment variable is added to the cert-manager controller Pod by
+the [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+
+> ℹ️ Route53 is a global service and does not have regional endpoints, but the region
+> is used as a hint to help compute the correct AWS credential scope and partition
+> when it connects to Route53.
+>
+> 📖 Read [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html) and
+> [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+> to learn more.
+
+> ℹ️ STS is a regional service and cert-manager will use regional STS endpoint URLs
+> computed from the `region` field or environment variables.
+> STS is used for [IRSA credentials](#eks-iam-role-for-service-accounts-irsa), [dedicated ServiceAccount credentials](#referencing-your-own-serviceaccount-within-in-an-issuer-or-clusterissuer), and [cross account access](#cross-account-access).
+>
+> 📖 Read [Manage AWS STS in an AWS Region](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+> to learn about which regions support STS.
+>
+> 📖 Read [AWS STS Regional endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html),
+> to learn how to configure the use of regional STS endpoints using environment variables.

--- a/content/docs/tutorials/getting-started-aws-letsencrypt/README.md
+++ b/content/docs/tutorials/getting-started-aws-letsencrypt/README.md
@@ -379,7 +379,7 @@ You need to prove to Let's Encrypt that you own the domain name of the certifica
 This is known as the [DNS-01 challenge type](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
 
 cert-manager can create that DNS record for you in by using the AWS Route53 API but it needs to authenticate first,
-and currently the most secure method of authentication is to use a [dedicated Kubernetes ServiceAccount token](../../configuration/acme/dns01/route53.md#referencing-your-own-serviceaccount-within-in-an-issuer-or-clusterissuer).
+and currently the most secure method of authentication is to use an [IAM Role with dedicated Kubernetes ServiceAccount](../../configuration/acme/dns01/route53.md#iam-role-with-dedicated-kubernetes-serviceaccount).
 The advantages of this method are that cert-manager will use an ephemeral Kubernetes ServiceAccount Token to authenticate to AWS and the token need not be stored in a Kubernetes Secret.
 
 > 📖 Read about [other ways to configure the ACME issuer with AWS Route53 DNS](../../configuration/acme/dns01/route53.md).

--- a/content/docs/tutorials/getting-started-aws-letsencrypt/README.md
+++ b/content/docs/tutorials/getting-started-aws-letsencrypt/README.md
@@ -12,8 +12,8 @@ In this tutorial you will learn how to deploy and configure cert-manager on AWS 
 and how to deploy an HTTPS web server and make it available on the Internet.
 You will learn how to configure cert-manager to get a signed certificate from Let's Encrypt,
 which will allow clients to connect to your HTTPS website securely.
-You will configure cert-manager to use the [Let's Encrypt DNS-01 challenge protocol](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) with AWS Route53 DNS,
-using IAM Roles for Service Accounts (IRSA) to authenticate to AWS.
+You will configure cert-manager to use the [Let's Encrypt DNS-01 challenge protocol](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) with AWS Route53 DNS.
+You will authenticate to Route53 using a [dedicated Kubernetes ServiceAccount token](../../configuration/acme/dns01/route53.md#referencing-your-own-serviceaccount-within-in-an-issuer-or-clusterissuer).
 
 # Part 1
 
@@ -379,7 +379,7 @@ You need to prove to Let's Encrypt that you own the domain name of the certifica
 This is known as the [DNS-01 challenge type](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
 
 cert-manager can create that DNS record for you in by using the AWS Route53 API but it needs to authenticate first,
-and currently the most secure method of authentication is to use [IAM roles for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+and currently the most secure method of authentication is to use a [dedicated Kubernetes ServiceAccount token](../../configuration/acme/dns01/route53.md#referencing-your-own-serviceaccount-within-in-an-issuer-or-clusterissuer).
 The advantages of this method are that cert-manager will use an ephemeral Kubernetes ServiceAccount Token to authenticate to AWS and the token need not be stored in a Kubernetes Secret.
 
 > 📖 Read about [other ways to configure the ACME issuer with AWS Route53 DNS](../../configuration/acme/dns01/route53.md).
@@ -425,7 +425,7 @@ aws iam create-policy \
 EOF
 ```
 
-> ℹ️ Read the [cert-manager ACME DNS01 Route53 configuration documentation](https://cert-manager.io/docs/configuration/acme/dns01/route53),
+> ℹ️ Read the [cert-manager ACME DNS01 Route53 configuration documentation](../../configuration/acme/dns01/route53.md),
 > for more details of this IAM policy.
 
 ## Create an IAM role and associate it with a Kubernetes service account


### PR DESCRIPTION
**Preview**: https://deploy-preview-1555--cert-manager.netlify.app/docs/configuration/acme/dns01/route53/

The aim of this PR is to help users understand that fundamentally cert-manager needs to get an access key **somehow**,
so that it can authenticate to Route53.

There are legacy mechanisms, where it can use an IAM User and a long-term access key from a mounted file, or from an environment variable in the cert-manager Pod, or by loading it from a Secret.

There are best-practice mechanisms, where it can use an IAM Role and get a temporary access key from STS, either by explicitly sending a Kubernetes ServiceAccount token to STS (AssumeRoleWithWebIdentity). 
Or by fetching a temporary access token from a local server such as IMDS on an EC2 node or from a Pod Identity agent in a DaemonSet Pod on a Kubernetes Node.

There are ambient mechanisms, where credentials are global to the cert-manager controller.
And there are non-ambient mechanisms, where the credentials can be unique to each Issuer or ClusterIssuer.

I have also added documentation about how cert-manager chooses an AWS region  and how that region is used.

Fixes: https://github.com/cert-manager/website/issues/56
Fixes: https://github.com/cert-manager/website/issues/753
Fixes: https://github.com/cert-manager/cert-manager/issues/4738
* https://github.com/cert-manager/website/issues/56
* https://github.com/cert-manager/website/issues/753
* https://github.com/cert-manager/cert-manager/issues/4738