### PR TITLE
Clarify ACME challenge scheduling behaviour

### DIFF
--- a/content/docs/concepts/acme-orders-challenges.md
+++ b/content/docs/concepts/acme-orders-challenges.md
@@ -92,9 +92,28 @@ is a backlog of challenges to complete.
 Instead of attempting to process all challenges at once, challenges are
 'scheduled' by cert-manager.
 
-This scheduler applies a cap on the maximum number of simultaneous challenges
-as well as disallows two challenges for the same DNS name and solver type
-(`HTTP01` or `DNS01`) to be completed at once.
+This scheduler is a coarse back-pressure mechanism. It applies a cap on the
+maximum number of simultaneous challenges, and it also disallows two
+challenges for the same DNS name and challenge type (`HTTP01` or `DNS01`) from
+being completed at once.
 
-The maximum number of challenges that can be processed at a time is 60 as of
-[`ddff78`](https://github.com/cert-manager/cert-manager/blob/ddff78f011558e64186d61f7c693edced1496afa/pkg/controller/acmechallenges/scheduler/scheduler.go#L31-L33).
+This behavior is intentionally conservative. The scheduler reasons about the
+externally visible ACME validation target rather than cert-manager's internal
+solver configuration. For example, HTTP01 validation is still against the same
+hostname even if different ingress classes or gateway routes are configured,
+and DNS01 validation is still against the same `_acme-challenge` name even if
+different DNS provider backends are configured.
+
+A single cert-manager instance performs self-checks from one network and DNS
+viewpoint only. As a result, differing solver backends do not reliably imply
+independent ACME-visible validation paths, so the scheduler keeps the key
+coarse by design.
+
+The scheduler does not attempt to model CA-specific rate limits, tenant
+fairness, or ownership policy for DNS names. Deployments that need stronger
+multi-tenant isolation or tighter control over which workloads may request
+certificates for which names should rely on [policy controls](../policy/README.md),
+admission, approval, or separate cert-manager deployments rather than on
+scheduler heuristics alone.
+
+The default maximum number of challenges that can be processed at a time is 60.

--- a/content/docs/concepts/acme-orders-challenges.md
+++ b/content/docs/concepts/acme-orders-challenges.md
@@ -89,12 +89,37 @@ is a backlog of challenges to complete.
 
 ### Challenge Scheduling
 
-Instead of attempting to process all challenges at once, challenges are
-'scheduled' by cert-manager.
+Instead of attempting to process all challenges at once, cert-manager
+schedules them.
 
-This scheduler applies a cap on the maximum number of simultaneous challenges
-as well as disallows two challenges for the same DNS name and solver type
-(`HTTP01` or `DNS01`) to be completed at once.
+The scheduler does two things:
 
-The maximum number of challenges that can be processed at a time is 60 as of
-[`ddff78`](https://github.com/cert-manager/cert-manager/blob/ddff78f011558e64186d61f7c693edced1496afa/pkg/controller/acmechallenges/scheduler/scheduler.go#L31-L33).
+- it limits how many challenges can be processed at the same time; and
+- it avoids processing two challenges at once when they would validate the
+  same target.
+
+For conflict detection, cert-manager uses the ACME validation target that is
+actually checked externally:
+
+- `HTTP01` challenges conflict if they validate the same hostname;
+- `DNS01` challenges conflict if they validate the same `_acme-challenge` DNS
+  name.
+
+Different internal solver settings do not make those challenges independent.
+For example, different ingress classes or gateway routes for `HTTP01`, or
+different DNS provider backends for `DNS01`, can still end up validating the
+same hostname or DNS record.
+
+The scheduler does not attempt to model CA-specific rate limits, tenant
+fairness, or ownership policy for DNS names. Deployments that need stronger
+multi-tenant isolation or tighter control over which workloads may request
+certificates for which names should rely on [policy controls](../policy/README.md),
+admission, approval, or separate cert-manager deployments rather than on
+scheduler heuristics alone.
+
+By default, cert-manager processes up to 60 challenges at a time.
+You can change this with the controller
+[`--max-concurrent-challenges`](../cli/controller.md) flag.
+If you install cert-manager with Helm, set `maxConcurrentChallenges`.
+If you use a controller configuration file, set `maxConcurrentChallenges` in
+[`ControllerConfiguration`](../reference/api-docs.md#controller.config.cert-manager.io/v1alpha1.ControllerConfiguration).

--- a/content/docs/configuration/acme/README.md
+++ b/content/docs/configuration/acme/README.md
@@ -38,6 +38,14 @@ DNS lookup and can validate that the client owns the domain for the requested
 certificate. With the correct permissions, cert-manager will automatically
 present this TXT record for your given DNS provider.
 
+For more detail on challenge lifecycle, self-checks, and the intentionally
+conservative challenge scheduling and back-pressure behavior, see [ACME Orders
+and Challenges](../../concepts/acme-orders-challenges.md). In shared deployments,
+if you need tighter control over which workloads may request certificates for
+which names, see the [policy documentation](../../policy/README.md). If you are
+debugging a failed issuance flow, see [Troubleshooting Problems with ACME /
+Let's Encrypt Certificates](../../troubleshooting/acme.md).
+
 ## Configuration
 
 ### Creating a Basic ACME Issuer

--- a/content/docs/troubleshooting/acme.md
+++ b/content/docs/troubleshooting/acme.md
@@ -11,8 +11,13 @@ Learn how to diagnose problems if cert-manager fails to renew ACME / Let's Encry
 When requesting ACME certificates, cert-manager will create `Order` and
 `Challenges` to complete the request. As such, there are more resources to
 investigate and debug if there is a problem during the process. You can read
-more about these resources in the [concepts
-pages](../concepts/acme-orders-challenges.md).
+more about these resources, including challenge self-checks and scheduling
+behavior, in the [ACME Orders and Challenges](../concepts/acme-orders-challenges.md)
+page.
+
+If you are operating cert-manager in a shared environment and need tighter
+control over which workloads may request certificates for which names, see the
+[policy documentation](../policy/README.md).
 
 Before you start here you should probably take a look at our [general troubleshooting guide](./README.md)
 


### PR DESCRIPTION
## What this PR does

Clarifies the ACME challenge scheduling documentation.

This updates the ACME concepts, configuration, and troubleshooting pages to explain that challenge scheduling is intentionally conservative, and that the scheduler should be understood as a coarse back-pressure mechanism rather than a fairness or policy layer.

Related to cert-manager/cert-manager#8781 and cert-manager/cert-manager#8643.

## Why

The current documentation explains what the scheduler does, but not clearly why it behaves this way.

In particular, this PR adds context that:

- cert-manager self-checks from a single network and DNS viewpoint;
- different solver backends do not reliably imply independent ACME-visible validation paths;
- the scheduler therefore keeps a coarse conflict key by design; and
- multi-tenant isolation and DNS-name ownership constraints are better handled through policy, approval, admission, or separate deployments.

It also adds cross-links from the ACME configuration and troubleshooting pages back to the concepts page, and to the policy documentation.
