### PR TITLE
fix(docs): correct spelling of constraints in approver-policy documentation

### DIFF
--- a/content/docs/policy/approval/approver-policy/README.md
+++ b/content/docs/policy/approval/approver-policy/README.md
@@ -92,7 +92,7 @@ subjects:
 
 ## Behavior
 
-CertificateRequestPolicy are split into 4 parts; `allowed`, `contraints`,
+CertificateRequestPolicy are split into 4 parts; `allowed`, `constraints`,
 `selector`, and `plugins`.
 
 ### Allowed

--- a/content/v1.11-docs/projects/approver-policy.md
+++ b/content/v1.11-docs/projects/approver-policy.md
@@ -128,7 +128,7 @@ subjects:
 
 ## Behavior
 
-CertificateRequestPolicy are split into 4 parts; `allowed`, `contraints`,
+CertificateRequestPolicy are split into 4 parts; `allowed`, `constraints`,
 `selector`, and `plugins`.
 
 ### Allowed

--- a/content/v1.14-docs/policy/approval/approver-policy/README.md
+++ b/content/v1.14-docs/policy/approval/approver-policy/README.md
@@ -92,7 +92,7 @@ subjects:
 
 ## Behavior
 
-CertificateRequestPolicy are split into 4 parts; `allowed`, `contraints`,
+CertificateRequestPolicy are split into 4 parts; `allowed`, `constraints`,
 `selector`, and `plugins`.
 
 ### Allowed

--- a/content/v1.15-docs/policy/approval/approver-policy/README.md
+++ b/content/v1.15-docs/policy/approval/approver-policy/README.md
@@ -92,7 +92,7 @@ subjects:
 
 ## Behavior
 
-CertificateRequestPolicy are split into 4 parts; `allowed`, `contraints`,
+CertificateRequestPolicy are split into 4 parts; `allowed`, `constraints`,
 `selector`, and `plugins`.
 
 ### Allowed

--- a/content/v1.16-docs/policy/approval/approver-policy/README.md
+++ b/content/v1.16-docs/policy/approval/approver-policy/README.md
@@ -92,7 +92,7 @@ subjects:
 
 ## Behavior
 
-CertificateRequestPolicy are split into 4 parts; `allowed`, `contraints`,
+CertificateRequestPolicy are split into 4 parts; `allowed`, `constraints`,
 `selector`, and `plugins`.
 
 ### Allowed

--- a/content/v1.17-docs/policy/approval/approver-policy/README.md
+++ b/content/v1.17-docs/policy/approval/approver-policy/README.md
@@ -92,7 +92,7 @@ subjects:
 
 ## Behavior
 
-CertificateRequestPolicy are split into 4 parts; `allowed`, `contraints`,
+CertificateRequestPolicy are split into 4 parts; `allowed`, `constraints`,
 `selector`, and `plugins`.
 
 ### Allowed

--- a/content/v1.18-docs/policy/approval/approver-policy/README.md
+++ b/content/v1.18-docs/policy/approval/approver-policy/README.md
@@ -92,7 +92,7 @@ subjects:
 
 ## Behavior
 
-CertificateRequestPolicy are split into 4 parts; `allowed`, `contraints`,
+CertificateRequestPolicy are split into 4 parts; `allowed`, `constraints`,
 `selector`, and `plugins`.
 
 ### Allowed


### PR DESCRIPTION
## What this PR does

Fixes a typo in the approver-policy documentation where "contraints" was misspelled. The correct spelling is "constraints".

## Changes

- Fixed the typo across all versioned docs (v1.11, v1.14, v1.15, v1.16, v1.17, v1.18) and current docs