### PR TITLE
Ungroup npm major upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,10 @@
       matchManagers: [
         'npm',
       ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
     },
   ],
 }


### PR DESCRIPTION
This is mainly to address https://github.com/cert-manager/website/pull/1767, as upgrading all major upgrades at the same time won't work. We will probably have to create more specialized groups, as some dependency upgrades must be coordinated. Renovate has some presets we might use, but let's deal with this in follow-up PRs.