### PR TITLE
docs(gateway):  fix dnsNames in gateway listener selection example

### DIFF
--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -253,7 +253,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
   dnsNames:
-    - foo.example.com
+    - bar.example.com
   secretName: example-com-tls
 ```
 


### PR DESCRIPTION
The example showed the wrong dnsName (foo.example.com) instead of the right bar.example.com taken from the fifth listener