### PR TITLE
Postpone the release of cert-manager 1.18

### DIFF
--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -28,7 +28,7 @@ should be stable enough to run.
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
-| [1.18][] | Jun 04, 2025 | Release of 1.20 | 1.29 → 1.33 / 4.16 → 4.17                      | 1.30 → 1.33                        |
+| [1.18][] | Jun 10, 2025 | Release of 1.20 | 1.29 → 1.33 / 4.16 → 4.17                      | 1.30 → 1.33                        |
 
 Dates in the future are not firm commitments and are subject to change.
 


### PR DESCRIPTION
I didn't manager to release 1.18.0 on Wednesday 4 June, because I hadn't finished the ACME profiles work, which is a key feature of this release. That's done now and I've released a beta which has been tested:
 * https://github.com/cert-manager/cert-manager/releases/tag/v1.18.0-beta.0

I'll do the release on Tuesday 10 June instead.

