### PR TITLE
docs: remove outdated instruction

### DIFF
--- a/content/docs/tutorials/getting-started-aks-letsencrypt/README.md
+++ b/content/docs/tutorials/getting-started-aks-letsencrypt/README.md
@@ -334,7 +334,7 @@ Now you will learn how to configure cert-manager to use Let's Encrypt and Azure 
 You need to prove to Let's Encrypt that you own the domain name of the certificate and one way to do this is to create a special DNS record in that domain.
 This is known as the [DNS-01 challenge type](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
 
-cert-manager can create that DNS record for you in by using the Azure DNS API but it needs to authenticate to Azure first,
+cert-manager can create that DNS record for you by using the Azure DNS API but it needs to authenticate to Azure first,
 and currently the most secure method of authentication is to use [workload identity federation](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview).
 The advantages of this method are that cert-manager will use an ephemeral Kubernetes ServiceAccount Token to authenticate to Azure and the token need not be stored in a Kubernetes Secret.
 


### PR DESCRIPTION
- Basic SKU is [no longer supported as of September 30, 2025](https://azure.microsoft.com/en-gb/updates?id=azure-basic-load-balancer-will-be-retired-on-30-september-2025-upgrade-to-standard-load-balancer).  
- Azure workload identity is in GA: https://github.com/Azure/AKS/issues/1480#event-14871842173. Hence, `aks-preview` is no longer required.