### PR TITLE
`make check` now works; node and npm couldn't be downloaded due to a change to the `ADDITIONAL_TOOLS` API

### DIFF
--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -43,10 +43,10 @@ $(bin_dir)/scratch/node@$(NODE_VERSION)_%: | $(bin_dir)/scratch
 	tar xzf $@.tar.gz --strip-components=1 -C $@
 	rm -f $@.tar.gz
 
-$(bin_dir)/downloaded/tools/node@$(NODE_VERSION)_%: | $(bin_dir)/scratch/node@$(NODE_VERSION)_% $(bin_dir)/downloaded/tools
+$(DOWNLOAD_DIR)/tools/node@$(NODE_VERSION)_%: | $(bin_dir)/scratch/node@$(NODE_VERSION)_% $(DOWNLOAD_DIR)/tools
 	$(LN) $(CURDIR)/$(bin_dir)/scratch/node@$(NODE_VERSION)_$*/bin/node $@
 
-$(bin_dir)/downloaded/tools/npm@$(NPM_VERSION)_%: | $(bin_dir)/scratch/node@$(NPM_VERSION)_% $(bin_dir)/downloaded/tools
+$(DOWNLOAD_DIR)/tools/npm@$(NPM_VERSION)_%: | $(bin_dir)/scratch/node@$(NPM_VERSION)_% $(DOWNLOAD_DIR)/tools
 	$(LN) $(CURDIR)/$(bin_dir)/scratch/node@$(NODE_VERSION)_$*/bin/npm $@
 
 # Export the node bin dir so npm can work


### PR DESCRIPTION
On macOS, I am getting:

```bash
$ make check
mkdir -p _bin/scratch
make: *** No rule to make target `/Users/mael.valais/code/cert-manager/website/_bin/downloaded/tools/npm@v20.11.1_darwin_arm64', needed by `_bin/tools/npm'.  Stop.
```

This has been broken since April 2024, in which https://github.com/cert-manager/makefile-modules/pull/124 changed how the "download" targets need to be laid out when using `ADDITIONAL_TOOLS`.

```diff
-#   creates a copy/ link to the corresponding versioned target:
-#   $(bin_dir)/tools/xxx@$(XXX_VERSION)_$(HOST_OS)_$(HOST_ARCH)
+#   creates a link to the corresponding versioned target:
+#   $(DOWNLOAD_DIR)/tools/xxx@$(XXX_VERSION)_$(HOST_OS)_$(HOST_ARCH)
```

Previously, the download target needed to be relative, e.g.:

```
_bin/downloaded/tools/npm@v20.11.1_darwin_arm64
```

Now, because of `$(DOWNLOAD_DIR)`, it needs to be absolute, e.g.:

```
/Homes/mael.valais/code/cert-manager/website/_bin/downloaded/tools/npm@v20.11.1_darwin_arm64
```
