### PR TITLE
Update triage party URL

### DIFF
--- a/content/docs/contributing/contributing-flow.md
+++ b/content/docs/contributing/contributing-flow.md
@@ -175,4 +175,4 @@ Here is the meaning that we give to the GitHub assignees:
 
 ### Triage Party!
 
-Every few weeks we will plan a Triage Party meeting, where we use the (Triage Party)[https://triage.build-infra.jetstack.net/] tool to go recent/old issues to prioritise them so we can address them in a timely matter. These meetings are open to everyone and invites will be sent out using our mailing list (warning: despite the word party these meetings are sometimes boring).
+Every few weeks we will plan a Triage Party meeting, where we use the [Triage Party](https://triage.infra.cert-manager.io/) tool to go recent/old issues to prioritise them so we can address them in a timely matter. These meetings are open to everyone and invites will be sent out using our mailing list (warning: despite the word party these meetings are sometimes boring).


### PR DESCRIPTION
I've already updated it in the Triage Party repo: https://github.com/google/triage-party/pull/308