### PR TITLE
chore(issuers): add zerossl custom issuer

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -801,6 +801,7 @@ cfssl-issuer
 cfmtls-issuer
 GlobalSign
 czertainly-issuer
+zerossl-issuer
 
 # TEMPORARY
 # these are temporarily ignored because the spellchecker

--- a/content/docs/configuration/issuers.md
+++ b/content/docs/configuration/issuers.md
@@ -29,6 +29,7 @@ The following list contains all known cert-manager issuer integrations.
 | 🥈   | venafi-issuer (in-tree)     | [📄][config:venafi-issuer]          | [Venafi TLS Protect][ca:venafi-issuer]                                 | -                                                 | [✔️][release:cert-manager]           | ✔️             |
 | 🥈   | cfssl-issuer                | [📄][config:cfssl-issuer]           | [CFSSL][ca:cfssl-issuer]                                               | -                                                 | [✔️][release:cfssl-issuer]           | ✔️             |
 | 🥈   | cfmtls-issuer               | [📄][config:cfmtls-issuer]          | [CFMTLS][ca:cfmtls-issuer]                                             | -                                                 | [✔️][release:cfmtls-issuer]          | ✔️             |
+| 🥈   | zerossl-issuer              | [📄][config:zerossl-issuer]         | [ZeroSSL][ca:zerossl-issuer]                                           | -                                                 | [✔️][release:zerossl-issuer]         | ✔️             |
 | 🥉   | tcs-issuer                  | [📄][config:tcs-issuer]             | [Intel's SGX technology][ca:tcs-issuer]                                | -                                                 | [❌][release:tcs-issuer]              | ✔️             |
 | 🥉   | freeipa-issuer              | [📄][config:freeipa-issuer]         | [FreeIPA][ca:freeipa-issuer]                                           | -                                                 | [❌][release:freeipa-issuer]          | ✔️             |
 | 🥉   | kms-issuer                  | [📄][config:kms-issuer]             | [AWS KMS][ca:kms-issuer]                                               | -                                                 | [❌][release:kms-issuer]              | ✔️             |
@@ -64,6 +65,7 @@ The following list contains all known cert-manager issuer integrations.
 [config:adcs-issuer]: https://djkormo.github.io/adcs-issuer/
 [config:cfssl-issuer]: https://gerrit.wikimedia.org/r/plugins/gitiles/operations/software/cfssl-issuer
 [config:cfmtls-issuer]: https://github.com/k8stooling/cfmtls-issuer
+[config:zerossl-issuer]: https://github.com/topfreegames/zerossl-issuer
 [config:cview-issuer]: https://secure-ly.github.io/cview-issuer-chart
 [config:czertainly-issuer]: https://docs.czertainly.com/docs/certificate-key/integration-guides/cert-manager-issuer/create-czertainly-issuer
 [config:keyvault-issuer]: https://github.com/gonicus/azure-keyvault-issuer
@@ -86,6 +88,7 @@ The following list contains all known cert-manager issuer integrations.
 [ca:venafi-issuer]: https://www.cyberark.com/products/certificate-manager/
 [ca:cfssl-issuer]: https://github.com/cloudflare/cfssl
 [ca:cfmtls-issuer]: https://developers.cloudflare.com/ssl/client-certificates/create-a-client-certificate/
+[ca:zerossl-issuer]: https://zerossl.com/
 [ca:freeipa-issuer]: https://www.freeipa.org
 [ca:kms-issuer]: https://aws.amazon.com/kms/
 [ca:origin-ca-issuer]: https://developers.cloudflare.com/ssl/origin-configuration/origin-ca
@@ -112,6 +115,7 @@ The following list contains all known cert-manager issuer integrations.
 [release:adcs-issuer]: https://github.com/djkormo/adcs-issuer/releases
 [release:cfssl-issuer]: https://gerrit.wikimedia.org/r/plugins/gitiles/operations/software/cfssl-issuer/+refs
 [release:cfmtls-issuer]: https://github.com/k8stooling/cfmtls-issuer/releases/
+[release:zerossl-issuer]: https://github.com/topfreegames/zerossl-issuer/releases
 [release:cview-issuer]: https://github.com/secure-ly/cview-issuer-chart/releases
 [release:czertainly-issuer]: https://github.com/CZERTAINLY/CZERTAINLY-Cert-Manager-Issuer/releases
 [release:keyvault-issuer]: https://github.com/gonicus/azure-keyvault-issuer/releases


### PR DESCRIPTION
It adds the [ZeroSSL](https://github.com/topfreegames/zerossl-issuer) external issuer using [ZeroSSL REST API](https://zerossl.com/documentation/api/). Even though zerossl provides an ACME API, it comes with some limitations that are not applied to their own API (such as DNS labels limitation).

