### PR TITLE
Added target metadata examples for trust-manager

### DIFF
--- a/content/docs/trust/trust-manager/README.md
+++ b/content/docs/trust/trust-manager/README.md
@@ -104,6 +104,11 @@ spec:
     # here named "bundle.jks" and "bundle.p12".
     configMap:
       key: "root-certs.pem"
+      metadata:
+        annotations:
+          argocd.argoproj.io/sync-wave: "1"
+        labels:
+          app.kubernetes.io/component: "trust-bundle"
     additionalFormats:
       jks:
         key: "bundle.jks"
@@ -145,6 +150,8 @@ Support for `Secret` targets must be explicitly enabled in the trust-manager con
 
 All `Bundle` targets are written to `ConfigMap`s (and/or `Secret`s) whose name matches that of the
 `Bundle`, and every target has a PEM-formatted bundle included.
+
+The annotations and labels for the target `ConfigMap`s (and/or `Secret`s) can be specified using `spec.target.configMap.metadata.annotations` and `spec.target.configMap.metadata.labels` (swapping `secret` for `configMap` where appropriate).
 
 Users can also optionally choose to write JKS/PKCS#12 formatted binary trust store(s) to targets.
 JKS has been supported since v0.5.0, and PKCS#12 since v0.7.0.

--- a/content/docs/trust/trust-manager/api-reference.md
+++ b/content/docs/trust/trust-manager/api-reference.md
@@ -516,6 +516,8 @@ AdditionalFormats specifies any additional formats to write to the target
           JKS requests a JKS-formatted binary trust bundle to be written to the target.
 The bundle has "changeit" as the default password.
 For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+Deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
+PKCS#12 trust stores created by trust-manager are compatible with Java.
 <br/>
         </td>
         <td>false</td>
@@ -524,7 +526,9 @@ For more information refer to this link https://cert-manager.io/docs/faq/#keysto
         <td>object</td>
         <td>
           PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+
 The bundle is by default created without a password.
+For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
 <br/>
         </td>
         <td>false</td>
@@ -538,6 +542,8 @@ The bundle is by default created without a password.
 JKS requests a JKS-formatted binary trust bundle to be written to the target.
 The bundle has "changeit" as the default password.
 For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+Deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
+PKCS#12 trust stores created by trust-manager are compatible with Java.
 
 <table>
     <thead>
@@ -574,7 +580,9 @@ For more information refer to this link https://cert-manager.io/docs/faq/#keysto
 
 
 PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+
 The bundle is by default created without a password.
+For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
 
 <table>
     <thead>
@@ -601,6 +609,24 @@ The bundle is by default created without a password.
 <br/>
           <br/>
             <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>profile</b></td>
+        <td>enum</td>
+        <td>
+          Profile specifies the certificate encryption algorithms and the HMAC algorithm
+used to create the PKCS12 trust store.
+
+If provided, allowed values are:
+`LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+`LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+`Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+Default value is `LegacyRC2` for backward compatibility.
+<br/>
+          <br/>
+            <i>Enum</i>: LegacyRC2, LegacyDES, Modern2023<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -630,6 +656,48 @@ data will be synced to.
 <br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b><a href="#bundlespectargetconfigmapmetadata">metadata</a></b></td>
+        <td>object</td>
+        <td>
+          Metadata is an optional set of labels and annotations to be copied to the target.
+<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.spec.target.configMap.metadata`
+
+
+Metadata is an optional set of labels and annotations to be copied to the target.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>annotations</b></td>
+        <td>map[string]string</td>
+        <td>
+          Annotations is a key value map to be copied to the target.
+<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>labels</b></td>
+        <td>map[string]string</td>
+        <td>
+          Labels is a key value map to be copied to the target.
+<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -742,6 +810,48 @@ By default, trust-manager has no permissions for writing to secrets and can only
 <br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b><a href="#bundlespectargetsecretmetadata">metadata</a></b></td>
+        <td>object</td>
+        <td>
+          Metadata is an optional set of labels and annotations to be copied to the target.
+<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### `Bundle.spec.target.secret.metadata`
+
+
+Metadata is an optional set of labels and annotations to be copied to the target.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>annotations</b></td>
+        <td>map[string]string</td>
+        <td>
+          Annotations is a key value map to be copied to the target.
+<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>labels</b></td>
+        <td>map[string]string</td>
+        <td>
+          Labels is a key value map to be copied to the target.
+<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -787,7 +897,7 @@ and will be the same for the same version of a bundle with identical certificate
 ### `Bundle.status.conditions[index]`
 
 
-BundleCondition contains condition information for a Bundle.
+Condition contains details for one aspect of the current state of this API Resource.
 
 <table>
     <thead>
@@ -802,19 +912,29 @@ BundleCondition contains condition information for a Bundle.
         <td><b>lastTransitionTime</b></td>
         <td>string</td>
         <td>
-          LastTransitionTime is the timestamp corresponding to the last status
-change of this condition.
+          lastTransitionTime is the last time the condition transitioned from one status to another.
+This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
 <br/>
           <br/>
             <i>Format</i>: date-time<br/>
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>message</b></td>
+        <td>string</td>
+        <td>
+          message is a human readable message indicating details about the transition.
+This may be an empty string.
+<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>reason</b></td>
         <td>string</td>
         <td>
-          Reason is a brief machine-readable explanation for the condition's last
-transition.
+          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+Producers of specific condition types may define expected values and meanings for this field,
+and whether the values are considered a guaranteed API.
 The value should be a CamelCase string.
 This field may not be empty.
 <br/>
@@ -824,7 +944,7 @@ This field may not be empty.
         <td><b>status</b></td>
         <td>enum</td>
         <td>
-          Status of the condition, one of True, False, Unknown.
+          status of the condition, one of True, False, Unknown.
 <br/>
           <br/>
             <i>Enum</i>: True, False, Unknown<br/>
@@ -834,28 +954,17 @@ This field may not be empty.
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          Type of the condition, known values are (`Synced`).
+          type of condition in CamelCase or in foo.example.com/CamelCase.
 <br/>
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b>message</b></td>
-        <td>string</td>
-        <td>
-          Message is a human-readable description of the details of the last
-transition, complementing reason.
-<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>observedGeneration</b></td>
         <td>integer</td>
         <td>
-          If set, this represents the .metadata.generation that the condition was
-set based upon.
-For instance, if .metadata.generation is currently 12, but the
-.status.condition[x].observedGeneration is 9, the condition is out of date
-with respect to the current state of the Bundle.
+          observedGeneration represents the .metadata.generation that the condition was set based upon.
+For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+with respect to the current state of the instance.
 <br/>
           <br/>
             <i>Format</i>: int64<br/>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "check": "concurrently --group --timings npm:check:* # Run all the npm check:* scripts in parallel",
     "check:next-lint": "next lint",
     "check:links": "find content/docs -type f -name '*.md' | xargs markdown-link-check --quiet --config markdown-link-check.json 2>&1 | awk -v RS=FILE: '/ERROR/{f=1; print RS $0} END{exit f}' # Split into records based on the word FILE and print only records containing word ERROR",
-    "check:spelling": "FORCE_COLOR=1 mdspell --report --en-us --ignore-numbers --ignore-acronyms 'content/**/*.md' 'content/**/*.html' '_layouts/*.html' '_includes/*.html' '*.html' '!**/api-docs.md' '!content/*docs/policy/approval/approver-policy/api-reference.md' # Force color output in mdspell. # See https://github.com/lukeapage/node-markdown-spellcheck/issues/36#issuecomment-482649408 ",
+    "check:spelling": "FORCE_COLOR=1 mdspell --report --en-us --ignore-numbers --ignore-acronyms 'content/**/*.md' 'content/**/*.html' '_layouts/*.html' '_includes/*.html' '*.html' '!**/api-docs.md' '!content/*docs/policy/approval/approver-policy/api-reference.md' '!content/*docs/trust/trust-manager/api-reference.md' # Force color output in mdspell. # See https://github.com/lukeapage/node-markdown-spellcheck/issues/36#issuecomment-482649408 ",
     "check:markdown": "remark --rc-path .remarkrc --frail --quiet content/"
   },
   "lint-staged": {

--- a/scripts/gendocs/generate-trust-manager
+++ b/scripts/gendocs/generate-trust-manager
@@ -20,7 +20,9 @@ set -o pipefail
 
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
-CRDOC=${REPO_ROOT}/scripts/bin/crdoc
+CRDOC="${REPO_ROOT}/scripts/bin/crdoc"
+
+TRUST_MANAGER_REF="${1:-"v0.15.0"}"
 
 tmpdir="$(mktemp -d)"
 
@@ -46,12 +48,12 @@ gendocs() {
 
 	echo "+++ Generating trust-manager reference docs..."
 
-	(cd $tmpdir && make generate-crds)
+	(cd "$tmpdir" && make generate-crds)
 
 	$CRDOC \
 		--resources "$tmpdir/_bin/scratch/crds/trust.cert-manager.io_bundles.yaml" \
-		--template $REPO_ROOT/scripts/gendocs/templates-trust-manager/markdown.tmpl \
-		--output $outputdir
+		--template "$REPO_ROOT/scripts/gendocs/templates-trust-manager/markdown.tmpl" \
+		--output "$outputdir"
 }
 
 # Note that this script only supports generating a single version of trust-manager API docs,
@@ -61,6 +63,6 @@ gendocs() {
 echo "+++ Cloning trust-manager repository..."
 git clone "https://github.com/cert-manager/trust-manager.git" "$tmpdir"
 
-checkout "v0.15.0"
+checkout "$TRUST_MANAGER_REF"
 
 gendocs "$REPO_ROOT/content/docs/trust/trust-manager/api-reference.md"


### PR DESCRIPTION
A follow up from https://github.com/cert-manager/trust-manager/pull/582 which adds the options to specify annotations and labels in the target configmaps/secrets that a Bundle creates.

Do I need to update `content/docs/trust/trust-manager/api-reference.md` using the latest commit from trust-manager's main branch?