### PR TITLE
docs(policy,approval,approver-policy): add username and groups to fields exposed to CEL validations

### DIFF
--- a/content/docs/policy/approval/approver-policy/README.md
+++ b/content/docs/policy/approval/approver-policy/README.md
@@ -214,7 +214,7 @@ The request attribute value is made available to the expression in the `self` va
 For multi-valued request attributes, the validation will be performed once per value.
 Similarly to the `self` variable, approver-policy provides the `cr` variable representing
 the request to validate. This variable is of object type, and at time of writing it has
-just two fields: `namespace` and `name`.
+four fields: `username`, `groups`, `namespace` and `name`.
 
 In the following, we use approver-policy CEL validation rules to ensure
 [X.509 SVID certificates](https://github.com/spiffe/spiffe/blob/890b9266095d37bad189529367f31de9be2504b6/standards/X509-SVID.md)

--- a/content/docs/policy/approval/approver-policy/api-reference.md
+++ b/content/docs/policy/approval/approver-policy/api-reference.md
@@ -465,8 +465,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -566,8 +566,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -667,8 +667,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -768,8 +768,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -959,8 +959,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -1060,8 +1060,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -1162,8 +1162,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -1264,8 +1264,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -1365,8 +1365,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -1466,8 +1466,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -1569,8 +1569,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -1671,8 +1671,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```
@@ -1772,8 +1772,8 @@ ref: https://github.com/google/cel-spec
 The Rule is scoped to the location of the validations in the schema.
 The `self` variable in the CEL expression is bound to the scoped value.
 To enable more advanced validation rules, approver-policy provides the
-`cr` (map) variable to the CEL expression containing `namespace` and
-`name` of the `CertificateRequest` resource.
+`cr` (map) variable to the CEL expression containing `username`, `groups`,
+`namespace` and `name` of the `CertificateRequest` resource.
 
 Example (rule for namespaced DNSNames):
 ```


### PR DESCRIPTION
username added through https://github.com/cert-manager/approver-policy/pull/514

groups added through https://github.com/cert-manager/approver-policy/pull/799

closes https://github.com/cert-manager/website/issues/1947