### PR TITLE
docs: sync info card for Gateway API support

### DIFF
--- a/content/docs/configuration/acme/http01/README.md
+++ b/content/docs/configuration/acme/http01/README.md
@@ -232,7 +232,7 @@ Since cert-manager 1.15, the Gateway API support is no longer gated behind a
 feature flag, but you still need to enable the Gateway API support.
 
 To enable the Gateway API support, use the [file-based
-configuration](../../installation/configuring-components.md#configuration-file) using the
+configuration](../../../installation/configuring-components.md#configuration-file) using the
 following `config` Helm value:
 
 ```yaml


### PR DESCRIPTION
The content is outdated, so sync the instruction with the following:
https://github.com/cert-manager/website/blob/63e8e16a349c9550239060023ba2f92c4d9834c2/content/docs/usage/gateway.md?plain=1#L52-L96