### PR TITLE
update cert-manager 1.20 release date from Feb 10 to Feb 24, 2026

### DIFF
--- a/content/announcements/2025-11-26-ingress-nginx-eol-and-gateway-api.md
+++ b/content/announcements/2025-11-26-ingress-nginx-eol-and-gateway-api.md
@@ -19,7 +19,7 @@ with certificates configured on cluster-operator-owned Gateways.
 
 The missing piece is Gateway API's experimental XListenerSet resource, which
 aims to restore per-team TLS configuration on a shared Gateway. cert-manager
-plans to add experimental XListenerSet support in 1.20, targeted for 10 February
+plans to add experimental XListenerSet support in 1.20, targeted for 24 February
 2026, with alpha builds in January 2026.
 
 [the announcement]: https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/
@@ -150,7 +150,7 @@ which act as the default issuer.
 
 - **January 2026:** Alpha builds with XListenerSet support. We will need your
   help to test it out!
-- **10 February 2026:** cert-manager 1.20 is expected to include XListenerSet
+- **24 February 2026:** cert-manager 1.20 is expected to include XListenerSet
   support as an experimental feature gated behind a feature flag.
 
 As Gateway API graduates ListenerSet to stable, we'll add support for the stable

--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -28,7 +28,7 @@ should be stable enough to run.
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
-| [1.20][] | Feb 10, 2026 | Release of 1.22 | 1.32 → 1.35 / 4.19 → 4.21                      | 1.32 → 1.35                        |
+| [1.20][] | Feb 24, 2026 | Release of 1.22 | 1.32 → 1.35 / 4.19 → 4.21                      | 1.32 → 1.35                        |
 
 Dates in the future are not firm commitments and are subject to change.
 


### PR DESCRIPTION
We decided to bump the date to give us a bit more time to do an alpha and test the XListenerSet changes.