### PR TITLE
Remove the scarf.sh tracking pixel

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -22,5 +22,3 @@ the private key never leaves the node and it is not stored in a Kubernetes Secre
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e661e870-758f-4c78-ac4a-0bad64a05471" />

--- a/content/v1.0-docs/README.md
+++ b/content/v1.0-docs/README.md
@@ -22,5 +22,3 @@ wisdom from other similar projects such as
 
 This is the full technical documentation for the project, and should be
 used as a source of references when seeking help with the project.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.1-docs/README.md
+++ b/content/v1.1-docs/README.md
@@ -22,5 +22,3 @@ wisdom from other similar projects such as
 
 This is the full technical documentation for the project, and should be
 used as a source of references when seeking help with the project.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.10-docs/README.md
+++ b/content/v1.10-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=41b274ef-c8eb-4895-9b6c-8b1080cc02b9" />

--- a/content/v1.11-docs/README.md
+++ b/content/v1.11-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=4d041ea7-4124-4be2-8ba5-f4496092308a" />

--- a/content/v1.12-docs/README.md
+++ b/content/v1.12-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=80c9ac98-1f17-47ef-9f4e-b55e2471892c" />

--- a/content/v1.13-docs/README.md
+++ b/content/v1.13-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=9b0370fb-3b85-44ce-8452-7ffc031e109f" />

--- a/content/v1.14-docs/README.md
+++ b/content/v1.14-docs/README.md
@@ -22,5 +22,3 @@ the private key never leaves the node and it is not stored in a Kubernetes Secre
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=3d7ab28a-5e59-4640-87ac-afa184b8c9dc" />

--- a/content/v1.15-docs/README.md
+++ b/content/v1.15-docs/README.md
@@ -22,5 +22,3 @@ the private key never leaves the node and it is not stored in a Kubernetes Secre
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8139d670-4d96-4721-a830-a9379240ab5b" />

--- a/content/v1.16-docs/README.md
+++ b/content/v1.16-docs/README.md
@@ -22,5 +22,3 @@ the private key never leaves the node and it is not stored in a Kubernetes Secre
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8139d670-4d96-4721-a830-a9379240ab5://static.scarf.sh/a.png?x-pxid=d34ce504-8436-48ce-9ad2-0d7bd48508a8" />

--- a/content/v1.17-docs/README.md
+++ b/content/v1.17-docs/README.md
@@ -22,5 +22,3 @@ the private key never leaves the node and it is not stored in a Kubernetes Secre
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e661e870-758f-4c78-ac4a-0bad64a05471" />

--- a/content/v1.18-docs/README.md
+++ b/content/v1.18-docs/README.md
@@ -22,5 +22,3 @@ the private key never leaves the node and it is not stored in a Kubernetes Secre
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e661e870-758f-4c78-ac4a-0bad64a05471" />

--- a/content/v1.2-docs/README.md
+++ b/content/v1.2-docs/README.md
@@ -22,5 +22,3 @@ wisdom from other similar projects such as
 
 This is the full technical documentation for the project, and should be
 used as a source of references when seeking help with the project.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.3-docs/README.md
+++ b/content/v1.3-docs/README.md
@@ -22,5 +22,3 @@ wisdom from other similar projects such as
 
 This is the full technical documentation for the project, and should be
 used as a source of references when seeking help with the project.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.4-docs/README.md
+++ b/content/v1.4-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.5-docs/README.md
+++ b/content/v1.5-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.6-docs/README.md
+++ b/content/v1.6-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.7-docs/README.md
+++ b/content/v1.7-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.8-docs/README.md
+++ b/content/v1.8-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=c8fe7fac-8d4f-475e-a75d-ef755d9c9ad6" />

--- a/content/v1.9-docs/README.md
+++ b/content/v1.9-docs/README.md
@@ -24,5 +24,3 @@ wisdom from other similar projects such as
 This website provides the full technical documentation for the project, and can be
 used as a reference; if you feel that there's anything missing, please let us know
 or [raise a PR](https://github.com/cert-manager/website/pulls) to add it.
-
-<img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=66883fe0-02bf-4985-83d1-bb5cda552ae5" />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -49,7 +49,6 @@ class MyDocument extends Document {
               }}
               />
           </>
-          <img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=629c2750-768c-491d-be17-38a92ddaa0ff" />
         </body>
       </Html>
     )

--- a/pages/support.jsx
+++ b/pages/support.jsx
@@ -43,7 +43,6 @@ function Support({ router }) {
         </div>
       </div>
     </div>
-    <img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=34e46cb4-8956-48fc-a9a2-a8d634b8968c" />
   </>;
 }
 


### PR DESCRIPTION
As far as I know scarf.sh is not used any more. 

* https://github.com/cert-manager/website/pull/1451
* https://github.com/cert-manager/website/pull/1628
* https://github.com/cert-manager/website/pull/1650

CyberArk tracker: [VC-47736](https://venafi.atlassian.net/browse/VC-47736) <!-- do not edit this line, will be re-added automatically -->