### PR TITLE
Fixed a typo in the trust-manager custom resource example

### DIFF
--- a/content/docs/trust/trust-manager/README.md
+++ b/content/docs/trust/trust-manager/README.md
@@ -85,7 +85,7 @@ spec:
       key: "ca.crt"
 
   # One more ConfigMap source, this time including all certificates from every key
-  - secret:
+  - configMap:
       name: "my-org-cas"
       includeAllKeys: true
 


### PR DESCRIPTION
Found a typo in the trust-manager custom resource example whilst at the contribfest on Wednesday 