### PR TITLE
v1.20.1: version bumps

### DIFF
--- a/content/docs/variables.json
+++ b/content/docs/variables.json
@@ -1,3 +1,3 @@
 {
-  "cert_manager_latest_version": "v1.20.0"
+  "cert_manager_latest_version": "v1.20.1"
 }


### PR DESCRIPTION
Commands I ran:

```
./scripts/gendocs/generate
```

(no changes)

## Instructions followed

> 
> (**final + patch releases**) Prepare the "Version Bumps" PR:
> 
> **⚠️ This step can be done ahead of time.**
> 
> Create a PR on the website titled something like "Bump versions".
> 
> -   If you are doing a **final release**, then this PR's base must be the `release-next` branch.
> -   If you are doing a **patch release**, then this PR's base must be `master`.
> 
> In this PR:
> 
> 1.  Update the CRD and CLI docs with the following instructions:
> 
>     Imagining that you are about to release v1.20.0, edit `scripts/gendocs/generate-new-import-path-docs` to change `CM_BRANCH` and `DOCS_FOLDER` to:
> 
>     ```
>     CM_BRANCH="release-1.20"
>     DOCS_FOLDER="docs"
> 
>     ```
> 
>     Then, run:
> 
>     ```
>     ./scripts/gendocs/generate
> 
>     ```
> 
> 2.  (**final + patch release of the latest minor version**) Bump the latest cert-manager version variable in the `content/docs/variables.json` file. For example, if you are releasing v1.20.0:
> 
>     ```
>     {"cert_manager_latest_version": "v1.20.0"}
> 
>     ```
> 
> 3.  (**final release**) Edit `content/docs/releases/README.md` and:
> 
>     -   update the section "Supported releases",
>     -   update the section "How we determine supported Kubernetes versions".