### PR TITLE
Update supported releases to reflect changes for c-m 1.19

### DIFF
--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -21,7 +21,7 @@ should be stable enough to run.
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
-| [1.19][] | Oct 07, 2025 | Release of 1.21 | 1.31 → 1.34 / 4.18 → 4.20                      | 1.31 → 1.34                        |
+| [1.19][] | Oct 07, 2025 | Release of 1.21 | 1.31 → 1.35 / 4.18 → 4.20                      | 1.31 → 1.35                        |
 | [1.18][] | Jun 10, 2025 | Release of 1.20 | 1.29 → 1.33 / 4.16 → 4.20                      | 1.29 → 1.33                        |
 
 ## Upcoming releases


### PR DESCRIPTION
https://github.com/cert-manager/testing/pull/1138 adds testing for k8s 1.35 with cert-manager 1.19

(This PR should only merge after that one)