### PR TITLE
Update 1.19 expected supported K8s releases

### DIFF
--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -29,7 +29,7 @@ should be stable enough to run.
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
-| [1.19][] | Oct 7, 2025  | Release of 1.21 | 1.29 → 1.33 / 4.16 → 4.18                      | 1.30 → 1.33                        |
+| [1.19][] | Oct 7, 2025  | Release of 1.21 | 1.31 → 1.34 / 4.18 → 4.19                      | 1.31 → 1.34                        |
 
 Dates in the future are not firm commitments and are subject to change.
 


### PR DESCRIPTION
For our upcoming 1.19 release of cert-manager, I think we should communicate the intent of supported Kubernetes versions. cert-manager 1.19 will support Kubernetes 1.34, as that is the version we run tests on for the master branch right now. It is pointless for OSS cert-manager to support Kubernetes versions that are EOL. I have used the following source for the proposed cut-off: https://endoflife.date/kubernetes.

For OpenShift, it's more complicated, as they appear to be lagging behind on Kubernetes versions. This page can provide a snapshot of their current status: https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/. We could eventually remove the explicit note about supported OpenShift versions. It's kinda pointless to state that we support something we don't test at all?

/cc @wallrj 