### PR TITLE
Update trust-manager API docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -87,6 +87,7 @@ APIServices
 APIs
 AWS
 Akamai
+ANDed
 Anthos
 AppRole
 approvers
@@ -106,6 +107,7 @@ BundleSource
 BundleTarget
 BundleCondition
 NamespaceSelector
+CamelCase
 CAs
 CNAME
 CNAMEs
@@ -160,6 +162,7 @@ Dean-Coakley
 DigitalOcean
 OVHCloud
 Distroless
+DoesNotExist
 DuckDuckGo
 etcd
 EC2
@@ -234,6 +237,7 @@ NameCheap
 NGINX
 NLB
 NLBs
+NotIn
 Ocado
 OmairK
 OpenAPI
@@ -343,6 +347,7 @@ coderanger
 config
 containerd
 customizable
+defaultCAPackageVersion
 distroless
 e.g.
 e2e
@@ -426,8 +431,10 @@ multivalue
 macOS
 makefile
 manual-rotation-private-key
+matchExpressions
 mechanism
 metadata
+metadata.generation
 middleware
 migrate-api-version
 misconfiguration
@@ -444,6 +451,7 @@ namespaces
 ndegory
 oauth2
 OAuth
+observedGeneration
 onwards
 openshift-supported-versions
 plaintext
@@ -472,6 +480,7 @@ runtime
 runtimes
 signoff
 sigstore
+status.condition
 stdout
 subchart
 subcommand
@@ -501,6 +510,7 @@ unredacted
 unschedule
 untrusted
 upstream
+useDefaultCAs
 userinfo
 util
 vhosakot

--- a/content/docs/trust/trust-manager/api-reference.md
+++ b/content/docs/trust/trust-manager/api-reference.md
@@ -55,14 +55,16 @@ Resource Types:
         <td><b><a href="#bundlespec">spec</a></b></td>
         <td>object</td>
         <td>
-          Desired state of the Bundle resource.<br/>
+          Desired state of the Bundle resource.
+<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#bundlestatus">status</a></b></td>
         <td>object</td>
         <td>
-          Status of the Bundle. This is set and managed automatically.<br/>
+          Status of the Bundle. This is set and managed automatically.
+<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -87,14 +89,16 @@ Desired state of the Bundle resource.
         <td><b><a href="#bundlespecsourcesindex">sources</a></b></td>
         <td>[]object</td>
         <td>
-          Sources is a set of references to data whose data will sync to the target.<br/>
+          Sources is a set of references to data whose data will sync to the target.
+<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#bundlespectarget">target</a></b></td>
         <td>object</td>
         <td>
-          Target is the target location in all namespaces to sync source data to.<br/>
+          Target is the target location in all namespaces to sync source data to.
+<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -104,7 +108,8 @@ Desired state of the Bundle resource.
 ### `Bundle.spec.sources[index]`
 
 
-BundleSource is the set of sources whose data will be appended and synced to the BundleTarget in all Namespaces.
+BundleSource is the set of sources whose data will be appended and synced to
+the BundleTarget in all Namespaces.
 
 <table>
     <thead>
@@ -119,28 +124,41 @@ BundleSource is the set of sources whose data will be appended and synced to the
         <td><b><a href="#bundlespecsourcesindexconfigmap">configMap</a></b></td>
         <td>object</td>
         <td>
-          ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.<br/>
+          ConfigMap is a reference (by name) to a ConfigMap's `data` key, or to a
+list of ConfigMap's `data` key using label selector, in the trust Namespace.
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>inLine</b></td>
         <td>string</td>
         <td>
-          InLine is a simple string to append as the source data.<br/>
+          InLine is a simple string to append as the source data.
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#bundlespecsourcesindexsecret">secret</a></b></td>
         <td>object</td>
         <td>
-          Secret is a reference to a Secrets's `data` key, in the trust Namespace.<br/>
+          Secret is a reference (by name) to a Secret's `data` key, or to a
+list of Secret's `data` key using label selector, in the trust Namespace.
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>useDefaultCAs</b></td>
         <td>boolean</td>
         <td>
-          UseDefaultCAs, when true, requests the default CA bundle to be used as a source. Default CAs are available if trust-manager was installed via Helm or was otherwise set up to include a package-injecting init container by using the "--default-package-location" flag when starting the trust-manager controller. If default CAs were not configured at start-up, any request to use the default CAs will fail. The version of the default CA package which is used for a Bundle is stored in the defaultCAPackageVersion field of the Bundle's status field.<br/>
+          UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
+Default CAs are available if trust-manager was installed via Helm
+or was otherwise set up to include a package-injecting init container by using the
+"--default-package-location" flag when starting the trust-manager controller.
+If default CAs were not configured at start-up, any request to use the default
+CAs will fail.
+The version of the default CA package which is used for a Bundle is stored in the
+defaultCAPackageVersion field of the Bundle's status field.
+<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -150,7 +168,8 @@ BundleSource is the set of sources whose data will be appended and synced to the
 ### `Bundle.spec.sources[index].configMap`
 
 
-ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
+ConfigMap is a reference (by name) to a ConfigMap's `data` key, or to a
+list of ConfigMap's `data` key using label selector, in the trust Namespace.
 
 <table>
     <thead>
@@ -165,21 +184,110 @@ ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
+          Key is the key of the entry in the object's `data` field to be used.
+<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name is the name of the source object in the trust Namespace. If not set, `selector` must be set.<br/>
+          Name is the name of the source object in the trust Namespace.
+This field must be left empty when `selector` is set
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#labelselector-v1-meta">selector</a></b></td>
-        <td>LabelSelector</td>
+        <td><b><a href="#bundlespecsourcesindexconfigmapselector">selector</a></b></td>
+        <td>object</td>
         <td>
-          A LabelSelector object to reference, by labels, a list of source objects in the trust Namespace. If not set, `name` must be set.<br/>
+          Selector is the label selector to use to fetch a list of objects. Must not be set
+when `Name` is set.
+<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.spec.sources[index].configMap.selector`
+
+
+Selector is the label selector to use to fetch a list of objects. Must not be set
+when `Name` is set.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#bundlespecsourcesindexconfigmapselectormatchexpressionsindex">matchExpressions</a></b></td>
+        <td>[]object</td>
+        <td>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.
+<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchLabels</b></td>
+        <td>map[string]string</td>
+        <td>
+          matchLabels is a map of key-value pairs. A single key-value in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.
+<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.spec.sources[index].configMap.selector.matchExpressions[index]`
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          key is the label key that the selector applies to.
+<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>string</td>
+        <td>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.
+<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.
+<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -189,7 +297,8 @@ ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
 ### `Bundle.spec.sources[index].secret`
 
 
-Secret is a reference to a Secrets's `data` key, in the trust Namespace.
+Secret is a reference (by name) to a Secret's `data` key, or to a
+list of Secret's `data` key using label selector, in the trust Namespace.
 
 <table>
     <thead>
@@ -204,21 +313,110 @@ Secret is a reference to a Secrets's `data` key, in the trust Namespace.
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
+          Key is the key of the entry in the object's `data` field to be used.
+<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name is the name of the source object in the trust Namespace. If not set, `selector` must be set.<br/>
+          Name is the name of the source object in the trust Namespace.
+This field must be left empty when `selector` is set
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#labelselector-v1-meta">selector</a></b></td>
-        <td>LabelSelector</td>
+        <td><b><a href="#bundlespecsourcesindexsecretselector">selector</a></b></td>
+        <td>object</td>
         <td>
-          A LabelSelector object to reference, by labels, a list of source objects in the trust Namespace. If not set, `name` must be set.<br/>
+          Selector is the label selector to use to fetch a list of objects. Must not be set
+when `Name` is set.
+<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.spec.sources[index].secret.selector`
+
+
+Selector is the label selector to use to fetch a list of objects. Must not be set
+when `Name` is set.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#bundlespecsourcesindexsecretselectormatchexpressionsindex">matchExpressions</a></b></td>
+        <td>[]object</td>
+        <td>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.
+<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchLabels</b></td>
+        <td>map[string]string</td>
+        <td>
+          matchLabels is a map of key-value pairs. A single key-value in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.
+<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.spec.sources[index].secret.selector.matchExpressions[index]`
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          key is the label key that the selector applies to.
+<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>string</td>
+        <td>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.
+<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.
+<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -243,28 +441,36 @@ Target is the target location in all namespaces to sync source data to.
         <td><b><a href="#bundlespectargetadditionalformats">additionalFormats</a></b></td>
         <td>object</td>
         <td>
-          AdditionalFormats specifies any additional formats to write to the target<br/>
+          AdditionalFormats specifies any additional formats to write to the target
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#bundlespectargetconfigmap">configMap</a></b></td>
         <td>object</td>
         <td>
-          ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.<br/>
+          ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+data will be synced to.
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#bundlespectargetnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.<br/>
+          NamespaceSelector will, if set, only sync the target resource in
+Namespaces which match the selector.
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#bundlespectargetsecret">secret</a></b></td>
         <td>object</td>
         <td>
-          Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.<br/>
+          Secret is the target Secret that all Bundle source data will be synced to.
+Using Secrets as targets is only supported if enabled at trust-manager startup.
+By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -289,14 +495,19 @@ AdditionalFormats specifies any additional formats to write to the target
         <td><b><a href="#bundlespectargetadditionalformatsjks">jks</a></b></td>
         <td>object</td>
         <td>
-          JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".<br/>
+          JKS requests a JKS-formatted binary trust bundle to be written to the target.
+The bundle has "changeit" as the default password.
+For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#bundlespectargetadditionalformatspkcs12">pkcs12</a></b></td>
         <td>object</td>
         <td>
-          PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.<br/>
+          PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+The bundle is by default created without a password.
+<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -306,7 +517,9 @@ AdditionalFormats specifies any additional formats to write to the target
 ### `Bundle.spec.target.additionalFormats.jks`
 
 
-JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
+JKS requests a JKS-formatted binary trust bundle to be written to the target.
+The bundle has "changeit" as the default password.
+For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
 
 <table>
     <thead>
@@ -321,9 +534,20 @@ JKS requests a JKS-formatted binary trust bundle to be written to the target. Th
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
+          Key is the key of the entry in the object's `data` field to be used.
+<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>password</b></td>
+        <td>string</td>
+        <td>
+          Password for JKS trust store
+<br/>
+          <br/>
+            <i>Default</i>: changeit<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -331,7 +555,8 @@ JKS requests a JKS-formatted binary trust bundle to be written to the target. Th
 ### `Bundle.spec.target.additionalFormats.pkcs12`
 
 
-PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
+PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+The bundle is by default created without a password.
 
 <table>
     <thead>
@@ -346,9 +571,20 @@ PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the targ
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
+          Key is the key of the entry in the object's `data` field to be used.
+<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>password</b></td>
+        <td>string</td>
+        <td>
+          Password for PKCS12 trust store
+<br/>
+          <br/>
+            <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -356,7 +592,8 @@ PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the targ
 ### `Bundle.spec.target.configMap`
 
 
-ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
+ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+data will be synced to.
 
 <table>
     <thead>
@@ -371,7 +608,8 @@ ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
+          Key is the key of the entry in the object's `data` field to be used.
+<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -381,7 +619,8 @@ ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will
 ### `Bundle.spec.target.namespaceSelector`
 
 
-NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.
+NamespaceSelector will, if set, only sync the target resource in
+Namespaces which match the selector.
 
 <table>
     <thead>
@@ -396,7 +635,9 @@ NamespaceSelector will, if set, only sync the target resource in Namespaces whic
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.<br/>
+          MatchLabels matches on the set of labels that must be present on a
+Namespace for the Bundle target to be synced there.
+<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -406,7 +647,9 @@ NamespaceSelector will, if set, only sync the target resource in Namespaces whic
 ### `Bundle.spec.target.secret`
 
 
-Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+Secret is the target Secret that all Bundle source data will be synced to.
+Using Secrets as targets is only supported if enabled at trust-manager startup.
+By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
 
 <table>
     <thead>
@@ -421,7 +664,8 @@ Secret is the target Secret that all Bundle source data will be synced to. Using
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
+          Key is the key of the entry in the object's `data` field to be used.
+<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -446,21 +690,20 @@ Status of the Bundle. This is set and managed automatically.
         <td><b><a href="#bundlestatusconditionsindex">conditions</a></b></td>
         <td>[]object</td>
         <td>
-          List of status conditions to indicate the status of the Bundle. Known condition types are `Bundle`.<br/>
+          List of status conditions to indicate the status of the Bundle.
+Known condition types are `Bundle`.
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>defaultCAVersion</b></td>
         <td>string</td>
         <td>
-          DefaultCAPackageVersion, if set and non-empty, indicates the version information which was retrieved when the set of default CAs was requested in the bundle source. This should only be set if useDefaultCAs was set to "true" on a source, and will be the same for the same version of a bundle with identical certificates.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#bundlestatustarget">target</a></b></td>
-        <td>object</td>
-        <td>
-          Target is the current Target that the Bundle is attempting or has completed syncing the source data to.<br/>
+          DefaultCAPackageVersion, if set and non-empty, indicates the version information
+which was retrieved when the set of default CAs was requested in the bundle
+source. This should only be set if useDefaultCAs was set to "true" on a source,
+and will be the same for the same version of a bundle with identical certificates.
+<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -482,253 +725,68 @@ BundleCondition contains condition information for a Bundle.
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>status</b></td>
+        <td><b>lastTransitionTime</b></td>
         <td>string</td>
         <td>
-          Status of the condition, one of ('True', 'False', 'Unknown').<br/>
+          LastTransitionTime is the timestamp corresponding to the last status
+change of this condition.
+<br/>
+          <br/>
+            <i>Format</i>: date-time<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>reason</b></td>
+        <td>string</td>
+        <td>
+          Reason is a brief machine-readable explanation for the condition's last
+transition.
+The value should be a CamelCase string.
+This field may not be empty.
+<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>status</b></td>
+        <td>enum</td>
+        <td>
+          Status of the condition, one of True, False, Unknown.
+<br/>
+          <br/>
+            <i>Enum</i>: True, False, Unknown<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          Type of the condition, known values are (`Synced`).<br/>
+          Type of the condition, known values are (`Synced`).
+<br/>
         </td>
         <td>true</td>
-      </tr><tr>
-        <td><b>lastTransitionTime</b></td>
-        <td>string</td>
-        <td>
-          LastTransitionTime is the timestamp corresponding to the last status change of this condition.<br/>
-          <br/>
-            <i>Format</i>: date-time<br/>
-        </td>
-        <td>false</td>
       </tr><tr>
         <td><b>message</b></td>
         <td>string</td>
         <td>
-          Message is a human readable description of the details of the last transition, complementing reason.<br/>
+          Message is a human-readable description of the details of the last
+transition, complementing reason.
+<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>observedGeneration</b></td>
         <td>integer</td>
         <td>
-          If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Bundle.<br/>
+          If set, this represents the .metadata.generation that the condition was
+set based upon.
+For instance, if .metadata.generation is currently 12, but the
+.status.condition[x].observedGeneration is 9, the condition is out of date
+with respect to the current state of the Bundle.
+<br/>
           <br/>
             <i>Format</i>: int64<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
-      </tr><tr>
-        <td><b>reason</b></td>
-        <td>string</td>
-        <td>
-          Reason is a brief machine readable explanation for the condition's last transition.<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### `Bundle.status.target`
-
-
-Target is the current Target that the Bundle is attempting or has completed syncing the source data to.
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#bundlestatustargetadditionalformats">additionalFormats</a></b></td>
-        <td>object</td>
-        <td>
-          AdditionalFormats specifies any additional formats to write to the target<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#bundlestatustargetconfigmap">configMap</a></b></td>
-        <td>object</td>
-        <td>
-          ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#bundlestatustargetnamespaceselector">namespaceSelector</a></b></td>
-        <td>object</td>
-        <td>
-          NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#bundlestatustargetsecret">secret</a></b></td>
-        <td>object</td>
-        <td>
-          Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### `Bundle.status.target.additionalFormats`
-
-
-AdditionalFormats specifies any additional formats to write to the target
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b><a href="#bundlestatustargetadditionalformatsjks">jks</a></b></td>
-        <td>object</td>
-        <td>
-          JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#bundlestatustargetadditionalformatspkcs12">pkcs12</a></b></td>
-        <td>object</td>
-        <td>
-          PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### `Bundle.status.target.additionalFormats.jks`
-
-
-JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>key</b></td>
-        <td>string</td>
-        <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
-        </td>
-        <td>true</td>
-      </tr></tbody>
-</table>
-
-
-### `Bundle.status.target.additionalFormats.pkcs12`
-
-
-PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>key</b></td>
-        <td>string</td>
-        <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
-        </td>
-        <td>true</td>
-      </tr></tbody>
-</table>
-
-
-### `Bundle.status.target.configMap`
-
-
-ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>key</b></td>
-        <td>string</td>
-        <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
-        </td>
-        <td>true</td>
-      </tr></tbody>
-</table>
-
-
-### `Bundle.status.target.namespaceSelector`
-
-
-NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>matchLabels</b></td>
-        <td>map[string]string</td>
-        <td>
-          MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.<br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### `Bundle.status.target.secret`
-
-
-Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>key</b></td>
-        <td>string</td>
-        <td>
-          Key is the key of the entry in the object's `data` field to be used.<br/>
-        </td>
-        <td>true</td>
       </tr></tbody>
 </table>

--- a/scripts/gendocs/generate-trust-manager
+++ b/scripts/gendocs/generate-trust-manager
@@ -46,8 +46,10 @@ gendocs() {
 
 	echo "+++ Generating trust-manager reference docs..."
 
+	(cd $tmpdir && make generate-crds)
+
 	$CRDOC \
-		--resources "$tmpdir/deploy/crds/trust.cert-manager.io_bundles.yaml" \
+		--resources "$tmpdir/_bin/scratch/crds/trust.cert-manager.io_bundles.yaml" \
 		--template $REPO_ROOT/scripts/gendocs/templates-trust-manager/markdown.tmpl \
 		--output $outputdir
 }

--- a/scripts/gendocs/templates-trust-manager/markdown.tmpl
+++ b/scripts/gendocs/templates-trust-manager/markdown.tmpl
@@ -66,7 +66,8 @@ Resource Types:
         <td><b>{{if .TypeKey}}<a href="#{{.TypeKey}}">{{.Name}}</a>{{else}}{{.Name}}{{end}}</b></td>
         <td>{{.Type}}</td>
         <td>
-          {{.Description}}<br/>
+          {{.Description | replace "{key,value}" "key-value"}}{{/* FIXME: Replacing construct from upstream K8s godocs causing broken HTML */}}
+<br/>
           {{- if or .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
           <br/>
           {{- end}}


### PR DESCRIPTION
After some refactoring of the CRD handling in trust-manager, the script to generate trust-manager API docs seems broken. This PR applies a quick fix to the generate-script and regenerates the trust-manager API docs.

Some upstream K8s godocs copied into the Bundle CRD is rendering invalid HTML and needs to be "escaped"/replaced.

Reported in https://github.com/cert-manager/trust-manager/issues/428.