### PR TITLE
Recategorize the new revisionHistoryLimit as a Potentially breaking change

### DIFF
--- a/content/docs/devops-tips/scaling-cert-manager.md
+++ b/content/docs/devops-tips/scaling-cert-manager.md
@@ -76,6 +76,8 @@ might accidentally or maliciously cause a denial of service for other users on t
 
 ## Set `revisionHistoryLimit: 1` on all Certificate resources
 
+> ℹ️ Not needed with cert-manager `>= v1.18.0`, because the default value was changed to `1`.
+
 By default, cert-manager will keep all the `CertificateRequest` resources that **it** creates
 ([`revisionHistoryLimit`](../reference/api-docs.md#cert-manager.io/v1.CertificateSpec)):
 

--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -67,12 +67,14 @@ config:
 
 ### The default value of `Certificate.Spec.RevisionHistoryLimit` is now `1`
 
-> ⚠️ Breaking change
+> ⚠️ Potentially breaking change
 
 The default value for the `Certificate` resource's `revisionHistoryLimit` field is now set to 1.
 This ensures that old `CertificateRequest` revisions are automatically garbage collected, improving resource management and reducing clutter in clusters.
 Previously, if not specified, no limit was applied, potentially leading to an accumulation of stale `CertificateRequest` resources.
 With this update, users no longer need to manually configure the revision history limit to benefit from automated cleanup.
+
+When you upgrade to cert-manager 1.18, all stale `CertificateRequest` resources will be garbage collected, unless you explicitly set the `revisionHistoryLimit` value on your `Certificate` resources.
 
 ### Copy annotations from Ingress or Gateway to the Certificate
 

--- a/content/docs/tutorials/certificate-defaults/README.md
+++ b/content/docs/tutorials/certificate-defaults/README.md
@@ -25,6 +25,8 @@ By setting custom defaults across our cluster, we enable platform teams to tackl
 
     Use a `ClusterPolicy` to set a custom default value for the `Certificate.Spec.RevisionHistoryLimit` field.
 
+    > ℹ️ Not needed with cert-manager `>= v1.18.0`, because the default value was changed to `1`.
+
 - **To help your users choose secure default key settings for their `Certificate` resources.**
 
     Use a `ClusterPolicy` to set custom default values for the `Certificate.Spec.PrivateKey` fields.
@@ -158,6 +160,7 @@ None of the three fields here are required fields, but they might need to be set
 These rules will:
 
 - Set a default value of: `revisionHistoryLimit: 2`.
+  > ℹ️ This is not necessary if you use cert-manager `>= v1.18.0`, because the default value was changed to `1`.
 - Set a [default value of `Always` under `spec.privateKey.rotationPolicy`](../../usage/certificate.md#the-rotationpolicy-setting).
   > ℹ️ This is not necessary if you use cert-manager `>=v1.18.0`, because the default value was changed from `Never` to `Always`.
 - Set defaults for all `spec.privateKey` fields.

--- a/public/docs/tutorials/getting-started-aws-letsencrypt/certificate.yaml
+++ b/public/docs/tutorials/getting-started-aws-letsencrypt/certificate.yaml
@@ -5,7 +5,6 @@ metadata:
   name: www
 spec:
   secretName: www-tls
-  revisionHistoryLimit: 1
   privateKey:
     rotationPolicy: Always
   commonName: www.$DOMAIN_NAME


### PR DESCRIPTION
**Preview**: https://deploy-preview-1706--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.18#the-default-value-of-certificatespecrevisionhistorylimit-is-now-1

Recategorize the new revisionHistoryLimit as a Potentially breaking change

And explain that the default has changed, in the scaling and setting sane defaults tutorials