### PR TITLE
Remove whitespace-nowrap from Toc component

### DIFF
--- a/components/docs/Toc.jsx
+++ b/components/docs/Toc.jsx
@@ -27,7 +27,7 @@ export default function Toc({ contents, maxHeadingLevel, indentation=2 }) {
           <ul>
             {items.map((item, idx) => {
                 return (
-                    <li className={`pl-${(item.depth - minLevel) * indentation} whitespace-nowrap mb-2`} key={idx}>
+                    <li className={`pl-${(item.depth - minLevel) * indentation} mb-2`} key={idx}>
                       <a
                         className="text-sm text-blue-900 cursor-pointer no-underline"
                         href={`#${item.slug}`}


### PR DESCRIPTION
Before:
<img width="1485" alt="Screenshot 2025-06-19 at 3 47 25 pm" src="https://github.com/user-attachments/assets/c5fa14ae-3ab5-4fb7-bebc-af1da0159477" />

After:
<img width="1494" alt="Screenshot 2025-06-19 at 4 43 28 pm" src="https://github.com/user-attachments/assets/2da6abb3-258e-455b-b299-3f44de312cac" />
