### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "cert-manager Website Dev",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+
+  "postCreateCommand": "npm ci && npm install -g netlify-cli",
+
+  "forwardPorts": [3000],
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "yzhang.markdown-all-in-one"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ npm ci
 
 This command is similar to `npm install` but it ensures that you will have a clean install of all the dependencies.
 
+### Devcontainer (optional)
+
+The repository includes a ready-to-use **devcontainer** for VS Code Dev Containers or GitHub Codespaces.
+This provides a fully configured development environment with all required tools and dependencies,
+so you can start working on the website without installing anything on your local machine.
+
+**Usage:**
+
+1. Open the repository in VS Code.
+2. When prompted, select **"Reopen in Container"** (or run **Dev Containers: Reopen in Container** from the command palette).
+3. Once the container is built, use the integrated terminal to run:
+
+```bash
+./scripts/server     # start the local development server
+./scripts/verify     # run lint, link-check, spell-check, etc.
+```
+
 ### Development Server
 
 The best development environment uses the Netlify CLI to serve the site locally. The Netlify CLI server


### PR DESCRIPTION
As I don't have any local setup for the tools used in this project, I need another environment to work in. This will probably be the case for other contributors to this project. The PR adds a simple devcontainer configuration that should allow contributors to spin up an online environment ready to work on this project.