### PR TITLE
Move old release entries into Older releases

### DIFF
--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -37,26 +37,6 @@
               "path": "/docs/releases/upgrading/upgrading-1.17-1.18.md"
             },
             {
-              "title": "1.17",
-              "path": "/docs/releases/release-notes/release-notes-1.17.md"
-            },
-            {
-              "title": "Upgrade 1.16 to 1.17",
-              "path": "/docs/releases/upgrading/upgrading-1.16-1.17.md"
-            },
-            {
-              "title": "1.16",
-              "path": "/docs/releases/release-notes/release-notes-1.16.md"
-            },
-            {
-              "title": "Upgrading from 1.12",
-              "path": "/docs/releases/upgrading/upgrading-1.12.md"
-            },
-            {
-              "title": "1.12",
-              "path": "/docs/releases/release-notes/release-notes-1.12.md"
-            },
-            {
               "title": "Older releases",
               "routes": [
                 {
@@ -66,6 +46,18 @@
                 {
                   "title": "Migrating Deprecated API Resources",
                   "path": "/docs/releases/upgrading/remove-deprecated-apis.md"
+                },
+                {
+                  "title": "1.17",
+                  "path": "/docs/releases/release-notes/release-notes-1.17.md"
+                },
+                {
+                  "title": "Upgrade 1.16 to 1.17",
+                  "path": "/docs/releases/upgrading/upgrading-1.16-1.17.md"
+                },
+                {
+                  "title": "1.16",
+                  "path": "/docs/releases/release-notes/release-notes-1.16.md"
                 },
                 {
                   "title": "Upgrade 1.15 to 1.16",
@@ -91,6 +83,15 @@
                   "title": "1.13",
                   "path": "/docs/releases/release-notes/release-notes-1.13.md"
                 },
+                {
+                  "title": "Upgrading from 1.12",
+                  "path": "/docs/releases/upgrading/upgrading-1.12.md"
+                },
+                {
+                  "title": "1.12",
+                  "path": "/docs/releases/release-notes/release-notes-1.12.md"
+                },
+
                 {
                   "title": "Upgrade 1.11 to 1.12",
                   "path": "/docs/releases/upgrading/upgrading-1.11-1.12.md"


### PR DESCRIPTION
Preview: https://deploy-preview-1799--cert-manager.netlify.app/docs/

<img width="1920" height="1098" alt="image" src="https://github.com/user-attachments/assets/babd67ea-7e36-4349-9343-3c61f76c3ca7" />


1.17 and 1.12 are no longer supported, so I've moved them to the older releases section.

- Remove top-level 1.17, 1.16 and 1.12 release and upgrade entries
- Moved them to the older releases sub-menu

Part of: https://github.com/cert-manager/cert-manager/issues/8113