### PR TITLE
docs: use recommended Cloudflare API token in DNS01 tutorial

### DIFF
--- a/content/docs/tutorials/acme/dns-validation.md
+++ b/content/docs/tutorials/acme/dns-validation.md
@@ -57,12 +57,13 @@ spec:
         - example.org
       dns01:
         cloudflare:
-          email: my-cloudflare-acc@example.com
-          # !! Remember to create a k8s secret before
-          # kubectl create secret generic cloudflare-api-key-secret
-          apiKeySecretRef:
-            name: cloudflare-api-key-secret
-            key: api-key
+          # API Tokens are recommended: they are scoped to specific zones and
+          # permissions and are easily revocable. Create the secret first, e.g.:
+          # kubectl create secret generic cloudflare-api-token-secret \
+          #   --from-literal=api-token=<API Token>
+          apiTokenSecretRef:
+            name: cloudflare-api-token-secret
+            key: api-token
 ```
 
 

--- a/content/docs/tutorials/acme/dns-validation.md
+++ b/content/docs/tutorials/acme/dns-validation.md
@@ -60,7 +60,7 @@ spec:
           # API Tokens are recommended: they are scoped to specific zones and
           # permissions and are easily revocable. Create the secret first, e.g.:
           # kubectl create secret generic cloudflare-api-token-secret \
-          #   --from-literal=api-token=<API Token>
+          #   --from-literal=api-token="$CLOUDFLARE_API_TOKEN"
           apiTokenSecretRef:
             name: cloudflare-api-token-secret
             key: api-token


### PR DESCRIPTION
Fixes #1596

The DNS01 validation tutorial configured the Cloudflare solver using `apiKeySecretRef` together with an `email` — the legacy Global API Key method. Following the tutorial with a Cloudflare **API token** (what most users create today) produces:

```
Error: 6003: Invalid request headers <- 6103: Invalid format for X-Auth-Key header
```

because an API token is supplied in an API key field.

This updates the example to the recommended `apiTokenSecretRef` method (dropping `email`), matching the [DNS01 Cloudflare configuration reference](https://cert-manager.io/docs/configuration/acme/dns01/cloudflare/), which notes that API tokens are recommended since they are zone-scoped and easily revocable. The legacy API Key method remains documented on that reference page.

/kind documentation

```release-note
NONE
```
