### PR TITLE
Remove Google Domains from the GKE getting started tutorial

### DIFF
--- a/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
+++ b/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
@@ -3,7 +3,7 @@ title: Deploy cert-manager on Google Kubernetes Engine (GKE) and create SSL cert
 description: Learn how to deploy cert-manager on Google Kubernetes (GKE) Engine and then configure it to sign SSL certificates using Let's Encrypt
 ---
 
-*Last Verified: 6 June 2025*
+*Last Verified: 14 April 2026*
 
 In this tutorial you will learn how to deploy and configure cert-manager on Google Kubernetes Engine (GKE).
 You will learn how to configure cert-manager to get a signed SSL certificate from Let's Encrypt,
@@ -38,7 +38,7 @@ Visit the [Get started with Google Cloud](https://cloud.google.com/docs/get-star
 
 **💻 Domain Name**
 
-You will need a domain name and the ability to create DNS records in that domain. We will be getting a $12 domain name from Google Domains. Google Domains is one of the many possible "domain name registrars". NameCheap and GoDaddy are two other well-known registrars.
+You will need a domain name and the ability to create DNS records in that domain. NameCheap and GoDaddy are two well-known registrars that may be used to register your domain name.
 
 > 💵 If you prefer not purchasing a domain name, it is also possible to adapt this tutorial to use the IP address to serve your website and for the SSL certificate.
 

--- a/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
+++ b/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
@@ -38,7 +38,7 @@ Visit the [Get started with Google Cloud](https://cloud.google.com/docs/get-star
 
 **💻 Domain Name**
 
-You will need a domain name and the ability to create DNS records in that domain. NameCheap and GoDaddy are two well-known registrars that may be used to register your domain name.
+You will need a domain name and the ability to create DNS records in that domain. You can register a domain name with any domain name registrar.
 
 > 💵 If you prefer not purchasing a domain name, it is also possible to adapt this tutorial to use the IP address to serve your website and for the SSL certificate.
 
@@ -190,16 +190,16 @@ export IP_ADDRESS=192.0.2.100  # Replace with your IP address
 
 ## 4. Create a domain name for your website
 
-You will need a domain name for your website, this allows Let's Encrypt to check your domain before it signs your SSL certificate,
+You will need a domain name for your website and Let's Encrypt checks your domain before it signs your SSL certificate,
 so the domain name needs to be reachable from the Internet.
 
 Once you have purchased your desired domain name, save it in an environment variable:
 
 ```bash
-export DOMAIN_NAME=mydomain.net
+export DOMAIN_NAME=example.net  # Replace with your domain name
 ```
 
-Next, you will need to create a new `A` record pointing at the IP address that we created above. Head back to your domain registrar and create a add a new record of type `A` that points to the IP address from the previous step.
+Next, you will need to create a new `A` record pointing at the IP address that we created above. Go to your domain registrar's DNS settings and add a new record of type `A` that points to the IP address from the previous step. Leave the host name empty (some registrars use `@` for this) because we are configuring the top-level domain name.
 
 > 🔰 Learn more about [What is a DNS A record? from the Cloudflare DNS tutorial](https://www.cloudflare.com/learning/dns/dns-records/dns-a-record/).
 
@@ -547,18 +547,17 @@ and forward HTTPS requests to a web server running in your Kubernetes cluster.
 
 ## Clean up
 
-After completing the tutorial you can clean up by deleting the cluster and the domain name and the static IP as follows:
+After completing the tutorial you can clean up by deleting the cluster and the static IP as follows:
 
 ```bash
 # Delete the cluster and all the Google Cloud resources related to the Ingress that it contains
 gcloud container clusters delete $CLOUDSDK_CONTAINER_CLUSTER
 
-# Delete the domain name
-gcloud dns record-sets delete $DOMAIN_NAME --zone $ZONE --type A
-
 # Delete the static IP address
 gcloud compute addresses delete web-ip --global
 ```
+
+Finally, delete the `A` record for your domain name at your domain registrar.
 
 ## Troubleshooting
 

--- a/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
+++ b/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
@@ -3,7 +3,7 @@ title: Deploy cert-manager on Google Kubernetes Engine (GKE) and create SSL cert
 description: Learn how to deploy cert-manager on Google Kubernetes (GKE) Engine and then configure it to sign SSL certificates using Let's Encrypt
 ---
 
-*Last Verified: 29 July 2026*
+*Last Verified: 6 June 2025*
 
 In this tutorial you will learn how to deploy and configure cert-manager on Google Kubernetes Engine (GKE).
 You will learn how to configure cert-manager to get a signed SSL certificate from Let's Encrypt,

--- a/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
+++ b/content/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/README.md
@@ -3,7 +3,7 @@ title: Deploy cert-manager on Google Kubernetes Engine (GKE) and create SSL cert
 description: Learn how to deploy cert-manager on Google Kubernetes (GKE) Engine and then configure it to sign SSL certificates using Let's Encrypt
 ---
 
-*Last Verified: 14 April 2026*
+*Last Verified: 29 July 2026*
 
 In this tutorial you will learn how to deploy and configure cert-manager on Google Kubernetes Engine (GKE).
 You will learn how to configure cert-manager to get a signed SSL certificate from Let's Encrypt,
@@ -190,26 +190,16 @@ export IP_ADDRESS=192.0.2.100  # Replace with your IP address
 
 ## 4. Create a domain name for your website
 
-You will need a domain name for your website and Let's Encrypt checks your domain before it signs your SSL certificate,
+You will need a domain name for your website, this allows Let's Encrypt to check your domain before it signs your SSL certificate,
 so the domain name needs to be reachable from the Internet.
 
-We will purchase a cheap domain name using a credit card. Go to https://domains.google.com, and type something in the search box. For the example, we searched for `hello-app.com` because the example container that we will be deploying is called `hello-app`. Most importantly, we make sure to sort the domain names by price:
-
-![](/images/getting-started/screenshot_google-domains_get-a-new-domain.png)
-
-We don't pick `hello-app.com` because it costs $2,800; instead, we go with the one at the top: `heyapp.net`. It looks good! We then click the cart button. On the next screen, you will want to disable the auto-renewal, since we don't want to pay for this domain every year:
-
-![](/images/getting-started/screenshot_google-domains_your-cart.png)
-
-Now that you know your domain name, save it in an environment variable:
+Once you have purchased your desired domain name, save it in an environment variable:
 
 ```bash
-export DOMAIN_NAME=heyapp.net
+export DOMAIN_NAME=mydomain.net
 ```
 
-Next, you will need to create a new `A` record pointing at the IP address that we created above. Head back to https://domains.google.com/registrar, open your domain (here, `heyapp.net`) and click "DNS" on the left menu. You will see "Custom records". You want to add a new record of type `A` and put the IP address from the previous step into "data". You must leave "Host name" empty because we are configuring the top-level domain name:
-
-![](/images/getting-started/screenshot_google-domains_resource-records.png)
+Next, you will need to create a new `A` record pointing at the IP address that we created above. Head back to your domain registrar and create a add a new record of type `A` that points to the IP address from the previous step.
 
 > 🔰 Learn more about [What is a DNS A record? from the Cloudflare DNS tutorial](https://www.cloudflare.com/learning/dns/dns-records/dns-a-record/).
 


### PR DESCRIPTION
**Preview:**
- https://deploy-preview-2062--cert-manager.netlify.app/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/#prerequisites
- https://deploy-preview-2062--cert-manager.netlify.app/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/#4-create-a-domain-name-for-your-website
- https://deploy-preview-2062--cert-manager.netlify.app/docs/tutorials/getting-started-with-cert-manager-on-google-kubernetes-engine-using-lets-encrypt-for-ingress-ssl/#clean-up

Fixes #2061

Google Domains shut down in 2024, so the GKE tutorial's step-by-step domain purchase and DNS instructions no longer work.

This PR makes the domain name steps generic. They now work with any registrar:

- Remove the Google Domains walkthrough and its three screenshots from the "Create a domain name for your website" section. Keep the instruction to create an `A` record at the top-level domain (empty host name) pointing at the static IP.
- Use the reserved `example.net` domain in the example, with a "replace with your domain name" comment.
- Fix the clean up section. The old `gcloud dns record-sets delete` command referenced an undefined `$ZONE` and a Cloud DNS zone that the tutorial never creates. The reader now deletes the `A` record at their registrar.

The `screenshot_google-domains_*.png` images stay in `static/images` because the versioned copies of this tutorial (`content/v1.11-docs` to `content/v1.18-docs`) still reference them. Updating those copies is a follow-up.

[Claude Fable 5.1]
