### PR TITLE
Release notes for cert-manager v1.18.4

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -202,6 +202,22 @@ And finally, thanks to the cert-manager steering committee for their feedback in
 - [@TrilokGeer](https://github.com/TrilokGeer)
 
 
+## `v1.18.4`
+
+We updated Go to fix some vulnerabilities in the Go standard library.
+
+Changes since `v1.18.3`:
+
+### Bug or Regression
+
+- Address false positive vulnerabilities `CVE-2025-47914` and `CVE-2025-58181` which were reported by Trivy. ([`#8282`](https://github.com/cert-manager/cert-manager/pull/8282), [`@SgtCoDFish`](https://github.com/SgtCoDFish))
+- Update Go to `v1.24.11` to fix `CVE-2025-61727` and `CVE-2025-61729` ([`#8295`](https://github.com/cert-manager/cert-manager/pull/8295), [`@wallrj-cyberark`](https://github.com/wallrj-cyberark))
+
+### Other (Cleanup or Flake)
+
+- Update cert-manager's ACME client, forked from `golang/x/crypto` ([`#8271`](https://github.com/cert-manager/cert-manager/pull/8271), [`@SgtCoDFish`](https://github.com/SgtCoDFish))
+- Updated Debian 12 distroless base images ([`#8328`](https://github.com/cert-manager/cert-manager/pull/8328), [`@wallrj-cyberark`](https://github.com/wallrj-cyberark))
+
 ## `v1.18.3`
 
 We fixed a bug which caused certificates to be re-issued unexpectedly, if the

--- a/content/v1.18-docs/variables.json
+++ b/content/v1.18-docs/variables.json
@@ -1,3 +1,3 @@
 {
-  "cert_manager_latest_version": "v1.18.3"
+  "cert_manager_latest_version": "v1.18.4"
 }


### PR DESCRIPTION
**Preview**: 
 * https://deploy-preview-1880--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.18#v1184
 * https://deploy-preview-1880--cert-manager.netlify.app/v1.18-docs/installation/


xref: https://github.com/cert-manager/cert-manager/issues/8327
 * https://github.com/cert-manager/cert-manager/issues/8327

CyberArk tracker: [VC-47734](https://venafi.atlassian.net/browse/VC-47734) <!-- do not edit this line, will be re-added automatically -->