### PR TITLE
Recommend reloader instead of wave, as that seems to no longer be maintained

### DIFF
--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -401,7 +401,7 @@ If your application only loads the private key and signed certificate once
 at start up, the new certificate won't immediately be served by your
 application, and you will want to either manually restart your pod with
 `kubectl rollout restart`, or automate the action by running
-[reloader](https://docs.stakater.com/reloader/). Reloader is a Secret controller that
+[Reloader](https://docs.stakater.com/reloader/). Reloader is a Secret controller that
 makes sure deployments get restarted whenever a mounted Secret changes.
 
 <div className="alert">


### PR DESCRIPTION
Recommend reloader instead of wave.

Fixes cert-manager/cert-manager#8155


❓ should I have been changing the text in the old doc versions too?


