### PR TITLE
fix instance value used by PodMonitor when selecting pods to monitor

### DIFF
--- a/content/docs/devops-tips/prometheus-metrics.md
+++ b/content/docs/devops-tips/prometheus-metrics.md
@@ -47,7 +47,7 @@ spec:
       - key: app.kubernetes.io/instance
         operator: In
         values:
-        - release-name
+        - cert-manager
       - key: app.kubernetes.io/component
         operator: In
         values:


### PR DESCRIPTION
I was trying to setup a PodMonitor using exactly what is defined in the documentation but realised that there were a small error in the 'matchExpressions'.

The label `app.kubernetes.io/instance` is always set to `cert-manager`. 
I checked the last `cert-manager.yaml` in the last release:

``` yaml
...
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cert-manager
  namespace: cert-manager
  labels:
    app: cert-manager
    app.kubernetes.io/name: cert-manager
    app.kubernetes.io/instance: cert-manager
    app.kubernetes.io/component: "controller"
    app.kubernetes.io/version: "v1.17.1"
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: cert-manager
      app.kubernetes.io/instance: cert-manager
      app.kubernetes.io/component: "controller"
  template:
    metadata:
      labels:
        app: cert-manager
        app.kubernetes.io/name: cert-manager
        app.kubernetes.io/instance: cert-manager
        app.kubernetes.io/component: "controller"
        app.kubernetes.io/version: "v1.17.1"
...
```

Otherwise, the documentation is really well done and complete, thanks!