### PR TITLE
Migrate Helm installations to OCI

### DIFF
--- a/content/docs/configuration/acme/http01/README.md
+++ b/content/docs/configuration/acme/http01/README.md
@@ -233,7 +233,7 @@ To enable the feature in cert-manager, turn on the `GatewayAPI` feature gate:
 - If you are using Helm:
 
   ```sh
-  helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager \
+  helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager --namespace cert-manager \
     --set "extraArgs={--enable-gateway-api}"
   ```
 

--- a/content/docs/contributing/policy.md
+++ b/content/docs/contributing/policy.md
@@ -109,7 +109,7 @@ appVersion: "0.1.0"
 dependencies:
   - name: cert-manager
     version: [[VAR::cert_manager_latest_version]]
-    repository: https://charts.jetstack.io
+    repository: oci://quay.io/jetstack/charts
     alias: cert-manager
     condition: cert-manager.enabled
 ```

--- a/content/docs/installation/compatibility.md
+++ b/content/docs/installation/compatibility.md
@@ -78,7 +78,7 @@ Not ready: the cert-manager webhook CA bundle is not injected yet
 
 ```console
 helm install \
-  cert-manager jetstack/cert-manager \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --version ${CERT_MANAGER_VERSION} --set global.leaderElection.namespace=cert-manager

--- a/content/docs/installation/upgrade.md
+++ b/content/docs/installation/upgrade.md
@@ -35,12 +35,6 @@ with the name of your Helm release for cert-manager (usually this is
 `cert-manager`) and replacing `<version>` with the version number you want to
 install.
 
-Add the Jetstack Helm repository (if you haven't already) and update it.
-
-```bash
-helm repo add jetstack https://charts.jetstack.io --force-update
-```
-
 The helm upgrade command will upgrade cert-manager to the specified or latest version of cert-manager, as listed on the
 [cert-manager Helm chart documentation page](https://artifacthub.io/packages/helm/cert-manager/cert-manager).
 
@@ -52,7 +46,7 @@ If you have installed the CRDs together with the helm install command (using `--
 Helm will upgrade the CRDs automatically when you upgrade the cert-manager Helm chart:
 
 ```bash
-helm upgrade --reset-then-reuse-values --version <version> <release_name> jetstack/cert-manager
+helm upgrade --reset-then-reuse-values --version <version> <release_name> oci://quay.io/jetstack/charts/cert-manager
 ```
 
 ### CRDs managed separately
@@ -62,6 +56,28 @@ option added to your Helm install command), you should upgrade your CRD resource
 
 ```bash
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<version>/cert-manager.crds.yaml
+```
+
+And then upgrade the Helm chart:
+
+```bash
+helm upgrade --reset-then-reuse-values --version <version> <release_name> oci://quay.io/jetstack/charts/cert-manager
+```
+
+### Upgrading from the Legacy Helm Repository
+
+The Helm charts for cert-manager have historically been published to the Jetstack repository at `https://charts.jetstack.io`.
+
+This repository is still available and there are no current plans for it to change, but it is recommended to use OCI Helm charts for the latest versions of cert-manager.
+**Note that the legacy HTTP Helm repository is updated a few hours after the OCI Helm charts are published**, so you may experience a delay before new releases are available via this method.
+
+To use the legacy repository instead of the OCI registry, you need to add the Jetstack Helm repository to your local Helm client
+and use a slightly different [Helm upgrade command](https://helm.sh/docs/helm/helm_upgrade/).
+
+Add the Jetstack Helm repository (if you haven't already) and update it.
+
+```bash
+helm repo add jetstack https://charts.jetstack.io --force-update
 ```
 
 And then upgrade the Helm chart:

--- a/content/docs/policy/approval/approver-policy/installation.md
+++ b/content/docs/policy/approval/approver-policy/installation.md
@@ -39,7 +39,7 @@ will stop all issuance (as no certificate requests will be approved)!
 # ⚠️ DANGER: Only do this in a cluster if you're sure it's safe!
 
 existing_cert_manager_version=$(helm get metadata -n cert-manager cert-manager | grep '^VERSION' | awk '{ print $2 }')
-helm upgrade cert-manager jetstack/cert-manager \
+helm upgrade cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --reuse-values \
   --namespace cert-manager \
   --version $existing_cert_manager_version \
@@ -51,9 +51,7 @@ helm upgrade cert-manager jetstack/cert-manager \
 To install approver-policy:
 
 ```terminal
-helm repo add jetstack https://charts.jetstack.io --force-update
-
-helm upgrade cert-manager-approver-policy jetstack/cert-manager-approver-policy \
+helm upgrade cert-manager-approver-policy oci://quay.io/jetstack/charts/cert-manager-approver-policy \
   --install \
   --namespace cert-manager \
   --wait
@@ -70,7 +68,7 @@ For example, if using approver-policy for the internal issuer types, along with
 set the following values when installing:
 
 ```terminal
-helm upgrade cert-manager-approver-policy jetstack/cert-manager-approver-policy \
+helm upgrade cert-manager-approver-policy oci://quay.io/jetstack/charts/cert-manager-approver-policy \
   --install \
   --namespace cert-manager \
   --wait \

--- a/content/docs/troubleshooting/webhook.md
+++ b/content/docs/troubleshooting/webhook.md
@@ -463,7 +463,7 @@ listening on. Using Helm, we can use the parameter `webhook.securePort`:
 
 ```sh
 helm install \
-  cert-manager jetstack/cert-manager \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --version [[VAR::cert_manager_latest_version]] \
@@ -1080,7 +1080,8 @@ resources in the `kube-system` namespace, and cert-manager uses the well-known
 can tell Helm to use a different namespace for the leader election:
 
 ```sh
-helm install cert-manager jetstack/cert-manager --version 1.8.0 \
+helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --version [[VAR::cert_manager_latest_version]] \
   --namespace cert-manager --create-namespace \
   --set global.leaderElection.namespace=cert-manager
 ```

--- a/content/docs/trust/trust-manager/README.md
+++ b/content/docs/trust/trust-manager/README.md
@@ -192,15 +192,13 @@ Next, we need to install trust-manager. You can follow the [installation guide](
 or use the commands below:
 
 ```bash
-helm repo add jetstack https://charts.jetstack.io --force-update
-
-helm install cert-manager jetstack/cert-manager \
+helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --version [[VAR::cert_manager_latest_version]] \
   --set crds.enabled=true
 
-helm upgrade trust-manager jetstack/trust-manager \
+helm upgrade trust-manager oci://quay.io/jetstack/charts/trust-manager \
   --install \
   --namespace cert-manager \
   --wait
@@ -382,7 +380,7 @@ TRUST_MANAGER_VER=$(helm list --filter "^trust-manager$" -n cert-manager -ojson 
 echo $TRUST_MANAGER_VER
 
 # Run the upgrade
-helm upgrade -f values.yaml -n cert-manager trust-manager jetstack/trust-manager --version $TRUST_MANAGER_VER
+helm upgrade -f values.yaml -n cert-manager trust-manager oci://quay.io/jetstack/charts/trust-manager --version $TRUST_MANAGER_VER
 ```
 
 If an incorrect tag is used, your deployment will fail and you'll likely need to use `helm rollback` to get back

--- a/content/docs/trust/trust-manager/installation.md
+++ b/content/docs/trust/trust-manager/installation.md
@@ -10,10 +10,6 @@ description: 'Installation guide for trust-manager'
 Helm is the easiest way to install trust-manager and comes with a publicly trusted certificate bundle package
 (for the`useDefaultCAs` source) derived from Debian containers.
 
-```bash
-helm repo add jetstack https://charts.jetstack.io --force-update
-```
-
 ### 2. Install cert-manager (optional)
 
 When installed via Helm, trust-manager has a dependency on cert-manager for provisioning an application certificate
@@ -25,7 +21,7 @@ If you haven't already installed cert-manager, you can install it using the foll
 
 ```bash
 # Run this command only if you haven't installed cert-manager already
-helm install cert-manager jetstack/cert-manager \
+helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --version [[VAR::cert_manager_latest_version]] \
@@ -42,7 +38,7 @@ If you don't want to rely on cert-manager, you can install using a Helm-generate
 trust-manager is simple to install and is contained in a single Helm chart:
 
 ```bash
-helm upgrade trust-manager jetstack/trust-manager \
+helm upgrade trust-manager oci://quay.io/jetstack/charts/trust-manager \
   --install \
   --namespace cert-manager \
   --wait
@@ -72,7 +68,7 @@ As of trust-manager v0.6.0 you can choose to automatically add an approver-polic
 will approve the trust-manager webhook certificate:
 
 ```bash
-helm upgrade trust-manager jetstack/trust-manager \
+helm upgrade trust-manager oci://quay.io/jetstack/charts/trust-manager \
   --install \
   --namespace cert-manager \
   --wait \
@@ -111,7 +107,7 @@ Installing without cert-manager can be great for smaller, more resource-constrai
 Using a Helm-generated cert requires a single flag:
 
 ```bash
-helm upgrade trust-manager jetstack/trust-manager \
+helm upgrade trust-manager oci://quay.io/jetstack/charts/trust-manager \
   --install \
   --namespace cert-manager \
   --wait \

--- a/content/docs/tutorials/acme/migrating-from-kube-lego.md
+++ b/content/docs/tutorials/acme/migrating-from-kube-lego.md
@@ -195,7 +195,7 @@ upgrade` in order to add a few additional flags. Assuming you've named your
 
 ```bash
 $ helm upgrade cert-manager \
-     jetstack/cert-manager \
+     oci://quay.io/jetstack/charts/cert-manager \
      --namespace cert-manager \
      --set ingressShim.defaultIssuerName=letsencrypt-staging \
      --set ingressShim.defaultIssuerKind=ClusterIssuer

--- a/content/docs/tutorials/certificate-defaults/README.md
+++ b/content/docs/tutorials/certificate-defaults/README.md
@@ -99,13 +99,12 @@ Once you have your cluster environment, install the required Kubernetes packages
 1. Install cert-manager
 
     ```shell
-    helm upgrade --install cert-manager cert-manager \
+    helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
       --namespace cert-manager \
       --version $CERT_MANAGER_CHART_VERSION \
       --set crds.enabled=true \
       --set startupapicheck.enabled=false \
-      --create-namespace \
-      --repo https://charts.jetstack.io/
+      --create-namespace
     ```
 
 1. Install Kyverno

--- a/content/docs/tutorials/getting-started-aks-letsencrypt/README.md
+++ b/content/docs/tutorials/getting-started-aks-letsencrypt/README.md
@@ -152,9 +152,8 @@ Now you can install and configure cert-manager.
 Install cert-manager using `helm` as follows:
 
 ```bash
-helm repo add jetstack https://charts.jetstack.io --force-update
 helm install \
-  cert-manager jetstack/cert-manager \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --version [[VAR::cert_manager_latest_version]] \
@@ -396,7 +395,7 @@ The labels can be configured using the Helm values file below:
 
 ```bash
 existing_cert_manager_version=$(helm get metadata -n cert-manager cert-manager | grep '^VERSION' | awk '{ print $2 }')
-helm upgrade cert-manager jetstack/cert-manager \
+helm upgrade cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --reuse-values \
   --namespace cert-manager \
   --version $existing_cert_manager_version \

--- a/content/docs/tutorials/getting-started-aws-letsencrypt/README.md
+++ b/content/docs/tutorials/getting-started-aws-letsencrypt/README.md
@@ -162,8 +162,7 @@ Now you can install and configure cert-manager.
 Install cert-manager using `helm` as follows:
 
 ```bash
-helm install cert-manager cert-manager \
-  --repo https://charts.jetstack.io \
+helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --set crds.enabled=true

--- a/content/docs/tutorials/zerossl/zerossl.md
+++ b/content/docs/tutorials/zerossl/zerossl.md
@@ -47,7 +47,7 @@ crds:
 
 Install it using helm:
 ```
-helm upgrade  --install --namespace cert-manager  --version [[VAR::cert_manager_latest_version]] cert-manager jetstack/cert-manager -f values.yaml 
+helm upgrade  --install --namespace cert-manager  --version [[VAR::cert_manager_latest_version]] cert-manager oci://quay.io/jetstack/charts/cert-manager -f values.yaml 
 ```
 
 ## Configure your DNS records

--- a/content/docs/usage/csi-driver-spiffe/README.md
+++ b/content/docs/usage/csi-driver-spiffe/README.md
@@ -214,7 +214,7 @@ The following example mounts the CA certificate used by the Trust Domain
 ClusterIssuer.
 
 ```terminal
-helm upgrade -i -n cert-manager cert-manager-csi-driver-spiffe jetstack/cert-manager-csi-driver-spiffe --wait \
+helm upgrade -i -n cert-manager cert-manager-csi-driver-spiffe oci://quay.io/jetstack/charts/cert-manager-csi-driver-spiffe --wait \
   --set "app.logLevel=1" \
   --set "app.trustDomain=my.trust.domain" \
   \

--- a/content/docs/usage/csi-driver-spiffe/installation.md
+++ b/content/docs/usage/csi-driver-spiffe/installation.md
@@ -24,7 +24,7 @@ Here's a example which reconfigure an installed cert-manager (v1.15.0+) to run w
 # ⚠️ This Helm option is only available in cert-manager v1.15.0 and later.
 
 existing_cert_manager_version=$(helm get metadata -n cert-manager cert-manager | grep '^VERSION' | awk '{ print $2 }')
-helm upgrade cert-manager jetstack/cert-manager \
+helm upgrade cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --reuse-values \
   --namespace cert-manager \
   --version $existing_cert_manager_version \
@@ -89,7 +89,7 @@ kubectl create configmap -n cert-manager spiffe-issuer \
 ```
 
 ```bash
-helm upgrade -i -n cert-manager cert-manager-csi-driver-spiffe jetstack/cert-manager-csi-driver-spiffe --wait \
+helm upgrade -i -n cert-manager cert-manager-csi-driver-spiffe oci://quay.io/jetstack/charts/cert-manager-csi-driver-spiffe --wait \
  --set "app.logLevel=1" \
  --set "app.trustDomain=my.trust.domain" \
  --set "app.issuer.name=" \
@@ -110,9 +110,7 @@ Note that the `issuer.name`, `issuer.kind` and `issuer.group` will need to be ch
 the issuer you're actually using!
 
 ```bash
-helm repo add jetstack https://charts.jetstack.io --force-update
-
-helm upgrade cert-manager-csi-driver-spiffe jetstack/cert-manager-csi-driver-spiffe \
+helm upgrade cert-manager-csi-driver-spiffe oci://quay.io/jetstack/charts/cert-manager-csi-driver-spiffe \
   --install \
   --namespace cert-manager \
   --wait \

--- a/content/docs/usage/csi-driver/installation.md
+++ b/content/docs/usage/csi-driver/installation.md
@@ -12,9 +12,7 @@ Instructions on how to install cert-manager can be found [on this website](../..
 To install csi-driver, use helm:
 
 ```terminal
-helm repo add jetstack https://charts.jetstack.io --force-update
-
-helm upgrade cert-manager-csi-driver jetstack/cert-manager-csi-driver \
+helm upgrade cert-manager-csi-driver oci://quay.io/jetstack/charts/cert-manager-csi-driver \
   --install \
   --namespace cert-manager \
   --wait

--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -71,7 +71,7 @@ config:
 The corresponding Helm command is:
 
 ```sh
-helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager \
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager --namespace cert-manager \
   --set config.apiVersion="controller.config.cert-manager.io/v1alpha1" \
   --set config.kind="ControllerConfiguration" \
   --set config.enableGatewayAPI=true

--- a/content/docs/usage/istio-csr/installation.md
+++ b/content/docs/usage/istio-csr/installation.md
@@ -67,11 +67,9 @@ We install cert-manager [using helm](https://cert-manager.io/docs/installation/h
 kind create cluster
 
 # Helm setup
-helm repo add jetstack https://charts.jetstack.io --force-update
-
 # install cert-manager; this might take a little time
 helm install \
-  cert-manager jetstack/cert-manager \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --version [[VAR::cert_manager_latest_version]] \
@@ -117,10 +115,8 @@ istio-csr is best installed via Helm, and it should be simple and quick to insta
 are a bunch of other configuration options for the helm chart, which you can check out [here](../../usage/istio-csr/README.md).
 
 ```console
-helm repo add jetstack https://charts.jetstack.io --force-update
-
 # We set a few helm template values so we can point at our static root CA
-helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
+helm upgrade cert-manager-istio-csr oci://quay.io/jetstack/charts/cert-manager-istio-csr \
   --install \
   --namespace cert-manager \
   --wait \
@@ -341,7 +337,7 @@ app:
 If cert-manager is already installed, you can use the same `helm upgrade` command as above but also specifying the name of the runtime configuration ConfigMap:
 
 ```bash
-helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
+helm upgrade cert-manager-istio-csr oci://quay.io/jetstack/charts/cert-manager-istio-csr \
   --install \
   --namespace cert-manager \
   --wait \
@@ -388,7 +384,7 @@ volumes:
 This file could then be used with the following command:
 
 ```bash
-helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
+helm upgrade cert-manager-istio-csr oci://quay.io/jetstack/charts/cert-manager-istio-csr \
   --install \
   --namespace cert-manager \
   --wait \

--- a/content/docs/usage/kube-csr.md
+++ b/content/docs/usage/kube-csr.md
@@ -43,7 +43,7 @@ Which can be added using Helm:
 
 ```bash
 $ helm install \
-  cert-manager jetstack/cert-manager \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --set featureGates="ExperimentalCertificateSigningRequestControllers=true" \


### PR DESCRIPTION
This PR migrates all (remaining) Helm installation/upgrade docs to use the OCI chart repositories.

Relates to https://github.com/cert-manager/community/issues/43: To provide non-CyberArk employee maintainers full release capabilities, we have decided to migrate our official Helm installation method to the OCI chart repositories.

After this is merged, I will create additional PRs to update the release process documentation as agreed in our weekly development meeting.

