### PR TITLE
Add info about orphaned leases when uninstalling

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -448,6 +448,7 @@ kube-ingress-aws-controller
 kube-lego
 kube-apiserver
 kube-proxy
+kube-system
 tcpdump
 kubebuilder
 kubectl

--- a/content/docs/installation/kubectl.md
+++ b/content/docs/installation/kubectl.md
@@ -195,6 +195,19 @@ Delete the installation manifests using a link to your currently running version
 kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/vX.Y.Z/cert-manager.yaml
 ```
 
+### Deleting orphaned leases
+
+Note: cert-manager uses Kubernetes [`Lease`](https://kubernetes.io/docs/concepts/architecture/leases/) 
+objects for leader election, which is enabled by default.
+These leases are typically created in the kube-system namespace, but the namespace can be configured.
+They are not automatically removed when uninstalling cert-manager. You can safely delete them manually:
+
+```bash
+kubectl delete lease -n <namespace> cert-manager-cainjector-leader-election cert-manager-controller
+```
+
+Replace `<namespace>` with the namespace where leader election leases were created (default is kube-system).
+
 ### Namespace Stuck in Terminating State
 
 If the namespace has been marked for deletion without deleting the cert-manager


### PR DESCRIPTION
I was made aware of https://github.com/kubernetes-sigs/kubebuilder/issues/4712. While I don't understand the actual issue here, we should probably document that cert-manager leases might be orphaned in the cluster after uninstalling. I wanted to use labels to select the leases to delete, e.g., `kubectl delete lease -n <namespace> -l app.kubernetes.io/name=cert-manager`, but it turns out that cert-manager doesn't add any labels to its lease resources.

I will create a cert-manager PR to add labels to leases, as this should be supported now, ref. https://github.com/kubernetes/client-go/blob/master/tools/leaderelection/resourcelock/leaselock.go#L63. The leases label feature was added quite recently in https://github.com/kubernetes/client-go/commit/34f791d2b1d1b3ad3d5d8e7a06f9e1b02abfa7b2, so we have to wait until we upgrade cert-manager dependencies to K8s 1.34.