### PR TITLE
Use OCI registry for use in sub-chart

### DIFF
--- a/content/docs/installation/helm.md
+++ b/content/docs/installation/helm.md
@@ -122,7 +122,7 @@ appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
     version: [[VAR::cert_manager_latest_version]]
-    repository: https://charts.jetstack.io
+    repository: oci://quay.io/jetstack/charts
     alias: cert-manager
     condition: cert-manager.enabled
 ```


### PR DESCRIPTION
Updates sample to use OCI Chart instead of legacy chart registry

