### PR TITLE
Fix dead external links and update make commands in the contributing doc

### DIFF
--- a/content/docs/contributing/crds.md
+++ b/content/docs/contributing/crds.md
@@ -16,14 +16,11 @@ for code generation.
 Verifying and updating CRDs and generated code can be done entirely through make. There are two steps; one will update CRDs and one will update generated code:
 
 ```bash
-# Check that CRDs and codegen are up to date
-make verify-crds verify-codegen
-
 # Update CRDs based on code
-make update-crds
+make generate-crds
 
 # Update generated code based on CRD defintions in code
-make update-codegen
+make generate-codegen
 ```
 
 ## Versions

--- a/content/docs/installation/best-practice.md
+++ b/content/docs/installation/best-practice.md
@@ -218,7 +218,7 @@ startupapicheck:
 > which obviates the need to explicitly set the tolerations in the Helm chart.
 >
 > ℹ️ Alternatively, you could use [Kyverno](https://kyverno.io/docs/) to limit which tolerations Pods are allowed to use.
-> Read [Restrict control plane scheduling](https://kyverno.io/policies/other/res/restrict-controlplane-scheduling/restrict-controlplane-scheduling/) as a starting point.
+> Read [Restrict control plane scheduling](https://kyverno.io/policies/other/restrict-controlplane-scheduling/restrict-controlplane-scheduling/) as a starting point.
 
 ## High Availability
 
@@ -524,7 +524,7 @@ or if there is a bug in one of the other threads which causes the process to dea
 
 ## Restrict Auto-Mount of Service Account Tokens
 
-This recommendation is described in the [Kyverno Policy Catalogue](https://kyverno.io/policies/other/res/restrict-automount-sa-token/restrict-automount-sa-token/) as follows:
+This recommendation is described in the [Kyverno Policy Catalogue](https://kyverno.io/policies/other/restrict-automount-sa-token/restrict-automount-sa-token/) as follows:
 > Kubernetes automatically mounts ServiceAccount credentials in each Pod. The
 > ServiceAccount may be assigned roles allowing Pods to access API resources.
 > Blocking this ability is an extension of the least privilege best practice and

--- a/content/docs/tutorials/README.md
+++ b/content/docs/tutorials/README.md
@@ -32,5 +32,4 @@ for you to learn from. Take a look!
 
 - A great AWS blog post on using cert-manager for end-to-end encryption in EKS. See [Setting up end-to-end TLS encryption on Amazon EKS](https://aws.amazon.com/blogs/containers/setting-up-end-to-end-tls-encryption-on-amazon-eks-with-the-new-aws-load-balancer-controller/)
 - A full cert-manager installation demo on a GKE Cluster. See [How-To: Automatic SSL Certificate Management for your Kubernetes Application Deployment](https://medium.com/contino-engineering/how-to-automatic-ssl-certificate-management-for-your-kubernetes-application-deployment-94b64dfc9114)
-- cert-manager installation on GKE Cluster using Workload Identity. See [Kubernetes, ingress-nginx, cert-manager & external-dns](https://blog.atomist.com/kubernetes-ingress-nginx-cert-manager-external-dns/)
 - A video tutorial for beginners showing cert-manager in action. See [Free SSL for Kubernetes with cert-manager](https://www.youtube.com/watch?v=hoLUigg4V18)

--- a/content/docs/usage/README.md
+++ b/content/docs/usage/README.md
@@ -15,7 +15,7 @@ There are several use cases and methods for requesting certificates through cert
   in your cluster.
 - [Securing OpenFaaS functions](https://docs.openfaas.com/reference/ssl/kubernetes-with-cert-manager/):
   Secure your OpenFaaS services using cert-manager.
-- [Integration with Garden](https://docs.garden.io/guides/cert-manager-integration): Garden is a
+- [Integration with Garden](https://github.com/garden-io/garden/tree/main/examples/cert-manager-ext-dns): Garden is a
   developer tool for developing Kubernetes applications which has first class
   support for integrating cert-manager.
 - [Securing Knative](https://knative.dev/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/): Secure


### PR DESCRIPTION
Propose some changes while walking through the documentation site.

- Updated `content/docs/contributing/crds.md` with latest commands documented in [make/ci.mk](https://github.com/cert-manager/cert-manager/blob/master/make/ci.mk).
- Updated the Kyverno's doc links path.
- Changed the Garden's example doc reference to the latest one.
- Removed a Tutorial reference that is no longer accessible.