### PR TITLE
Release notes for cert-manager v1.19.0

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -325,6 +325,7 @@ literalSubject
 LiteralSubject
 LiteralSubjects
 SVIDs
+steerers
 stevehipwell
 TLDs
 TODO
@@ -494,6 +495,7 @@ OAuth
 observedGeneration
 onwards
 openshift-supported-versions
+parsable
 plaintext
 powershell
 pre
@@ -583,6 +585,8 @@ v1.18
 v1.18.0
 v1.18.0.
 v1.19
+v1.19.0
+alpha.0
 v1.5
 v1.5.0
 v1.5.0.

--- a/content/docs/cli/cainjector.md
+++ b/content/docs/cli/cainjector.md
@@ -25,7 +25,7 @@ Flags:
       --feature-gates mapStringBool                          A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                                              AllAlpha=true|false (ALPHA - default=false)
                                                              AllBeta=true|false (BETA - default=false)
-                                                             CAInjectorMerging=true|false (ALPHA - default=false)
+                                                             CAInjectorMerging=true|false (BETA - default=true)
                                                              ServerSideApply=true|false (ALPHA - default=false)
   -h, --help                                                 help for cainjector
       --kubeconfig string                                    Paths to a kubeconfig. Only required if out-of-cluster.

--- a/content/docs/cli/controller.md
+++ b/content/docs/cli/controller.md
@@ -40,6 +40,7 @@ Flags:
       --enable-profiling                                     Enable profiling for controller.
       --extra-certificate-annotations strings                Extra annotation to be added by the ingress-shim controller to certificate object
       --feature-gates mapStringBool                          A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
+                                                             ACMEHTTP01IngressPathTypeExact=true|false (BETA - default=true)
                                                              AllAlpha=true|false (ALPHA - default=false)
                                                              AllBeta=true|false (BETA - default=false)
                                                              DefaultPrivateKeyRotationPolicyAlways=true|false (BETA - default=true)

--- a/content/docs/cli/webhook.md
+++ b/content/docs/cli/webhook.md
@@ -22,6 +22,7 @@ Flags:
       --dynamic-serving-leaf-duration duration               leaf duration of serving certificates (default 168h0m0s)
       --enable-profiling                                     Enable profiling for webhook.
       --feature-gates mapStringBool                          A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
+                                                             ACMEHTTP01IngressPathTypeExact=true|false (BETA - default=true)
                                                              AllAlpha=true|false (ALPHA - default=false)
                                                              AllBeta=true|false (BETA - default=false)
                                                              DefaultPrivateKeyRotationPolicyAlways=true|false (BETA - default=true)

--- a/content/docs/reference/api-docs.md
+++ b/content/docs/reference/api-docs.md
@@ -1920,7 +1920,7 @@ description: >-
         <em>string</em>
       </td>
       <td>
-        <p>The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.</p>
+        <p>The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]); port is optional. This field is required.</p>
       </td>
     </tr>
     <tr>

--- a/content/docs/reference/api-docs.md
+++ b/content/docs/reference/api-docs.md
@@ -20,9 +20,6 @@ description: >-
     <a href="#controller.config.cert-manager.io%2fv1alpha1">controller.config.cert-manager.io/v1alpha1</a>
   </li>
   <li>
-    <a href="#meta.cert-manager.io%2fv1">meta.cert-manager.io/v1</a>
-  </li>
-  <li>
     <a href="#webhook.config.cert-manager.io%2fv1alpha1">webhook.config.cert-manager.io/v1alpha1</a>
   </li>
 </ul>
@@ -190,9 +187,7 @@ description: >-
             <td>
               <code>issuerRef</code>
               <br />
-              <em>
-                <a href="#meta.cert-manager.io/v1.ObjectReference">ObjectReference</a>
-              </em>
+              <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.IssuerReference</em>
             </td>
             <td>
               <p>References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an &lsquo;ACME&rsquo; Issuer, an error will be returned and the Challenge will be marked as failed.</p>
@@ -286,9 +281,7 @@ description: >-
             <td>
               <code>issuerRef</code>
               <br />
-              <em>
-                <a href="#meta.cert-manager.io/v1.ObjectReference">ObjectReference</a>
-              </em>
+              <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.IssuerReference</em>
             </td>
             <td>
               <p>IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an &lsquo;ACME&rsquo; Issuer, an error will be returned and the Order will be marked as failed.</p>
@@ -770,6 +763,7 @@ description: >-
         <em>[]sigs.k8s.io/gateway-api/apis/v1.ParentReference</em>
       </td>
       <td>
+        <em>(Optional)</em>
         <p>
           When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See:
           <a href="https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways">https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways</a>
@@ -942,6 +936,47 @@ description: >-
       <td>
         <em>(Optional)</em>
         <p>Labels that should be added to the created ACME HTTP01 solver pods.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h3 id="acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01IngressPodResources">ACMEChallengeSolverHTTP01IngressPodResources</h3>
+<p> (<em>Appears on:</em> <a href="#acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01IngressPodSpec">ACMEChallengeSolverHTTP01IngressPodSpec</a>) </p>
+<div>
+  <p>ACMEChallengeSolverHTTP01IngressPodResources defines resource requirements for ACME HTTP01 solver pods. To keep API surface essential, this trims down the &lsquo;corev1.ResourceRequirements&rsquo; type to only include the Requests and Limits fields.</p>
+</div>
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>limits</code>
+        <br />
+        <em>
+          <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcelist-v1-core">Kubernetes core/v1.ResourceList</a>
+        </em>
+      </td>
+      <td>
+        <em>(Optional)</em>
+        <p> Limits describes the maximum amount of compute resources allowed. More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a> </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>requests</code>
+        <br />
+        <em>
+          <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcelist-v1-core">Kubernetes core/v1.ResourceList</a>
+        </em>
+      </td>
+      <td>
+        <em>(Optional)</em>
+        <p> Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to the global values configured via controller flags. Requests cannot exceed Limits. More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a> </p>
       </td>
     </tr>
   </tbody>
@@ -1168,6 +1203,19 @@ description: >-
         <p>If specified, the pod&rsquo;s security context</p>
       </td>
     </tr>
+    <tr>
+      <td>
+        <code>resources</code>
+        <br />
+        <em>
+          <a href="#acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01IngressPodResources">ACMEChallengeSolverHTTP01IngressPodResources</a>
+        </em>
+      </td>
+      <td>
+        <em>(Optional)</em>
+        <p>If specified, the pod&rsquo;s resource requirements. These values override the global resource configuration flags. Note that when only specifying resource limits, ensure they are greater than or equal to the corresponding global resource requests configured via controller flags (&ndash;acme-http01-solver-resource-request-cpu, &ndash;acme-http01-solver-resource-request-memory). Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 <h3 id="acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01IngressPodTemplate">ACMEChallengeSolverHTTP01IngressPodTemplate</h3>
@@ -1293,6 +1341,19 @@ description: >-
               <p>If specified, the pod&rsquo;s security context</p>
             </td>
           </tr>
+          <tr>
+            <td>
+              <code>resources</code>
+              <br />
+              <em>
+                <a href="#acme.cert-manager.io/v1.ACMEChallengeSolverHTTP01IngressPodResources">ACMEChallengeSolverHTTP01IngressPodResources</a>
+              </em>
+            </td>
+            <td>
+              <em>(Optional)</em>
+              <p>If specified, the pod&rsquo;s resource requirements. These values override the global resource configuration flags. Note that when only specifying resource limits, ensure they are greater than or equal to the corresponding global resource requests configured via controller flags (&ndash;acme-http01-solver-resource-request-cpu, &ndash;acme-http01-solver-resource-request-memory). Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.</p>
+            </td>
+          </tr>
         </table>
       </td>
     </tr>
@@ -1382,9 +1443,7 @@ description: >-
       <td>
         <code>keySecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <p> keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The <code>key</code> is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret <strong>must</strong> be un-padded, base64 URL encoded data. </p>
@@ -1447,7 +1506,7 @@ description: >-
       </td>
       <td>
         <em>(Optional)</em>
-        <p>PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let&rsquo;s Encrypt&rsquo;s shortest ECDSA chain you would use: &ldquo;ISRG Root X2&rdquo; or &ldquo;ISRG Root X1&rdquo; for the (old default) Let&rsquo;s Encrypt root CA. This value picks the first certificate bundle in the combined set of ACME default and alternative chains that has a root-most certificate with this value as its issuer&rsquo;s commonname.</p>
+        <p>PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let&rsquo;s Encrypt&rsquo;s DST cross-sign you would use: &ldquo;DST Root CA X3&rdquo; or &ldquo;ISRG Root X1&rdquo; for the newer Let&rsquo;s Encrypt root CA. This value picks the first certificate bundle in the combined set of ACME default and alternative chains that has a root-most certificate with this value as its issuer&rsquo;s commonname.</p>
       </td>
     </tr>
     <tr>
@@ -1489,9 +1548,7 @@ description: >-
       <td>
         <code>privateKeySecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <p> PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a <code>key</code> may be specified to select a specific entry within the named Secret resource. If <code>key</code> is not specified, a default of <code>tls.key</code> will be used. </p>
@@ -1570,9 +1627,7 @@ description: >-
       <td>
         <code>accountSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td></td>
     </tr>
@@ -1603,9 +1658,7 @@ description: >-
       <td>
         <code>clientTokenSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td></td>
     </tr>
@@ -1613,9 +1666,7 @@ description: >-
       <td>
         <code>clientSecretSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td></td>
     </tr>
@@ -1623,9 +1674,7 @@ description: >-
       <td>
         <code>accessTokenSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td></td>
     </tr>
@@ -1659,9 +1708,7 @@ description: >-
       <td>
         <code>clientSecretSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -1755,9 +1802,7 @@ description: >-
       <td>
         <code>serviceAccountSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -1812,9 +1857,7 @@ description: >-
       <td>
         <code>apiKeySecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -1825,9 +1868,7 @@ description: >-
       <td>
         <code>apiTokenSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -1853,9 +1894,7 @@ description: >-
       <td>
         <code>tokenSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td></td>
     </tr>
@@ -1881,16 +1920,14 @@ description: >-
         <em>string</em>
       </td>
       <td>
-        <p>The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]); port is optional. This field is required.</p>
+        <p>The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.</p>
       </td>
     </tr>
     <tr>
       <td>
         <code>tsigSecretSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -1917,6 +1954,19 @@ description: >-
       <td>
         <em>(Optional)</em>
         <p> The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when <code>tsigSecretSecretRef</code> and <code>tsigKeyName</code> are defined. Supported values are (case-insensitive): <code>HMACMD5</code> (default), <code>HMACSHA1</code>, <code>HMACSHA256</code> or <code>HMACSHA512</code>. </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>protocol</code>
+        <br />
+        <em>
+          <a href="#acme.cert-manager.io/v1.RFC2136UpdateProtocol">RFC2136UpdateProtocol</a>
+        </em>
+      </td>
+      <td>
+        <em>(Optional)</em>
+        <p> Protocol to use for dynamic DNS update queries. Valid values are (case-sensitive) <code>TCP</code> and <code>UDP</code>; <code>UDP</code> (default). </p>
       </td>
     </tr>
   </tbody>
@@ -1962,9 +2012,7 @@ description: >-
       <td>
         <code>accessKeyIDSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -1975,9 +2023,7 @@ description: >-
       <td>
         <code>secretAccessKeySecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -2360,9 +2406,7 @@ description: >-
       <td>
         <code>issuerRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.ObjectReference">ObjectReference</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.IssuerReference</em>
       </td>
       <td>
         <p>References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an &lsquo;ACME&rsquo; Issuer, an error will be returned and the Challenge will be marked as failed.</p>
@@ -2487,9 +2531,7 @@ description: >-
       <td>
         <code>issuerRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.ObjectReference">ObjectReference</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.IssuerReference</em>
       </td>
       <td>
         <p>IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an &lsquo;ACME&rsquo; Issuer, an error will be returned and the Order will be marked as failed.</p>
@@ -2646,6 +2688,35 @@ description: >-
       <td>
         <em>(Optional)</em>
         <p>FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h3 id="acme.cert-manager.io/v1.RFC2136UpdateProtocol"> RFC2136UpdateProtocol (<code>string</code> alias) </h3>
+<p> (<em>Appears on:</em> <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderRFC2136">ACMEIssuerDNS01ProviderRFC2136</a>) </p>
+<div></div>
+<table>
+  <thead>
+    <tr>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <p>&#34;TCP&#34;</p>
+      </td>
+      <td>
+        <p>RFC2136UpdateProtocolTCP utilizes TCP to update queries.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p>&#34;UDP&#34;</p>
+      </td>
+      <td>
+        <p>RFC2136UpdateProtocolUDP utilizes UDP to update queries.</p>
       </td>
     </tr>
   </tbody>
@@ -3300,9 +3371,7 @@ description: >-
             <td>
               <code>issuerRef</code>
               <br />
-              <em>
-                <a href="#meta.cert-manager.io/v1.ObjectReference">ObjectReference</a>
-              </em>
+              <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.IssuerReference</em>
             </td>
             <td>
               <p>Reference to the issuer responsible for issuing the certificate. If the issuer is namespace-scoped, it must be in the same namespace as the Certificate. If the issuer is cluster-scoped, it can be used from any namespace.</p>
@@ -3519,9 +3588,7 @@ description: >-
             <td>
               <code>issuerRef</code>
               <br />
-              <em>
-                <a href="#meta.cert-manager.io/v1.ObjectReference">ObjectReference</a>
-              </em>
+              <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.IssuerReference</em>
             </td>
             <td>
               <p>Reference to the issuer responsible for issuing the certificate. If the issuer is namespace-scoped, it must be in the same namespace as the Certificate. If the issuer is cluster-scoped, it can be used from any namespace.</p>
@@ -3917,9 +3984,7 @@ description: >-
       <td>
         <code>status</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.ConditionStatus">ConditionStatus</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.ConditionStatus</em>
       </td>
       <td>
         <p> Status of the condition, one of (<code>True</code>, <code>False</code>, <code>Unknown</code>). </p>
@@ -4190,9 +4255,7 @@ description: >-
       <td>
         <code>status</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.ConditionStatus">ConditionStatus</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.ConditionStatus</em>
       </td>
       <td>
         <p> Status of the condition, one of (<code>True</code>, <code>False</code>, <code>Unknown</code>). </p>
@@ -4319,9 +4382,7 @@ description: >-
       <td>
         <code>issuerRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.ObjectReference">ObjectReference</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.IssuerReference</em>
       </td>
       <td>
         <p>Reference to the issuer responsible for issuing the certificate. If the issuer is namespace-scoped, it must be in the same namespace as the Certificate. If the issuer is cluster-scoped, it can be used from any namespace.</p>
@@ -4711,9 +4772,7 @@ description: >-
       <td>
         <code>issuerRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.ObjectReference">ObjectReference</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.IssuerReference</em>
       </td>
       <td>
         <p>Reference to the issuer responsible for issuing the certificate. If the issuer is namespace-scoped, it must be in the same namespace as the Certificate. If the issuer is cluster-scoped, it can be used from any namespace.</p>
@@ -4984,9 +5043,7 @@ description: >-
       <td>
         <code>status</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.ConditionStatus">ConditionStatus</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.ConditionStatus</em>
       </td>
       <td>
         <p> Status of the condition, one of (<code>True</code>, <code>False</code>, <code>Unknown</code>). </p>
@@ -5252,9 +5309,7 @@ description: >-
       <td>
         <code>passwordSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -5621,9 +5676,7 @@ description: >-
       <td>
         <code>passwordSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -5905,9 +5958,7 @@ description: >-
       <td>
         <code>secretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <p> Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The <code>key</code> field must be specified and denotes which entry within the Secret resource is used as the app role secret. </p>
@@ -5932,9 +5983,7 @@ description: >-
       <td>
         <code>tokenSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -6112,9 +6161,7 @@ description: >-
       <td>
         <code>caBundleSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -6125,9 +6172,7 @@ description: >-
       <td>
         <code>clientCertSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -6138,9 +6183,7 @@ description: >-
       <td>
         <code>clientKeySecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -6177,9 +6220,7 @@ description: >-
       <td>
         <code>secretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -6239,9 +6280,7 @@ description: >-
       <td>
         <code>apiTokenSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <p>APITokenSecretRef is a secret key selector for the Venafi Cloud API token.</p>
@@ -6327,9 +6366,7 @@ description: >-
       <td>
         <code>credentialsRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.LocalObjectReference">LocalObjectReference</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.LocalObjectReference</em>
       </td>
       <td>
         <p>CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials. The secret must contain the key &lsquo;access-token&rsquo; for the Access Token Authentication, or two keys, &lsquo;username&rsquo; and &lsquo;password&rsquo; for the API Keys Authentication.</p>
@@ -6350,9 +6387,7 @@ description: >-
       <td>
         <code>caBundleSecretRef</code>
         <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>
-        </em>
+        <em>github.com/cert-manager/cert-manager/pkg/apis/meta/v1.SecretKeySelector</em>
       </td>
       <td>
         <em>(Optional)</em>
@@ -6968,166 +7003,6 @@ description: >-
   </tbody>
 </table>
 <hr />
-<h2 id="meta.cert-manager.io/v1">meta.cert-manager.io/v1</h2>
-<div>
-  <p>Package v1 contains meta types for cert-manager APIs</p>
-</div>
-<p>Resource Types:</p>
-<ul></ul>
-<h3 id="meta.cert-manager.io/v1.ConditionStatus"> ConditionStatus (<code>string</code> alias) </h3>
-<p> (<em>Appears on:</em> <a href="#cert-manager.io/v1.CertificateCondition">CertificateCondition</a>, <a href="#cert-manager.io/v1.CertificateRequestCondition">CertificateRequestCondition</a>, <a href="#cert-manager.io/v1.IssuerCondition">IssuerCondition</a>) </p>
-<div>
-  <p>ConditionStatus represents a condition&rsquo;s status.</p>
-</div>
-<table>
-  <thead>
-    <tr>
-      <th>Value</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <p>&#34;False&#34;</p>
-      </td>
-      <td>
-        <p>ConditionFalse represents the fact that a given condition is false</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p>&#34;True&#34;</p>
-      </td>
-      <td>
-        <p>ConditionTrue represents the fact that a given condition is true</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p>&#34;Unknown&#34;</p>
-      </td>
-      <td>
-        <p>ConditionUnknown represents the fact that a given condition is unknown</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h3 id="meta.cert-manager.io/v1.LocalObjectReference">LocalObjectReference</h3>
-<p> (<em>Appears on:</em> <a href="#cert-manager.io/v1.VenafiTPP">VenafiTPP</a>, <a href="#meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</a>) </p>
-<div>
-  <p>A reference to an object in the same namespace as the referent. If the referent is a cluster-scoped resource (e.g., a ClusterIssuer), the reference instead refers to the resource with the given name in the configured &lsquo;cluster resource namespace&rsquo;, which is set as a flag on the controller component (and defaults to the namespace that cert-manager runs in).</p>
-</div>
-<table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p> Name of the resource being referred to. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names">https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</a> </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h3 id="meta.cert-manager.io/v1.ObjectReference">ObjectReference</h3>
-<p> (<em>Appears on:</em> <a href="#acme.cert-manager.io/v1.ChallengeSpec">ChallengeSpec</a>, <a href="#acme.cert-manager.io/v1.OrderSpec">OrderSpec</a>, <a href="#cert-manager.io/v1.CertificateRequestSpec">CertificateRequestSpec</a>, <a href="#cert-manager.io/v1.CertificateSpec">CertificateSpec</a>) </p>
-<div>
-  <p>ObjectReference is a reference to an object with a given name, kind and group.</p>
-</div>
-<table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name of the resource being referred to.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kind</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Kind of the resource being referred to.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>group</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Group of the resource being referred to.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h3 id="meta.cert-manager.io/v1.SecretKeySelector">SecretKeySelector</h3>
-<p>
-  (<em>Appears on:</em> <a href="#acme.cert-manager.io/v1.ACMEExternalAccountBinding">ACMEExternalAccountBinding</a>, <a href="#acme.cert-manager.io/v1.ACMEIssuer">ACMEIssuer</a>, <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderAcmeDNS">ACMEIssuerDNS01ProviderAcmeDNS</a>, <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderAkamai">ACMEIssuerDNS01ProviderAkamai</a>, <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderAzureDNS">ACMEIssuerDNS01ProviderAzureDNS</a>, <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderCloudDNS">ACMEIssuerDNS01ProviderCloudDNS</a>, <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderCloudflare">ACMEIssuerDNS01ProviderCloudflare</a>, <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderDigitalOcean">ACMEIssuerDNS01ProviderDigitalOcean</a>, <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderRFC2136">ACMEIssuerDNS01ProviderRFC2136</a>,
-  <a href="#acme.cert-manager.io/v1.ACMEIssuerDNS01ProviderRoute53">ACMEIssuerDNS01ProviderRoute53</a>, <a href="#cert-manager.io/v1.JKSKeystore">JKSKeystore</a>, <a href="#cert-manager.io/v1.PKCS12Keystore">PKCS12Keystore</a>, <a href="#cert-manager.io/v1.VaultAppRole">VaultAppRole</a>, <a href="#cert-manager.io/v1.VaultAuth">VaultAuth</a>, <a href="#cert-manager.io/v1.VaultIssuer">VaultIssuer</a>, <a href="#cert-manager.io/v1.VaultKubernetesAuth">VaultKubernetesAuth</a>, <a href="#cert-manager.io/v1.VenafiCloud">VenafiCloud</a>, <a href="#cert-manager.io/v1.VenafiTPP">VenafiTPP</a>)
-</p>
-<div>
-  <p> A reference to a specific &lsquo;key&rsquo; within a Secret resource. In some instances, <code>key</code> is a required field. </p>
-</div>
-<table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>LocalObjectReference</code>
-        <br />
-        <em>
-          <a href="#meta.cert-manager.io/v1.LocalObjectReference">LocalObjectReference</a>
-        </em>
-      </td>
-      <td>
-        <p> (Members of <code>LocalObjectReference</code> are embedded into this type.) </p>
-        <p>The name of the Secret resource being referred to.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>key</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p> The key of the entry in the Secret resource&rsquo;s <code>data</code> field to be used. Some instances of this field may be defaulted, in others it may be required. </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<hr />
 <h2 id="webhook.config.cert-manager.io/v1alpha1">webhook.config.cert-manager.io/v1alpha1</h2>
 <div>
   <p>Package v1alpha1 is the v1alpha1 version of the webhook config API.</p>
@@ -7262,5 +7137,5 @@ description: >-
 </table>
 <hr />
 <p>
-  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>3ab737e</code>. </em>
+  <em> Generated with <code>gen-crd-api-reference-docs</code> on git commit <code>12a3ef9</code>. </em>
 </p>

--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -21,15 +21,14 @@ should be stable enough to run.
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
+| [1.19][] | Oct 07, 2025 | Release of 1.21 | 1.31 → 1.34 / 4.18 → 4.19                      | 1.31 → 1.34                        |
 | [1.18][] | Jun 10, 2025 | Release of 1.20 | 1.29 → 1.33   /   4.16 → 4.18                  | 1.29 → 1.33                        |
-| [1.17][] | Feb 03, 2025 | Release of 1.19 | 1.29 → 1.33   /   4.16 → 4.18                  | 1.29 → 1.32                        |
-
 
 ## Upcoming releases
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
-| [1.19][] | Oct 7, 2025  | Release of 1.21 | 1.31 → 1.34 / 4.18 → 4.19                      | 1.31 → 1.34                        |
+| [1.20][] | Feb 10, 2026 | Release of 1.21 | 1.31 → 1.34 / 4.18 → 4.19                      | 1.31 → 1.34                        |
 
 Dates in the future are not firm commitments and are subject to change.
 
@@ -308,6 +307,7 @@ are no longer supported.
 
 | Release      | Release Date | EOL          | Compatible Kubernetes versions | Compatible OpenShift versions |
 |--------------|:------------:|:------------:|:------------------------------:|:-----------------------------:|
+| [1.17][]     | Feb 03, 2025 | Oct 07, 2025 | 1.29 → 1.33                    | 1.29 → 1.32                   |
 | [1.16][]     | Oct 03, 2024 | Jun 10, 2025 | 1.25 → 1.32                    | 4.14 → 4.17                   |
 | [1.15][]     | Jun 05, 2024 | Feb 03, 2025 | 1.25 → 1.32                    | 4.12 → 4.16                   |
 | [1.14][]     | Feb 03, 2024 | Oct 03, 2024 | 1.24 → 1.31                    | 4.11 → 4.16                   |

--- a/content/docs/releases/release-notes/release-notes-1.19.md
+++ b/content/docs/releases/release-notes/release-notes-1.19.md
@@ -5,45 +5,104 @@ description: 'cert-manager release notes: cert-manager 1.19'
 
 cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.
 
-cert-manager 1.19 introduces several new features and breaking changes.
-
-TODO
+This release focuses on expanding platform compatibility, improving deployment flexibility, enhancing observability, and addressing key reliability issues.
 
 Be sure to review all new features and changes below, and read the full release notes carefully before upgrading.
 
 ## Major Themes
 
-TODO
+###  Deployment and Platform Compatibility
+- The default network policy now includes `IPv6` rules to improve support for dual-stack and `IPv6` enabled clusters.
+- The Helm chart has a new `global.nodeSelector` value, to set a single node selector across all cert-manager components. This simplifies the deployment of cert-manager.
+- The Helm chart has a new (experimental) `global.hostUsers` flag which, if set to `false`, configures all the cert-manager Pods to use the [User Namespace feature of Kubernetes `>= 1.33`](https://kubernetes.io/docs/tasks/configure-pod-container/user-namespaces/). You can use this feature to reduce the damage a compromised container can do to the host or other pods in the same node. This new feature is disabled by default to maintain compatibility with Kubernetes `< 1.33`. In the future, when Kubernetes 1.32 reaches its end-of-life, the Helm chart value may be removed (or become a no-op) and cert-manager Pods will be configured to use user-namespaces by default.
+
+### ACME and Certificate Management
+- There is a new feature gate `ACMEHTTP01IngressPathTypeExact`, to allow `ingress-nginx` users to turn off the new default Ingress `PathType: Exact` setting. This is useful if you are using an old version of `ingress-nginx` which does not properly support `PathType: Exact`.
+- The Issuer and ClusterIssuer custom resources have new fields which allow you to configure resource requests and resource limits for ACME HTTP-01 solver pods. This allows teams to override the global `--acme-http01-solver-resource-*` flag values which are set by the platform administrator.
+- The ACME challenge authorization timeout has been increased to two minutes to reduce `error waiting for authorization` failures.
+- There is now stricter solver validation to reject configurations that specify multiple ingress selection options (e.g. `class`, `ingressClassName`, `name`).
+- There are DNS and API improvements. A new `protocol` field was added for the `rfc2136` DNS01 provider.
+- The `CAInjectorMerging` feature has been promoted to BETA which means it is enabled by default. This means the feature, which configures the CA Injector to merges new CA certificates with existing ones instead of replacing them outright, is now considered stable and will be active unless explicitly disabled.
+- There are various reliability fixes related to certificates and CSRs: increased maximum parsable PEM sizes, corrected permitted URI domain handling in CSR name constraints, and improved admission error messages for malformed PEM data.
+
+### Observability, Reliability, and Maintenance
+- There is a new Prometheus metric called `certmanager_certificate_challenge_status`.
+- POTENTIALLY BREAKING: A high cardinality label, called `path`, was removed from the `certmanager_acme_client_request_count` and `certmanager_acme_client_request_duration_seconds` metrics. It is replaced with a new bounded cardinality label called `action`. This may require updates to dashboards and alerts.
 
 ## Community
 
 As always, we'd like to thank all of the community members who helped in this release cycle, including all below who merged a PR and anyone that helped by commenting on issues, testing, or getting involved in cert-manager meetings. We're lucky to have you involved.
 
 A special thanks to:
-
-- TODO
-
+{/* BEGIN contributors */}
+- [`@StingRayZA`](https://github.com/StingRayZA)
+- [`@armagankaratosun`](https://github.com/armagankaratosun)
+- [`@hjoshi123`](https://github.com/hjoshi123)
+- [`@jcpunk`](https://github.com/jcpunk)
+- [`@kinolaev`](https://github.com/kinolaev)
+- [`@lunarwhite`](https://github.com/lunarwhite)
+- [`@mladen-rusev-cyberark`](https://github.com/mladen-rusev-cyberark)
+- [`@prasad89`](https://github.com/prasad89)
+- [`@quantpoet`](https://github.com/quantpoet)
+- [`@sspreitzer`](https://github.com/sspreitzer)
+{/* END contributors */}
 for their contributions, comments and support!
 
 Also, thanks to the cert-manager maintainer team for their help in this release:
-
-- [@inteon](https://github.com/inteon)
-- [@erikgb](https://github.com/erikgb)
-- [@SgtCoDFish](https://github.com/SgtCoDFish)
-- [@ThatsMrTalbot](https://github.com/ThatsMrTalbot)
-- [@munnerz](https://github.com/munnerz)
-- [@maelvls](https://github.com/maelvls)
+{/* BEGIN maintainers */}
+- [`@SgtCoDFish`](https://github.com/SgtCoDFish)
+- [`@ThatsMrTalbot`](https://github.com/ThatsMrTalbot)
+- [`@erikgb`](https://github.com/erikgb)
+- [`@inteon`](https://github.com/inteon)
+- [`@maelvls`](https://github.com/maelvls)
+- [`@munnerz`](https://github.com/munnerz)
+- [`@wallrj`](https://github.com/wallrj)
+{/* END maintainers */}
 
 And finally, thanks to the cert-manager steering committee for their feedback in this release cycle:
+{/* BEGIN steerers */}
+- [`@FlorianLiebhart`](https://github.com/FlorianLiebhart)
+- [`@TrilokGeer`](https://github.com/TrilokGeer)
+- [`@ianarsenault`](https://github.com/ianarsenault)
+- [`@ssyno`](https://github.com/ssyno)
+{/* END steerers */}
 
-- [@FlorianLiebhart](https://github.com/FlorianLiebhart)
-- [@ssyno](https://github.com/ssyno)
-- [@ianarsenault](https://github.com/ianarsenault)
-- [@TrilokGeer](https://github.com/TrilokGeer)
-
-
+{/* BEGIN changelog v1.19.0 */}
 ## `v1.19.0`
 
-Changes since `v1.18.2`:
+Changes since `v1.18.0`:
 
-TODO
+### Feature
+
+- Add IPv6 rules to the default network policy ([`#7726`](https://github.com/cert-manager/cert-manager/pull/7726), [`@jcpunk`](https://github.com/jcpunk))
+- Add `global.nodeSelector` to helm chart to allow for a single `nodeSelector` to be set across all services. ([`#7818`](https://github.com/cert-manager/cert-manager/pull/7818), [`@StingRayZA`](https://github.com/StingRayZA))
+- Add a feature gate to default to Ingress `pathType` `Exact` in ACME HTTP01 Ingress challenge solvers. ([`#7795`](https://github.com/cert-manager/cert-manager/pull/7795), [`@sspreitzer`](https://github.com/sspreitzer))
+- Add generated `applyconfigurations` allowing clients to make type-safe server-side apply requests for cert-manager resources. ([`#7866`](https://github.com/cert-manager/cert-manager/pull/7866), [`@erikgb`](https://github.com/erikgb))
+- Added API defaults to issuer references group (cert-manager.io) and kind (Issuer). ([`#7414`](https://github.com/cert-manager/cert-manager/pull/7414), [`@erikgb`](https://github.com/erikgb))
+- Added `certmanager_certificate_challenge_status` Prometheus metric. ([`#7736`](https://github.com/cert-manager/cert-manager/pull/7736), [`@hjoshi123`](https://github.com/hjoshi123))
+- Added `protocol` field for `rfc2136` DNS01 provider ([`#7881`](https://github.com/cert-manager/cert-manager/pull/7881), [`@hjoshi123`](https://github.com/hjoshi123))
+- Added experimental field `hostUsers` flag to all pods. Not set by default. ([`#7973`](https://github.com/cert-manager/cert-manager/pull/7973), [`@hjoshi123`](https://github.com/hjoshi123))
+- Support configurable resource requests and limits for ACME HTTP01 solver pods through ClusterIssuer and Issuer specifications, allowing granular resource management that overrides global `--acme-http01-solver-resource-*` settings. ([`#7972`](https://github.com/cert-manager/cert-manager/pull/7972), [`@lunarwhite`](https://github.com/lunarwhite))
+- The `CAInjectorMerging` feature has been promoted to BETA and is now enabled by default ([`#8017`](https://github.com/cert-manager/cert-manager/pull/8017), [`@ThatsMrTalbot`](https://github.com/ThatsMrTalbot))
+- The controller, webhook and ca-injector now log their version and git commit on startup for easier debugging and support. ([`#8072`](https://github.com/cert-manager/cert-manager/pull/8072), [`@prasad89`](https://github.com/prasad89))
+- Updated `certificate` metrics to the collector approach. ([`#7856`](https://github.com/cert-manager/cert-manager/pull/7856), [`@hjoshi123`](https://github.com/hjoshi123))
+
+### Bug or Regression
+
+- ACME: Increased challenge authorization timeout to 2 minutes to fix `error waiting for authorization` ([`#7796`](https://github.com/cert-manager/cert-manager/pull/7796), [`@hjoshi123`](https://github.com/hjoshi123))
+- BUGFIX: permitted URI domains were incorrectly used to set the excluded URI domains in the CSR's name constraints ([`#7816`](https://github.com/cert-manager/cert-manager/pull/7816), [`@kinolaev`](https://github.com/kinolaev))
+- Enforced ACME HTTP-01 solver validation to properly reject configurations when multiple ingress options (`class`, `ingressClassName`, `name`) are specified simultaneously ([`#8021`](https://github.com/cert-manager/cert-manager/pull/8021), [`@lunarwhite`](https://github.com/lunarwhite))
+- Increase maximum sizes of PEM certificates and chains which can be parsed in cert-manager, to handle leaf certificates with large numbers of DNS names or other identities ([`#7961`](https://github.com/cert-manager/cert-manager/pull/7961), [`@SgtCoDFish`](https://github.com/SgtCoDFish))
+- Reverted adding the `global.rbac.disableHTTPChallengesRole` Helm option. ([`#7836`](https://github.com/cert-manager/cert-manager/pull/7836), [`@inteon`](https://github.com/inteon))
+- This change removes the `path` label of core ACME client metrics and will require users to update their monitoring dashboards and alerting rules if using those metrics. ([`#8109`](https://github.com/cert-manager/cert-manager/pull/8109), [`@mladen-rusev-cyberark`](https://github.com/mladen-rusev-cyberark))
+- Use the latest version of `ingress-nginx` in E2E tests to ensure compatibility ([`#7792`](https://github.com/cert-manager/cert-manager/pull/7792), [`@wallrj`](https://github.com/wallrj))
+
+### Other (Cleanup or Flake)
+
+- Helm: Fix naming template of `tokenrequest` RoleBinding resource to improve consistency ([`#7761`](https://github.com/cert-manager/cert-manager/pull/7761), [`@lunarwhite`](https://github.com/lunarwhite))
+- Improve error messages when certificates, CRLs or private keys fail admission due to malformed or missing PEM data ([`#7928`](https://github.com/cert-manager/cert-manager/pull/7928), [`@SgtCoDFish`](https://github.com/SgtCoDFish))
+- Major upgrade of Akamai SDK. NOTE: The new version has not been fully tested end-to-end due to the lack of cloud infrastructure. ([`#8003`](https://github.com/cert-manager/cert-manager/pull/8003), [`@hjoshi123`](https://github.com/hjoshi123))
+- Update kind images to include the Kubernetes 1.33 node image ([`#7786`](https://github.com/cert-manager/cert-manager/pull/7786), [`@wallrj`](https://github.com/wallrj))
+- Use `maps.Copy` for cleaner map handling ([`#8092`](https://github.com/cert-manager/cert-manager/pull/8092), [`@quantpoet`](https://github.com/quantpoet))
+- Vault: Migrate Vault E2E add-on tests from deprecated `vault-client-go` to the new `vault/api` client. ([`#8059`](https://github.com/cert-manager/cert-manager/pull/8059), [`@armagankaratosun`](https://github.com/armagankaratosun))
+{/* END changelog v1.19.0 */}

--- a/content/docs/releases/upgrading/upgrading-1.18-1.19.md
+++ b/content/docs/releases/upgrading/upgrading-1.18-1.19.md
@@ -3,9 +3,16 @@ title: Upgrading from v1.18 to v1.19
 description: 'cert-manager installation: Upgrading v1.18 to v1.19'
 ---
 
-Before upgrading cert-manager from 1.18 to 1.19, please read the following important notes about breaking changes in 1.19:
+Before upgrading cert-manager from 1.18 to 1.19, please read the following important notes about breaking changes in
 
-TODO
+## Potentially Breaking: ACME metrics label changes
+
+A high cardinality label, called `path`, was removed from the `certmanager_acme_client_request_count` and `certmanager_acme_client_request_duration_seconds` metrics.
+It is replaced with a new bounded cardinality label called `action`.
+If you are using these metrics, you may need to update your dashboards and alerts.
+
+1. Update any dashboards and alerts that using the old `path` label, to use the new bounded `action` label.
+2. If you rely on the high-cardinality `path` label, consider adding a Prometheus relabeling or recording rule to preserve the prior semantics (but beware of storage and cost).
 
 ## Next Steps
 

--- a/content/docs/releases/upgrading/upgrading-1.18-1.19.md
+++ b/content/docs/releases/upgrading/upgrading-1.18-1.19.md
@@ -3,7 +3,7 @@ title: Upgrading from v1.18 to v1.19
 description: 'cert-manager installation: Upgrading v1.18 to v1.19'
 ---
 
-Before upgrading cert-manager from 1.18 to 1.19, please read the following important notes about breaking changes in
+Before upgrading cert-manager from 1.18 to 1.19, please read the following important notes about breaking changes:
 
 ## Potentially Breaking: ACME metrics label changes
 

--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,3 +1,3 @@
 {
-  "cert_manager_latest_version": "v1.18.2"
+  "cert_manager_latest_version": "v1.19.0"
 }

--- a/scripts/gendocs/generate-new-import-path-docs
+++ b/scripts/gendocs/generate-new-import-path-docs
@@ -155,7 +155,7 @@ LATEST_VERSION="docs" # to also upgrade a specific version, use v1.13-docs, v1.1
 #genversionwithcli "release-1.15" "v1.15-docs"
 #genversionwithcli "release-1.16" "v1.16-docs"
 #genversionwithcli "release-1.17" "v1.17-docs"
-genversionwithcli "release-1.18" "$LATEST_VERSION"
+genversionwithcli "release-1.19" "$LATEST_VERSION"
 
 # Rather than generate the same docs again for /docs, copy from the latest version
 


### PR DESCRIPTION
Preview:
 * Installation versions: https://deploy-preview-1792--cert-manager.netlify.app/docs/installation/
 * Supported releases: https://deploy-preview-1792--cert-manager.netlify.app/docs/releases/
 * Release notes: https://deploy-preview-1792--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.19
 * Upgrade notes: https://deploy-preview-1792--cert-manager.netlify.app/docs/releases/upgrading/upgrading-1.18-1.19/
 * API reference: https://deploy-preview-1792--cert-manager.netlify.app/docs/reference/api-docs/
 * CLI reference: https://deploy-preview-1792--cert-manager.netlify.app/docs/cli/cainjector/ 

Part of: https://github.com/cert-manager/cert-manager/issues/8113

These changes were carried out according to the release-notes sections of the release process:
 * https://deploy-preview-1785--cert-manager.netlify.app/docs/contributing/release-process/#minor-releases


I used the cert-manager release-notes tool that I'm developing in https://github.com/cert-manager/website/pull/1785 and added some narrative with the help of gpt-5-mini.

- Populate release-notes-1.19.md with major themes and highlights
- Populated the upgrade notes page
- Add categorized changes sections: Feature, Bug or Regression, Other
- Add contributor acknowledgements and notes about upgrades and fixes
- Updated cert-manager version variable
- Updated CLI and API reference docs

The changes will be merged into the `release-next` branch, which will later be merged into the main branch when we've published the release.