### PR TITLE
Fix wording in rfc2136 documentation on rate limits

### DIFF
--- a/content/docs/configuration/acme/dns01/rfc2136.md
+++ b/content/docs/configuration/acme/dns01/rfc2136.md
@@ -161,11 +161,11 @@ Note how the `tsig-secret` and `tsig-secret-key` match the configuration in the
 
 ## Rate Limits
 
-The `rfc2136` provider waits until *all* nameservers to in your domain's SOA RR
+The `rfc2136` provider waits until *all* nameservers authoritative for your domain
 respond with the same result before it contacts Let's Encrypt to complete the
 challenge process. This is because the challenge server contacts a
 non-authoritative DNS server that does a recursive query (a query for records it
-does not maintain locally). If the servers in the SOA do not contain the correct
+does not maintain locally). If not all the authoritative servers contain the correct
 values, it's likely that the non-authoritative server will have bad information
 as well, causing the request to go against rate limits and eventually locking
 the process out.


### PR DESCRIPTION
Update the discussion of rate limits in the dns-01 rfc2136 documentation to refer to authoritative nameservers rather
rather than SOA records.

Closes #1822.