### PR TITLE
netlify: document deploy-preview security for forked pull requests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,16 @@
 	NEXT_PUBLIC_DOCS_SEARCH_INDEX_NAME = "cert-manager"
 	NEXT_PUBLIC_DOMAIN_URL = "https://cert-manager.io"
 
+# Security (CWE-829): deploy previews for pull requests from public forks run
+# untrusted code automatically, before any review. Do NOT add secrets to this
+# block or to [build.environment] — they would be handed to fork builds. Secrets
+# belong in [context.production.environment] or a production-scoped Netlify UI
+# variable, which the sensitive-variable policy keeps from untrusted deploys:
+# https://docs.netlify.com/build/environment-variables/get-started/#sensitive-variable-policy
+# This block is intentionally empty: deploy previews inherit the public values
+# from [build.environment]; it exists only to make the "no secrets" rule visible.
+[context.deploy-preview.environment]
+
 # Prevent search engines from indexing preview sites for branch deploys. See
 # - https://docs.netlify.com/routing/headers/#custom-headers-for-different-branch-or-deploy-contexts
 # - https://developers.google.com/search/docs/crawling-indexing/block-indexing


### PR DESCRIPTION
## Motivation

A security review flagged that Netlify builds deploy previews for pull requests from public forks automatically (CWE-829): `next build` runs the fork's `next.config.js`, `package.json` scripts and bundled JavaScript on Netlify's build infrastructure before any maintainer reviews the diff. Because a fork pull request controls the whole checkout — including `netlify.toml` — no configuration committed here can block that build on its own.

## What this changes

This makes no change to build behaviour. It records, in source, the security posture that already protects the site, and guards against a future regression:

- A comment in `netlify.toml` explaining that fork deploy previews run untrusted code and must therefore only ever receive public values.
- An explicit (intentionally empty) `[context.deploy-preview.environment]` block and a note asking contributors not to add secrets to it or to `[build.environment]`. Secrets belong in `[context.production.environment]` or a production-scoped Netlify UI variable, so fork previews never receive them.
- A link to the relevant Netlify documentation (sensitive-variable policy).

The protection itself lives in the site's Netlify settings, which were verified as part of this work:

- The sensitive-variable policy withholds sensitive variables from untrusted (fork) deploys.
- No secret variable is scoped to the deploy-preview context; the only variables present are public (`NEXT_PUBLIC_*`, `NODE_VERSION`, `NETLIFY_NEXT_PLUGIN_SKIP`).
- The fork build cache is isolated from production.

## Testing

- `netlify.toml` parses cleanly (validated with a TOML parser).
- The documentation link was checked and resolves.
- No functional change to the build; the deploy preview generated for this pull request exercises the new `[context.deploy-preview.environment]` block.
