### PR TITLE
[VC-48226]: document default NetworkPolicy and example values

### DIFF
--- a/content/docs/installation/best-practice.md
+++ b/content/docs/installation/best-practice.md
@@ -47,6 +47,44 @@ Or you may prefer to use the custom resources provided by your CNI software.
 > 📖 Learn about the [Kubernetes builtin NetworkPolicy API](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 > and see [some example policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-policies).
 
+The cert-manager Helm chart allows you to create a `NetworkPolicy` resource for
+each `Deployment`.
+
+By default, it allows inbound traffic to all the listening ports of each component.
+And by default, it allows outbound traffic to:
+- TCP port 443: For connections to the Kubernetes API server and other
+  in-cluster and external HTTPS API servers.
+- TCP port 6443: For connections to the Kubernetes API server on OpenShift.
+- TCP and UDP port 53: To resolve DNS names using the in-cluster DNS and
+  external DNS servers when using DNS01.
+- TCP port 80: So that the controller can perform ACME HTTP01 self-checks before
+  accepting the ACME server challenge.
+
+These are over-permissive defaults to provide a good installation experience.
+
+You should customize the `ingress` and `egress` rules to restrict the inbound
+and outbound traffic to allow only those connections which are necessary for
+your cert-manager configuration.
+
+Example Helm values:
+
+```yaml
+# helm-values.yaml
+networkPolicy:
+  enabled: true
+
+webhook:
+  networkPolicy:
+    enabled: true
+
+cainjector:
+  networkPolicy:
+    enabled: true
+```
+
+There are examples of extended egress rules in the example Helm chart values
+file at the end of this document.
+
 ### Network Requirements
 
 Here is an overview of the network requirements:

--- a/content/docs/releases/release-notes/release-notes-1.20.md
+++ b/content/docs/releases/release-notes/release-notes-1.20.md
@@ -12,6 +12,14 @@ Be sure to review all new features and changes below, and read the full release 
 
 ## Major Themes
 
+### Network Policy
+
+The cert-manager Helm chart now allows you to create `NetworkPolicy` resources
+for all the cert-manager Deployments.
+This makes it easier to follow [best practices when deploying cert-manager in production](../../installation/best-practice.md#network-requirements-and-network-policy).
+
+### TODO ADD REMAINING THEMES
+
 TODO
 
 ## Community

--- a/public/docs/installation/best-practice/values.best-practice.yaml
+++ b/public/docs/installation/best-practice/values.best-practice.yaml
@@ -38,6 +38,63 @@ volumeMounts:
   name: serviceaccount-token
   readOnly: true
 
+# Enable the default network policy for cert-manager controller
+networkPolicy:
+  enabled: true
+  egress:
+
+  # Required: Kubernetes API requests.
+  # Use port 6443 on OpenShift clusters.
+  - ports:
+    - port: 443
+      protocol: TCP
+
+  # Required: DNS look ups.
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+
+  # Some example egress rules designed to allow cert-manager E2E tests to run
+  # with Network policies enabled. In production you should edit or remove these
+  # to match your requirements.
+
+  # Example: Allow access to the HTTP01 solver pod for ACME HTTP01 self-checks
+  # Only needed if your cluster users use the ACME issuer with HTTP01
+  - ports:
+    - port: 80
+      protocol: TCP
+
+  # Example: In-cluster DNS (Bind) server used by the ACME issuer with DNS01
+  - ports:
+    - port: 8053
+      protocol: UDP
+    - port: 8053
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: bind
+
+  # Example: In-cluster ACME server used by the ACME issuer
+  - ports:
+    - port: 14000
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: pebble
+
+  # Example: In-cluster Vault servers used by the Vault issuer
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: e2e-vault
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: e2e-vault-mtls
+
 webhook:
   replicaCount: 3
   podDisruptionBudget:
@@ -69,6 +126,10 @@ webhook:
   - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
     name: serviceaccount-token
     readOnly: true
+
+  # Enable the default network policy for cert-manager webhook
+  networkPolicy:
+    enabled: true
 
 cainjector:
   extraArgs:
@@ -104,6 +165,10 @@ cainjector:
   - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
     name: serviceaccount-token
     readOnly: true
+
+  # Enable the default network policy for cert-manager cainjector
+  networkPolicy:
+    enabled: true
 
 startupapicheck:
   automountServiceAccountToken: false


### PR DESCRIPTION
**Preview**: 
 * https://deploy-preview-1911--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.20#network-policy
 * https://deploy-preview-1911--cert-manager.netlify.app/docs/installation/best-practice/#network-requirements-and-network-policy

Documentation to accompany @jcpunk 's https://github.com/cert-manager/cert-manager/pull/8370
 * https://github.com/cert-manager/cert-manager/pull/8370
 
## Changes
- Document default NetworkPolicy behavior and recommend restricting rules
- Add example Helm values for enabling networkPolicy per component
- Update public best-practice YAML to enable networkPolicy keys

## Slack Discussion
 * https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1768585788050239

## Testing

I tested the sample Helm values by using them in the best-practice E2E tests in:
 * https://github.com/cert-manager/cert-manager/pull/8387