### PR TITLE
Add cert-manager 1.19 boilerplate release notes and upgrade guide

### DIFF
--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -21,8 +21,16 @@
               "path": "/docs/releases/README.md"
             },
             {
-              "title": "1.18",
-              "path": "/docs/releases/release-notes/release-notes-1.18.md"
+              "title": "1.19",
+              "path": "/docs/releases/release-notes/release-notes-1.19.md"
+            },
+            {
+                "title": "Upgrade 1.18 to 1.19",
+                "path": "/docs/releases/upgrading/upgrading-1.18-1.19.md"
+            },
+            {
+                "title": "1.18",
+                "path": "/docs/releases/release-notes/release-notes-1.18.md"
             },
             {
               "title": "Upgrade 1.17 to 1.18",

--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -337,7 +337,8 @@ NB: cert-manager 1.12 was a public Long Term Support (LTS) release sponsored by 
 
 [s]: #kubernetes-supported-versions
 [test]: #supported-vs-tested
-[1.19]: https://github.com/cert-manager/cert-manager/milestone/41
+[1.20]: https://github.com/cert-manager/cert-manager/milestone/42
+[1.19]: ./release-notes/release-notes-1.19.md
 [1.18]: ./release-notes/release-notes-1.18.md
 [1.17]: ./release-notes/release-notes-1.17.md
 [1.16]: ./release-notes/release-notes-1.16.md

--- a/content/docs/releases/release-notes/release-notes-1.19.md
+++ b/content/docs/releases/release-notes/release-notes-1.19.md
@@ -1,0 +1,49 @@
+---
+title: Release 1.19
+description: 'cert-manager release notes: cert-manager 1.19'
+---
+
+cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.
+
+cert-manager 1.19 introduces several new features and breaking changes.
+
+TODO
+
+Be sure to review all new features and changes below, and read the full release notes carefully before upgrading.
+
+## Major Themes
+
+TODO
+
+## Community
+
+As always, we'd like to thank all of the community members who helped in this release cycle, including all below who merged a PR and anyone that helped by commenting on issues, testing, or getting involved in cert-manager meetings. We're lucky to have you involved.
+
+A special thanks to:
+
+- TODO
+
+for their contributions, comments and support!
+
+Also, thanks to the cert-manager maintainer team for their help in this release:
+
+- [@inteon](https://github.com/inteon)
+- [@erikgb](https://github.com/erikgb)
+- [@SgtCoDFish](https://github.com/SgtCoDFish)
+- [@ThatsMrTalbot](https://github.com/ThatsMrTalbot)
+- [@munnerz](https://github.com/munnerz)
+- [@maelvls](https://github.com/maelvls)
+
+And finally, thanks to the cert-manager steering committee for their feedback in this release cycle:
+
+- [@FlorianLiebhart](https://github.com/FlorianLiebhart)
+- [@ssyno](https://github.com/ssyno)
+- [@ianarsenault](https://github.com/ianarsenault)
+- [@TrilokGeer](https://github.com/TrilokGeer)
+
+
+## `v1.19.0`
+
+Changes since `v1.18.2`:
+
+TODO

--- a/content/docs/releases/upgrading/upgrading-1.18-1.19.md
+++ b/content/docs/releases/upgrading/upgrading-1.18-1.19.md
@@ -1,0 +1,12 @@
+---
+title: Upgrading from v1.18 to v1.19
+description: 'cert-manager installation: Upgrading v1.18 to v1.19'
+---
+
+Before upgrading cert-manager from 1.18 to 1.19, please read the following important notes about breaking changes in 1.19:
+
+TODO
+
+## Next Steps
+
+From here on, you can follow the [regular upgrade process](../../installation/upgrade.md).


### PR DESCRIPTION
Preview:
 * https://deploy-preview-1781--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.19/
 * https://deploy-preview-1781--cert-manager.netlify.app/docs/releases/upgrading/upgrading-1.18-1.19

Add boilerplate for cert-manager 1.19 release notes and docs so that it's easier for cert-manager PR authors to contribute short release note paragraphs for cert-manager 1.19 features.

- Add v1.19 release notes file
- Add upgrading guide for v1.18 to v1.19
- Update docs manifest to include v1.19 and upgrade entry
- Update releases README links to point to v1.19 files and milestone

Prior art:
 * https://github.com/cert-manager/website/pull/1680

Part of: https://github.com/cert-manager/cert-manager/issues/8113