### PR TITLE
Delay cert-manager 1.21 release by 1 week

### DIFF
--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -28,7 +28,7 @@ should be stable enough to run.
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
-| 1.21     | Jun 24, 2026 | Release of 1.23 | 1.33 → 1.36 / 4.20 → 4.22                      | 1.33 → 1.36                        |
+| 1.21     | Jul 01, 2026 | Release of 1.23 | 1.33 → 1.36 / 4.20 → 4.22                      | 1.33 → 1.36                        |
 
 Dates in the future are not firm commitments and are subject to change.
 


### PR DESCRIPTION
Deploy preview: https://deploy-preview-2146--cert-manager.netlify.app/docs/releases/

## Summary

- Move the planned release date for cert-manager 1.21 from Jun 24 to Jul 01, 2026

## Motivation

Agreed in the cert-manager weekly meeting on 2026-06-11 to allow time for the
following PRs to be completed and merged before the release:

- cert-manager/cert-manager#8766 — per-solver DNS01 nameserver configuration (@ThatsMrTalbot)
- cert-manager/cert-manager#8858 — `waitInsteadOfSelfCheck` per solver (@wallrj)
- cert-manager/cert-manager#8798 — ACME ARI implementation (@hjoshi123)
- cert-manager/cert-manager#8823 — custom static labels for Prometheus metrics (@Peac36)
- cert-manager/cert-manager#8464 — clock skew resilience in webhook dynamic serving certificate renewal (@Peac36)

## Test plan

- [ ] Verify the releases page renders correctly on the Netlify preview