### PR TITLE
Migrate Flux installation to OCI Helm chart

### DIFF
--- a/content/docs/installation/continuous-deployment-and-gitops.md
+++ b/content/docs/installation/continuous-deployment-and-gitops.md
@@ -51,7 +51,7 @@ flux check
 ### Create a `HelmRepository` resource
 
 ```bash
-flux create source helm cert-manager --url https://charts.jetstack.io
+flux create source helm cert-manager --url oci://quay.io/jetstack/charts
 ```
 
 ### Create a `HelmRelease` resource


### PR DESCRIPTION
This is a leftover after https://github.com/cert-manager/website/pull/1842. I left this out because I wanted to use the Flux `OCIRepository` source resource instead of the more traditional `HelmRepository`. But it seems like the flux CLI doesn't currently support creating Helm `OCIRepository` resources as described in https://fluxcd.io/flux/components/helm/helmreleases/#recommended-settings.