### PR TITLE
acme/dns01/route53: document stricter IAM policy

### DIFF
--- a/content/docs/configuration/acme/dns01/route53.md
+++ b/content/docs/configuration/acme/dns01/route53.md
@@ -35,7 +35,12 @@ permissions:
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets"
       ],
-      "Resource": "arn:aws:route53:::hostedzone/*"
+      "Resource": "arn:aws:route53:::hostedzone/*",
+      "Condition": {
+        "ForAllValues:StringEquals": {
+          "route53:ChangeResourceRecordSetsRecordTypes": ["TXT"]
+        }
+      }
     },
     {
       "Effect": "Allow",


### PR DESCRIPTION
Hi, this PR enhance acme/dns01/route53 suggested IAM policy by restricting changes' scope to `TXT` record only, so everything is more PoLP.

Thank you, regards