### PR TITLE
docs: use stringData in the DigitalOcean DNS01 Secret example

### DIFF
--- a/content/docs/configuration/acme/dns01/digitalocean.md
+++ b/content/docs/configuration/acme/dns01/digitalocean.md
@@ -12,22 +12,20 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: digitalocean-dns
-data:
+type: Opaque
+stringData:
   # insert your DO access token here
-  access-token: "base64 encoded access-token here"
-  ```
+  access-token: "your-access-token"
+```
 
 The access token must have write access.
+
+Using `stringData` lets you provide the token in plain text; Kubernetes
+base64-encodes it for you when the `Secret` is created.
 
 To create a Personal Access Token, see [DigitalOcean documentation](https://docs.digitalocean.com/reference/api/create-personal-access-token/).
 
 Handy direct link: https://cloud.digitalocean.com/account/api/tokens/new
-
-To encode your access token into base64, you can use the following
-
-```bash
-echo -n 'your-access-token' | base64
-```
 
 ```yaml
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
## What

Switches the DigitalOcean ACME DNS01 `Secret` example to use `stringData` instead of a base64-encoded `data` field, and removes the now-redundant base64 encoding instructions. Also fixes a malformed closing code fence.

## Why

Issue #354 reports that the base64 instructions on this page are confusing. The reporter noted they would have done the right thing on the first try if the example had not told them to base64-encode the token. When closing the earlier PR #740, @SgtCoDFish suggested that adding a `stringData` note would be a good improvement and invited a new PR.

Using `stringData` lets users paste the token in plain text and lets Kubernetes encode it, which removes the footgun. This matches the existing Cloudflare DNS01 example, which already uses `stringData`.

Closes #354

```release-note
NONE
```
