### PR TITLE
docs: Add small into on prow to help potential new community members

### DIFF
--- a/content/docs/contributing/README.md
+++ b/content/docs/contributing/README.md
@@ -74,35 +74,6 @@ Once you have access to Kubernetes Slack, you can search for and join the follow
 - [`#cert-manager`](https://kubernetes.slack.com/messages/cert-manager): A channel for all users of cert-manager; use this for any usage-related questions.
 - [`#cert-manager-dev`](https://kubernetes.slack.com/messages/cert-manager-dev): Dedicated to collaboration between cert-manager contributors and maintainers. Please use this channel for code-related questions only.
 
-## Issues & Pull Requests
+## Issues and Pull Requests
 
-Across our GitHub organization we make use of [prow](https://docs.prow.k8s.io/docs/overview/) for automation.
-This means that we don't label issues or pull requests manually.
-We make use of prow's functionality to label issues with metadata and signal pull requests are ready to test.
-
-If you are new to the Kubernetes ecosystem then this may not be familiar to you.
-To learn more, here is a full list of commands: https://prow.k8s.io/command-help.
-
-> Please note that not all commands may work within the cert-manager organization.
-
-Some commands are reserved for maintainer or contributors only. 
-Prow may indicate to you in a follow up comment if a command was unable to be applied.
-
-### Labeling Issues
-
-Here are a couple of example commands we often use to label an issue:
-
-1. To label an issue as a "good first issue" a comment can be added to the issue as follows:
-
-        ```text
-        /good-first-issue
-        ```
-
-1. To remove a label such as the one above:
-
-        ```text
-        /remove-good-first-issue
-        ```
-
-Further common example may be added at a later date.
-If you are confused, please reach out to the maintainers and community on [slack](#slack).
+If you are looking for help understanding our issue and pull request usage, then please review the [contributing flow](./contributing-flow.md) page.

--- a/content/docs/contributing/README.md
+++ b/content/docs/contributing/README.md
@@ -73,3 +73,36 @@ Once you have access to Kubernetes Slack, you can search for and join the follow
 
 - [`#cert-manager`](https://kubernetes.slack.com/messages/cert-manager): A channel for all users of cert-manager; use this for any usage-related questions.
 - [`#cert-manager-dev`](https://kubernetes.slack.com/messages/cert-manager-dev): Dedicated to collaboration between cert-manager contributors and maintainers. Please use this channel for code-related questions only.
+
+## Issues & Pull Requests
+
+Across our GitHub organisation we make use of [prow](https://docs.prow.k8s.io/docs/overview/) for automation.
+This means that we don't label issues or pull requests manually.
+We make use of prow's functionality to label issues with metadata and signal pull requests are ready to test.
+
+If you are new to the Kubernetes ecosystem then this may not be familiar to you.
+To learn more, here is a full list of commands: https://prow.k8s.io/command-help.
+
+> Please note that not all commands may work within the cert-manager organisation.
+
+Some commands are reserved for maintainer or contributors only. 
+Prow may indicate to you in a follow up comment if a command was unable to be applied.
+
+### Labeling Issues
+
+Here are a couple of example commands we often use to label an issue:
+
+1. To label an issue as a "good first issue" a comment can be added to the issue as follows:
+
+        ```text
+        /good-first-issue
+        ```
+
+1. To remove a label such as the one above:
+
+        ```text
+        /remove-good-first-issue
+        ```
+
+Further common example may be added at a later date.
+If you are confused, please reach out to the maintainers and community on [slack](#slack).

--- a/content/docs/contributing/README.md
+++ b/content/docs/contributing/README.md
@@ -76,14 +76,14 @@ Once you have access to Kubernetes Slack, you can search for and join the follow
 
 ## Issues & Pull Requests
 
-Across our GitHub organisation we make use of [prow](https://docs.prow.k8s.io/docs/overview/) for automation.
+Across our GitHub organization we make use of [prow](https://docs.prow.k8s.io/docs/overview/) for automation.
 This means that we don't label issues or pull requests manually.
 We make use of prow's functionality to label issues with metadata and signal pull requests are ready to test.
 
 If you are new to the Kubernetes ecosystem then this may not be familiar to you.
 To learn more, here is a full list of commands: https://prow.k8s.io/command-help.
 
-> Please note that not all commands may work within the cert-manager organisation.
+> Please note that not all commands may work within the cert-manager organization.
 
 Some commands are reserved for maintainer or contributors only. 
 Prow may indicate to you in a follow up comment if a command was unable to be applied.

--- a/content/docs/contributing/contributing-flow.md
+++ b/content/docs/contributing/contributing-flow.md
@@ -13,7 +13,8 @@ Any issues towards the documentation should also be filed there.
 ## GitHub bot
 
 We use [Prow](https://github.com/k8s-ci-robot/test-infra/tree/master/prow) on all our repositories.
-If you've ever looked at a Kubernetes repo, you will probably already have met Prow. Prow will be able to help you in GitHub using its commands.
+If you've ever looked at a Kubernetes repo, you will probably already have met Prow. 
+Prow will be able to help you in GitHub using its commands.
 You can find then all [on the command help page](https://prow.infra.cert-manager.io/command-help).
 Prow will also run all tests and assign certain labels on PRs.
 
@@ -148,13 +149,32 @@ We brief our users/contributors about this in our bi-weekly community meeting, f
 
 ### Labels
 
-We make a heavy use of GitHub labels for PRs and Issues. The ones on PRs are mostly managed by Prow and code reviewers.
-In issues we always aim to add 3 types: area, priority and kind. These are set using Prow using `/area`, `/kind` and `/priority`.
+We utilize GitHub labels for PRs and Issues. The ones on PRs are mostly managed by Prow and code reviewers.
+In issues we always aim to add 3 types: area, priority and kind. 
+These are set using Prow using `/area`, `/kind` and `/priority`.
 Sometimes `/triage` is also added which helps us when following up Issues.
 
 * Area indicates the code area which is/will need changing
 * Kind indicates if it is a `bug` or a `feature` but also can be `documentation` or `cleanup` (general maintenance)
 * Priority is the priority it has for the cert-manager team, PRs are still very welcome for those!
+
+#### Good First Issues
+
+Some Issues will be labeled with `good first issue`. 
+This indicates we believe anyone should be able to have a go at this issue.
+This label is also manage via Prow. It can be assigned and unassigned as follows:
+
+1. To label an issue as a "good first issue" a comment can be added to the issue as follows:
+
+        ```text
+        /good-first-issue
+        ```
+
+2. To remove this label, comment with:
+
+        ```text
+        /remove-good-first-issue
+        ```
 
 ### Assignees meaning in PRs and issues
 


### PR DESCRIPTION
Based on discussion in standup this week, a small PR to add some reference to the use of `prow` as opposed to directly using the native GitHub features.