### PR TITLE
Add the boilerplate content for release-1.18 release notes

### DIFF
--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -21,6 +21,14 @@
               "path": "/docs/releases/README.md"
             },
             {
+              "title": "1.18",
+              "path": "/docs/releases/release-notes/release-notes-1.18.md"
+            },
+            {
+              "title": "Upgrade 1.17 to 1.18",
+              "path": "/docs/releases/upgrading/upgrading-1.17-1.18.md"
+            },
+            {
               "title": "1.17",
               "path": "/docs/releases/release-notes/release-notes-1.17.md"
             },

--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -1,0 +1,57 @@
+---
+title: Release 1.18
+description: 'cert-manager release notes: cert-manager 1.18'
+---
+
+cert-manager v1.18 includes:
+
+- TODO
+
+## Major Themes
+
+### TODO
+
+## Community
+
+As always, we'd like to thank all of the community members who helped in this release cycle, including all below who merged a PR and anyone that helped by commenting on issues, testing, or getting involved in cert-manager meetings. We're lucky to have you involved.
+
+A special thanks to:
+
+- TODO
+
+for their contributions, comments and support!
+
+Also, thanks to the cert-manager maintainer team for their help in this release:
+
+- [@inteon](https://github.com/inteon)
+- [@erikgb](https://github.com/erikgb)
+- [@SgtCoDFish](https://github.com/SgtCoDFish)
+- [@ThatsMrTalbot](https://github.com/ThatsMrTalbot)
+- [@munnerz](https://github.com/munnerz)
+- [@maelvls](https://github.com/maelvls)
+
+And finally, thanks to the cert-manager steering committee for their feedback in this release cycle:
+
+- [@FlorianLiebhart](https://github.com/FlorianLiebhart)
+- [@ssyno](https://github.com/ssyno)
+- [@ianarsenault](https://github.com/ianarsenault)
+- [@TrilokGeer](https://github.com/TrilokGeer)
+
+
+## `v1.18.0`
+
+### Feature
+
+TODO
+
+### Documentation
+
+TODO
+
+### Bug or Regression
+
+TODO
+
+### Other (Cleanup or Flake)
+
+TODO

--- a/content/docs/releases/upgrading/upgrading-1.17-1.18.md
+++ b/content/docs/releases/upgrading/upgrading-1.17-1.18.md
@@ -1,0 +1,12 @@
+---
+title: Upgrading from v1.17 to v1.18
+description: 'cert-manager installation: Upgrading v1.17 to v1.18'
+---
+
+Before upgrading cert-manager from 1.17 to 1.18, please read the following important notes about breaking changes in 1.18:
+
+1. TODO
+
+## Next Steps
+
+From here on, you can follow the [regular upgrade process](../../installation/upgrade.md).


### PR DESCRIPTION
**Preview**: 
 * https://deploy-preview-1680--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.18
 * https://deploy-preview-1680--cert-manager.netlify.app/docs/releases/upgrading/upgrading-1.17-1.18

Adding the boiler plate for the 1.18 release notes in this separate PR so that it's easier for cert-manager PR authors to contribute short release note paragraphs for cert-manager 1.18 features.