### PR TITLE
docs: add infomaniak third party provider

### DIFF
--- a/content/docs/configuration/acme/dns01/README.md
+++ b/content/docs/configuration/acme/dns01/README.md
@@ -173,6 +173,7 @@ Links to these supported providers along with their documentation are below:
 - [`cert-manager-webhook-hetzner`](https://github.com/vadimkim/cert-manager-webhook-hetzner)
 - [`cert-manager-webhook-ibmcis`](https://github.com/jb-dk/cert-manager-webhook-ibmcis)
 - [`cert-manager-webhook-infomaniak`](https://github.com/Infomaniak/cert-manager-webhook-infomaniak)
+- [`cert-manager-webhook-infomaniak`](https://github.com/M0NsTeRRR/cert-manager-webhook-infomaniak) (third-party alternative)
 - [`cert-manager-webhook-inwx`](https://gitlab.com/smueller18/cert-manager-webhook-inwx)
 - [`cert-manager-webhook-ionos-cloud`](https://github.com/ionos-cloud/cert-manager-webhook-ionos-cloud)
 - [`cert-manager-webhook-linode`](https://github.com/linode/cert-manager-webhook-linode)


### PR DESCRIPTION
Hello,

Differences between mine and the official one :
- **Distroless image**: Only the binary, running rootless for enhanced security.
- **Updated dependencies**: Regularly maintained for reliability and security.
- **Open collaboration**: Issues enabled for community feedback and contributions.
- **OCI-compatible artifacts**: Helm chart and container images are published in OCI format and signed, making them easy to integrate with GitOps tools like Flux and ArgoCD.

Fix issue #1935