### PR TITLE
Update cert-manager-mixin project

### DIFF
--- a/content/docs/devops-tips/prometheus-metrics.md
+++ b/content/docs/devops-tips/prometheus-metrics.md
@@ -181,4 +181,4 @@ Check the health of the cert-manager scrape targets on the Prometheus status pag
 
 ## Monitoring Mixin
 
-Monitoring mixins are a way to bundle common alerts, rules, and dashboards for an application in a configurable and extensible way, using the Jsonnet data templating language. A cert-manager monitoring mixin can be found here https://gitlab.com/uneeq-oss/cert-manager-mixin. Documentation on usage can be found with the `cert-manager-mixin` project.
+Monitoring mixins are a way to bundle common alerts, rules, and dashboards for an application in a configurable and extensible way, using the Jsonnet data templating language. A cert-manager monitoring mixin can be found here https://github.com/imusmanmalik/cert-manager-mixin. Documentation on usage can be found with the `cert-manager-mixin` project.


### PR DESCRIPTION
https://gitlab.com/uneeq-oss/cert-manager-mixin is no longer maintained.

Monitoring mixins website is now referencing another mixin here https://monitoring.mixins.dev/cert-manager/
The new mixin is a fork of the previous one.