### PR TITLE
Fix/update upcoming release entry for 1.20

### DIFF
--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -28,7 +28,7 @@ should be stable enough to run.
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
-| [1.20][] | Feb 10, 2026 | Release of 1.21 | 1.31 → 1.34 / 4.18 → 4.20                      | 1.31 → 1.34                        |
+| [1.20][] | Feb 10, 2026 | Release of 1.22 | 1.32 → 1.35 / 4.19 → 4.21                      | 1.32 → 1.35                        |
 
 Dates in the future are not firm commitments and are subject to change.
 


### PR DESCRIPTION
While linking to our upcoming releases in a cert-manager issue, I noticed it was a bit outdated. Kubernetes 1.31 is already EOL with the release of 1.35. And we usually support two releases of cert-manager.