### PR TITLE
Limit version dropdown to last two releases

### DIFF
--- a/components/docs/VersionSelect.jsx
+++ b/components/docs/VersionSelect.jsx
@@ -23,6 +23,7 @@ export default function VersionSelect({
       return compareVersions(labelFromVersion(first), labelFromVersion(second))
     })
     .reverse()
+    .slice(0, 2) // Only show the last two releases in the dropdown list
 
   return (
     <div className="bg-gray-1 rounded-md border-2 border-gray-2/50">


### PR DESCRIPTION
**Preview**: https://deploy-preview-1796--cert-manager.netlify.app/docs/

It was impossible to see the `release-next` link in the versions drop-down list because it went off the bottom of the page.

I've limited it now without actually deleting any of those old pages from the site.

- Show only the two most recent releases in the version dropdown
- Implemented by adding .slice(0, 2) in VersionSelect.jsx

new
<img width="1920" height="1098" alt="image" src="https://github.com/user-attachments/assets/f7aca80b-f1a5-4d75-bd9a-52eb30ef0c02" />

vs 

old
<img width="1920" height="1096" alt="image" src="https://github.com/user-attachments/assets/a2571378-a149-4f15-a395-83141d62c3bd" />


## Testing

I've verified that it works in Microsoft edge and Google Chrome and Firefox Mobile. 

CyberArk tracker: [VC-45942](https://venafi.atlassian.net/browse/VC-45942) <!-- do not edit this line, will be re-added automatically -->