### PR TITLE
chore(): update broken LocalObjectReference link to k8s API reference

### DIFF
--- a/content/docs/reference/api-docs.md
+++ b/content/docs/reference/api-docs.md
@@ -1136,7 +1136,7 @@ description: >-
         <code>imagePullSecrets</code>
         <br />
         <em>
-          <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+          <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
         </em>
       </td>
       <td>
@@ -1261,7 +1261,7 @@ description: >-
               <code>imagePullSecrets</code>
               <br />
               <em>
-                <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+                <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
               </em>
             </td>
             <td>

--- a/content/v1.12-docs/reference/api-docs.md
+++ b/content/v1.12-docs/reference/api-docs.md
@@ -991,7 +991,7 @@ description: >-
         <code>imagePullSecrets</code>
         <br />
         <em>
-          <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+          <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
         </em>
       </td>
       <td>
@@ -1103,7 +1103,7 @@ description: >-
               <code>imagePullSecrets</code>
               <br />
               <em>
-                <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+                <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
               </em>
             </td>
             <td>

--- a/content/v1.13-docs/reference/api-docs.md
+++ b/content/v1.13-docs/reference/api-docs.md
@@ -994,7 +994,7 @@ description: >-
         <code>imagePullSecrets</code>
         <br />
         <em>
-          <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+          <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
         </em>
       </td>
       <td>
@@ -1106,7 +1106,7 @@ description: >-
               <code>imagePullSecrets</code>
               <br />
               <em>
-                <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+                <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
               </em>
             </td>
             <td>

--- a/content/v1.14-docs/reference/api-docs.md
+++ b/content/v1.14-docs/reference/api-docs.md
@@ -997,7 +997,7 @@ description: >-
         <code>imagePullSecrets</code>
         <br />
         <em>
-          <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+          <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
         </em>
       </td>
       <td>
@@ -1109,7 +1109,7 @@ description: >-
               <code>imagePullSecrets</code>
               <br />
               <em>
-                <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+                <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
               </em>
             </td>
             <td>

--- a/content/v1.15-docs/reference/api-docs.md
+++ b/content/v1.15-docs/reference/api-docs.md
@@ -997,7 +997,7 @@ description: >-
         <code>imagePullSecrets</code>
         <br />
         <em>
-          <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core">[]Kubernetes core/v1.LocalObjectReference</a>
+          <a href="https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/">[]Kubernetes core/v1.LocalObjectReference</a>
         </em>
       </td>
       <td>


### PR DESCRIPTION
### Changes:
Updated the API reference link to point to the correct `LocalObjectReference` in the Kubernetes documentation.