### PR TITLE
Add another option for the ACME HTTP01 challenge issue

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -76,7 +76,7 @@ controller:
 
 #### Option 3. Upgrade `ingress-nginx`
 
-This issue is resolved in `ingress-nginx` v1.13.2 (released August 30, 2025).
+This issue is resolved in `ingress-nginx` v1.13.2 (released August 29, 2025).
 If you are running `ingress-nginx` v1.13.2 or later, you do not need to apply the workarounds described above.
 See the [fix commit](https://github.com/kubernetes/ingress-nginx/commit/618aae18515213bcf3fb820e6f8c234703d844b2)
 

--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -76,9 +76,11 @@ controller:
 
 #### Option 3. Upgrade `ingress-nginx`
 
-This issue is resolved in `ingress-nginx` v1.13.2 (released August 29, 2025).
-If you are running `ingress-nginx` v1.13.2 or later, you do not need to apply the workarounds described above.
-See the [fix commit](https://github.com/kubernetes/ingress-nginx/commit/618aae18515213bcf3fb820e6f8c234703d844b2)
+This issue is resolved in `ingress-nginx` versions `v1.13.2` and `v1.12.6`, both released on August 29, 2025.
+
+If you are running ingress-nginx `v1.13.2+` or `v1.12.6+`, you do not need to apply the workarounds described above.  
+
+See the [fix commit](https://github.com/kubernetes/ingress-nginx/commit/618aae18515213bcf3fb820e6f8c234703d844b2)  
 
 ### ACME Certificate Profiles
 

--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -74,6 +74,12 @@ controller:
     strict-validate-path-type: false
 ```
 
+#### Option 3. Upgrade `ingress-nginx`
+
+This issue is resolved in `ingress-nginx` v1.13.2 (released August 30, 2025).
+If you are running `ingress-nginx` v1.13.2 or later, you do not need to apply the workarounds described above.
+See the [fix commit](https://github.com/kubernetes/ingress-nginx/commit/618aae18515213bcf3fb820e6f8c234703d844b2)
+
 ### ACME Certificate Profiles
 
 cert-manager now supports the selection of ACME certificate profiles, allowing


### PR DESCRIPTION
ACME HTTP01 challenge issue is resolved in `ingress-nginx` v1.13.2 (released August 30, 2025)