### PR TITLE
docs: update ListenerSet example to use http01-parentreffallback annotation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1532,3 +1532,5 @@ keyrings
 nolint
 requestgen
 yourname
+parentrefnamespace
+parentreffallback

--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -572,6 +572,7 @@ spec:
   gatewayClassName: eg
   listeners:
     - name: http
+      hostname: dummy
       protocol: HTTP
       port: 80
   allowedListeners:
@@ -579,7 +580,9 @@ spec:
       from: All
 ```
 
-The Gateway's HTTP listener serves ACME HTTP-01 challenges for all tenant ListenerSets.
+The `dummy` listener is required because the `listeners` cannot be left empty.
+See the [issue 4425](https://github.com/kubernetes-sigs/gateway-api/issues/4425)
+in the Gateway API project to learn more.
 
 In their namespace, the developer creates a Service, ListenerSet, and HTTPRoute
 for their application:
@@ -660,7 +663,6 @@ metadata:
   namespace: dev
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    acme.cert-manager.io/http01-parentreffallback: "true"
 spec:
   parentRef:
     name: eg
@@ -674,9 +676,11 @@ spec:
         mode: Terminate
         certificateRefs:
           - name: backend-tls
+    - name: http
+      hostname: echo.example.com
+      port: 80
+      protocol: HTTP
 ```
-
-The `acme.cert-manager.io/http01-parentreffallback: "true"` annotation tells cert-manager to use the ListenerSet's parent Gateway (rather than the ListenerSet itself) as the `parentRef` on the solver HTTPRoute. This allows the ListenerSet to be HTTPS-only while ACME HTTP-01 challenges are served by the shared Gateway HTTP listener.
 
 cert-manager will automatically create a Certificate resource based on the
 ListenerSet:
@@ -686,9 +690,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   annotations:
-    acme.cert-manager.io/http01-parentrefkind: Gateway
-    acme.cert-manager.io/http01-parentrefname: eg
-    acme.cert-manager.io/http01-parentrefnamespace: envoy-gateway-system
+    acme.cert-manager.io/http01-parentrefkind: ListenerSet
+    acme.cert-manager.io/http01-parentrefname: backend
   name: backend-tls
   namespace: dev
 spec:
@@ -715,7 +718,76 @@ above.
 
 In addition, ListenerSet supports the following annotation:
 
-- `acme.cert-manager.io/http01-parentreffallback`: when set to `"true"`, cert-manager uses the ListenerSet's `spec.parentRef` (the parent Gateway) as the `parentRef` on solver HTTPRoutes instead of the ListenerSet itself. Use this when the ListenerSet has no HTTP listener and relies on the shared Gateway HTTP listener for ACME HTTP-01 challenges.
+- `acme.cert-manager.io/http01-parentreffallback`: when set to `"true"`, cert-manager uses the ListenerSet's `spec.parentRef` (the parent Gateway) as the `parentRef` on the HTTPRoute it creates to serve ACME HTTP-01 challenges, instead of the ListenerSet itself.
+
+### Alternative: HTTPS-only ListenerSet with shared Gateway HTTP listener
+
+In the [Self-Service TLS with ListenerSet and HTTP-01](#example-self-service-tls-with-listenerset-and-http-01) example, the ListenerSet includes its own HTTP listener for ACME HTTP-01 challenges.
+
+As an alternative, you can omit the HTTP listener from the ListenerSet and rely on a single HTTP listener on the parent Gateway. In this case, remove the `dummy` hostname from the Gateway's HTTP listener so it can serve real traffic, and add the `acme.cert-manager.io/http01-parentreffallback: "true"` annotation to the ListenerSet:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: eg
+  namespace: envoy-gateway-system
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+  allowedListeners:
+    namespaces:
+      from: All
+---
+kind: ListenerSet
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: backend
+  namespace: dev
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    acme.cert-manager.io/http01-parentreffallback: "true"
+spec:
+  parentRef:
+    name: eg
+    namespace: envoy-gateway-system
+  listeners:
+    - name: https
+      hostname: echo.example.com
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: backend-tls
+```
+
+With this annotation, cert-manager uses the parent Gateway (rather than the ListenerSet itself) as the `parentRef` on the HTTPRoute it creates to serve ACME HTTP-01 challenges. The Gateway's HTTP listener serves ACME HTTP-01 challenges for all tenant ListenerSets. The resulting Certificate will reference the Gateway:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    acme.cert-manager.io/http01-parentrefkind: Gateway
+    acme.cert-manager.io/http01-parentrefname: eg
+    acme.cert-manager.io/http01-parentrefnamespace: envoy-gateway-system
+  name: backend-tls
+  namespace: dev
+spec:
+  dnsNames:
+  - echo.example.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt
+  secretName: backend-tls
+  usages:
+  - digital signature
+  - key encipherment
+```
 
 ## Inner workings diagram for developers
 

--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -572,7 +572,6 @@ spec:
   gatewayClassName: eg
   listeners:
     - name: http
-      hostname: dummy
       protocol: HTTP
       port: 80
   allowedListeners:
@@ -580,9 +579,7 @@ spec:
       from: All
 ```
 
-The `dummy` listener is required because the `listeners` cannot be left empty.
-See the [issue 4425](https://github.com/kubernetes-sigs/gateway-api/issues/4425)
-in the Gateway API project to learn more.
+The Gateway's HTTP listener serves ACME HTTP-01 challenges for all tenant ListenerSets.
 
 In their namespace, the developer creates a Service, ListenerSet, and HTTPRoute
 for their application:
@@ -663,6 +660,7 @@ metadata:
   namespace: dev
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    acme.cert-manager.io/http01-parentreffallback: "true"
 spec:
   parentRef:
     name: eg
@@ -676,11 +674,9 @@ spec:
         mode: Terminate
         certificateRefs:
           - name: backend-tls
-    - name: http
-      hostname: echo.example.com
-      port: 80
-      protocol: HTTP
 ```
+
+The `acme.cert-manager.io/http01-parentreffallback: "true"` annotation tells cert-manager to use the ListenerSet's parent Gateway (rather than the ListenerSet itself) as the `parentRef` on the solver HTTPRoute. This allows the ListenerSet to be HTTPS-only while ACME HTTP-01 challenges are served by the shared Gateway HTTP listener.
 
 cert-manager will automatically create a Certificate resource based on the
 ListenerSet:
@@ -690,8 +686,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   annotations:
-    acme.cert-manager.io/http01-parentrefkind: ListenerSet
-    acme.cert-manager.io/http01-parentrefname: backend
+    acme.cert-manager.io/http01-parentrefkind: Gateway
+    acme.cert-manager.io/http01-parentrefname: eg
+    acme.cert-manager.io/http01-parentrefnamespace: envoy-gateway-system
   name: backend-tls
   namespace: dev
 spec:
@@ -715,6 +712,10 @@ defined in that ListenerSet.
 ListenerSet resources support the same cert-manager annotations as Gateway
 resources. See the [Supported Annotations](#supported-annotations) section
 above.
+
+In addition, ListenerSet supports the following annotation:
+
+- `acme.cert-manager.io/http01-parentreffallback`: when set to `"true"`, cert-manager uses the ListenerSet's `spec.parentRef` (the parent Gateway) as the `parentRef` on solver HTTPRoutes instead of the ListenerSet itself. Use this when the ListenerSet has no HTTP listener and relies on the shared Gateway HTTP listener for ACME HTTP-01 challenges.
 
 ## Inner workings diagram for developers
 

--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -720,7 +720,7 @@ In addition, ListenerSet supports the following annotation:
 
 - `acme.cert-manager.io/http01-parentreffallback`: when set to `"true"`, cert-manager uses the ListenerSet's `spec.parentRef` (the parent Gateway) as the `parentRef` on the HTTPRoute it creates to serve ACME HTTP-01 challenges, instead of the ListenerSet itself.
 
-### Alternative: HTTPS-only ListenerSet with shared Gateway HTTP listener
+### HTTPS-only ListenerSet with shared Gateway HTTP listener
 
 In the [Self-Service TLS with ListenerSet and HTTP-01](#example-self-service-tls-with-listenerset-and-http-01) example, the ListenerSet includes its own HTTP listener for ACME HTTP-01 challenges.
 


### PR DESCRIPTION
Updates the ListenerSet example in the Gateway usage guide to reflect the new `acme.cert-manager.io/http01-parentreffallback` annotation introduced in https://github.com/cert-manager/cert-manager/pull/8749

- Removes the HTTP listener from the ListenerSet (tenants declare HTTPS only)
- Adds the fallback annotation to the example ListenerSet
- Updates the generated Certificate to show Gateway parentRef annotations
- Adds the annotation to the Supported Annotations section