### PR TITLE
Fix csi-driver example pod

### DIFF
--- a/content/docs/usage/csi-driver/README.md
+++ b/content/docs/usage/csi-driver/README.md
@@ -57,9 +57,11 @@ spec:
     - name: tls
       csi:
         driver: csi.cert-manager.io
+        readOnly: true
         volumeAttributes:
-              csi.cert-manager.io/issuer-name: ca-issuer
-              csi.cert-manager.io/dns-names: ${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local
+          csi.cert-manager.io/issuer-name: ca-issuer
+          csi.cert-manager.io/issuer-kind: Issuer
+          csi.cert-manager.io/dns-names: ${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local
 ```
 
 Once created, the CSI driver will generate a private key locally (for the pod), request a


### PR DESCRIPTION
The missing "readOnly" means that this example doesn't work when used, as "readOnly" is required.

(I've been meaning to fix that for a long time!)

I also think the example benefits from including the issuer-kind, to make it clearer that it might need to be changed.