### PR TITLE
Add Venafi OAuth token metrics and AuthFailed condition docs

### DIFF
--- a/content/docs/configuration/venafi.md
+++ b/content/docs/configuration/venafi.md
@@ -367,6 +367,25 @@ more information on how to create Certificate resources.
 | `tokenEndpoint` | No | `https://auth.apps.paloaltonetworks.com/oauth2/access_token` | OAuth 2.0 token endpoint URL used to obtain access tokens. |
 | `url` | No | `https://api.strata.paloaltonetworks.com/ngts` | Base URL for the NGTS API endpoint. |
 
+## Issuer conditions
+
+### AuthFailed
+
+When a Venafi endpoint rejects the supplied credentials (for example, with an HTTP 401 or 403 response), the `Issuer` or `ClusterIssuer` Ready condition transitions to `False` with `reason: AuthFailed`:
+
+```bash
+$ kubectl describe issuer corp-issuer --namespace='NAMESPACE OF YOUR ISSUER RESOURCE'
+...
+Status:
+  Conditions:
+    Message: OAuth token request failed: ...
+    Reason:  AuthFailed
+    Status:  False
+    Type:    Ready
+```
+
+`AuthFailed` indicates that the credentials themselves are invalid. This is distinct from the generic `ErrorSetup` reason, which covers transient network or infrastructure problems. If you see `AuthFailed`, check the credentials in the referenced `Secret` — the API key for CyberArk Certificate Manager SaaS, the access token or username/password for CyberArk Certificate Manager Self-Hosted, or the `client-id` and `client-secret` for NGTS — and ensure they are correct and have not expired.
+
 ## Issuer specific annotations
 
 ### Custom Fields

--- a/content/docs/configuration/venafi.md
+++ b/content/docs/configuration/venafi.md
@@ -384,7 +384,7 @@ Status:
     Type:    Ready
 ```
 
-`AuthFailed` indicates that the credentials themselves are invalid. This is distinct from the generic `ErrorSetup` reason, which covers transient network or infrastructure problems. If you see `AuthFailed`, check the credentials in the referenced `Secret` — the API key for CyberArk Certificate Manager SaaS, the access token or username/password for CyberArk Certificate Manager Self-Hosted, or the `client-id` and `client-secret` for NGTS — and ensure they are correct and have not expired.
+`AuthFailed` indicates that the credentials themselves are invalid. This is distinct from the generic `ErrorSetup` reason, which covers transient network or infrastructure problems. If you see `AuthFailed`, check the credentials in the referenced `Secret` — the API key for CyberArk Certificate Manager SaaS, the access token or username/password for CyberArk Certificate Manager Self-Hosted, or the `client-id` and `client-secret` for Next-Gen Trust Security (NGTS) — and ensure they are correct and have not expired.
 
 ## Issuer specific annotations
 

--- a/content/docs/configuration/venafi.md
+++ b/content/docs/configuration/venafi.md
@@ -367,25 +367,6 @@ more information on how to create Certificate resources.
 | `tokenEndpoint` | No | `https://auth.apps.paloaltonetworks.com/oauth2/access_token` | OAuth 2.0 token endpoint URL used to obtain access tokens. |
 | `url` | No | `https://api.strata.paloaltonetworks.com/ngts` | Base URL for the NGTS API endpoint. |
 
-## Issuer conditions
-
-### AuthFailed
-
-When a Venafi endpoint rejects the supplied credentials (for example, with an HTTP 401 or 403 response), the `Issuer` or `ClusterIssuer` Ready condition transitions to `False` with `reason: AuthFailed`:
-
-```bash
-$ kubectl describe issuer corp-issuer --namespace='NAMESPACE OF YOUR ISSUER RESOURCE'
-...
-Status:
-  Conditions:
-    Message: OAuth token request failed: ...
-    Reason:  AuthFailed
-    Status:  False
-    Type:    Ready
-```
-
-`AuthFailed` indicates that the credentials themselves are invalid. This is distinct from the generic `ErrorSetup` reason, which covers transient network or infrastructure problems. If you see `AuthFailed`, check the credentials in the referenced `Secret` — the API key for CyberArk Certificate Manager SaaS, the access token or username/password for CyberArk Certificate Manager Self-Hosted, or the `client-id` and `client-secret` for Next-Gen Trust Security (NGTS) — and ensure they are correct and have not expired.
-
 ## Issuer specific annotations
 
 ### Custom Fields

--- a/content/docs/devops-tips/prometheus-metrics.md
+++ b/content/docs/devops-tips/prometheus-metrics.md
@@ -181,7 +181,7 @@ Check the health of the cert-manager scrape targets on the Prometheus status pag
 
 ## Venafi metrics
 
-cert-manager exposes the following Prometheus metrics for Venafi OAuth token requests. These are emitted by the controller whenever a Venafi `Issuer` or `ClusterIssuer` authenticates against a TPP, Cloud, or NGTS endpoint.
+cert-manager exposes the following Prometheus metrics for Venafi OAuth token requests. These are emitted by the controller whenever a Venafi `Issuer` or `ClusterIssuer` authenticates against a TPP, Cloud, or Next-Gen Trust Security (NGTS) endpoint.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|

--- a/content/docs/devops-tips/prometheus-metrics.md
+++ b/content/docs/devops-tips/prometheus-metrics.md
@@ -179,6 +179,17 @@ Check the health of the cert-manager scrape targets on the Prometheus status pag
 
 ![](/docs/devops-tips/prometheus-metrics/prometheus-status-targets.png)
 
+## Venafi metrics
+
+cert-manager exposes the following Prometheus metrics for Venafi OAuth token requests. These are emitted by the controller whenever a Venafi `Issuer` or `ClusterIssuer` authenticates against a TPP, Cloud, or NGTS endpoint.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `certmanager_venafi_oauth_token_requests_total` | Counter | `status` (`success` \| `failure`) | Total number of Venafi OAuth token requests made by cert-manager. |
+| `certmanager_venafi_oauth_token_request_duration_seconds` | Histogram | — | Duration of Venafi OAuth token requests. Buckets cover typical token-exchange latencies from 10ms to 30s. |
+
+These metrics can be used to alert on elevated token request failure rates or unexpected latency increases in the authentication flow.
+
 ## Monitoring Mixin
 
 Monitoring mixins are a way to bundle common alerts, rules, and dashboards for an application in a configurable and extensible way, using the Jsonnet data templating language. A cert-manager monitoring mixin can be found here https://github.com/imusmanmalik/cert-manager-mixin. Documentation on usage can be found with the `cert-manager-mixin` project.


### PR DESCRIPTION
Documents the two new Prometheus metrics added in https://github.com/cert-manager/cert-manager/pull/8808 (certmanager_venafi_oauth_token_requests_total and certmanager_venafi_oauth_token_request_duration_seconds) in the Prometheus metrics page, and adds an "Issuer conditions" section to the Venafi configuration docs explaining the new AuthFailed condition reason and how it differs from ErrorSetup.