### PR TITLE
docs: document the cert-manager.io/secret-template ingress annotation

### DIFF
--- a/content/docs/usage/ingress.md
+++ b/content/docs/usage/ingress.md
@@ -191,7 +191,7 @@ trigger `Certificate` resources to be automatically created:
   set the `spec.secretTemplate` field of the generated Certificate.
   The value is a JSON representation of `secretTemplate` and must not contain any unknown fields.
   `secretTemplate` accepts `annotations` and `labels` maps, which are copied onto the `Secret` that stores the certificate.
-  For example: `cert-manager.io/secret-template: '{"labels": {"my-label": "value"}, "annotations": {"kubed.appscode.com/sync": "true"}}'`.
+  For example: `cert-manager.io/secret-template: '{"labels": {"team": "platform"}, "annotations": {"example.com/owner": "platform"}}'`.
 
 ## Copying annotations to the Certificate
 

--- a/content/docs/usage/ingress.md
+++ b/content/docs/usage/ingress.md
@@ -187,6 +187,12 @@ trigger `Certificate` resources to be automatically created:
   configure `spec.privateKey.rotationPolicy` field to set the rotation policy of the private key for a Certificate.
   Valid values are `Never` and `Always`. If unset a rotation policy `Always` will be used.
 
+- `cert-manager.io/secret-template`: (optional) this annotation allows you to
+  set the `spec.secretTemplate` field of the generated Certificate.
+  The value is a JSON representation of `secretTemplate` and must not contain any unknown fields.
+  `secretTemplate` accepts `annotations` and `labels` maps, which are copied onto the `Secret` that stores the certificate.
+  For example: `cert-manager.io/secret-template: '{"labels": {"my-label": "value"}, "annotations": {"kubed.appscode.com/sync": "true"}}'`.
+
 ## Copying annotations to the Certificate
 
 > ℹ️ This feature was added in cert-manager `v1.18.0`.


### PR DESCRIPTION
## What

Documents the `cert-manager.io/secret-template` annotation in the **Supported Annotations** list on the Ingress usage page.

## Why

The auto-generated annotations reference (`content/docs/reference/annotations.md`) already lists `cert-manager.io/secret-template` and cross-links it to the Ingress usage page, but that page's Supported Annotations list never documented it, so the cross-reference landed on a page with no matching entry (#1715).

The new bullet describes the annotation accurately per the cert-manager source (`IngressSecretTemplate`): the value is a JSON representation of the Certificate `spec.secretTemplate` (which accepts `annotations` and `labels` maps), with no unknown fields, plus an example.

Closes #1715

```release-note
NONE
```
