### PR TITLE
Update documentation example for `preferredChain`

### DIFF
--- a/content/docs/reference/api-docs.md
+++ b/content/docs/reference/api-docs.md
@@ -1447,7 +1447,7 @@ description: >-
       </td>
       <td>
         <em>(Optional)</em>
-        <p>PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let&rsquo;s Encrypt&rsquo;s DST cross-sign you would use: &ldquo;DST Root CA X3&rdquo; or &ldquo;ISRG Root X1&rdquo; for the newer Let&rsquo;s Encrypt root CA. This value picks the first certificate bundle in the combined set of ACME default and alternative chains that has a root-most certificate with this value as its issuer&rsquo;s commonname.</p>
+        <p>PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let&rsquo;s Encrypt&rsquo;s shortest ECDSA chain you would use: &ldquo;ISRG Root X2&rdquo; or &ldquo;ISRG Root X1&rdquo; for the (old default) Let&rsquo;s Encrypt root CA. This value picks the first certificate bundle in the combined set of ACME default and alternative chains that has a root-most certificate with this value as its issuer&rsquo;s commonname.</p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
The documentation on the `preferredChain` still mentions the cross-signed version of `ISRG Root X1` CA cert from Let's Encrypt, which has expired as of Monday, September 30th, 2024 (see https://letsencrypt.org/2023/07/10/cross-sign-expiration/).

To use a more representative example, I've replaced this with the example from current Let's Encrypt documentation (see https://letsencrypt.org/certificates/#chains). 

Note that the wording and example are very much opiniated, so there's a variety of alternative approaches to replacing this example:
- word differently from what I've now picked
- remove the example entirely
- just refer to upstream Let's Encrypt documentation without listing an example, to prevent it from going outdated once more at some point in the future