### PR TITLE
feat: add cert-manager-webhook-regery to docs

### DIFF
--- a/content/docs/configuration/acme/dns01/README.md
+++ b/content/docs/configuration/acme/dns01/README.md
@@ -181,6 +181,7 @@ Links to these supported providers along with their documentation are below:
 - [`cert-manager-webhook-oci`](https://gitlab.com/dn13/cert-manager-webhook-oci) (Oracle Cloud Infrastructure)
 - [`cert-manager-webhook-opentelekomcloud`](https://github.com/akyriako/cert-manager-webhook-opentelekomcloud)
 - [`cert-manager-webhook-pdns`](https://github.com/zachomedia/cert-manager-webhook-pdns)
+- [`cert-manager-webhook-regery`](https://github.com/darioackermann/cert-manager-webhook-regery)
 - [`cert-manager-webhook-scaleway`](https://github.com/scaleway/cert-manager-webhook-scaleway)
 - [`cert-manager-webhook-selectel`](https://github.com/selectel/cert-manager-webhook-selectel)
 - [`cert-manager-webhook-softlayer`](https://github.com/cgroschupp/cert-manager-webhook-softlayer)


### PR DESCRIPTION
### What does this PR do?

- It adds an url to [`cert-manager-webhook-regery`](https://github.com/darioackermann/cert-manager-webhook-regery)   that I am maintaining. 
This means that regery.com users can now use cert-manager  🎉 
- Orders the existing list alphabetically... because half of the list was the order and the other was not.. that threw me off ;)

