### PR TITLE
Fix node/npm requirements in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     }
   ],
   "engines": {
-    "npm": ">=11.0.0",
-    "node": ">=24.0.0"
+    "npm": "11.x",
+    "node": "24.x"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
I noticed that the integrity checksums are removed in https://github.com/cert-manager/website/pull/2134, and this seems to be because Renovate now uses Node 26 ([logs](https://developer.mend.io/github/cert-manager/website/-/job/df4e63c2-2542-4d40-a163-f8f5e9d13fdd)). This change should ensure Renovate is forced to use Node 24, for now. We will eventually upgrade Node to the next LTS release, but I would like the lockfile maintenance PRs to continue working until then.

The lock file maintenance PR issue was last fixed in https://github.com/cert-manager/website/pull/2059, and I think we need even tighter control over the node version.