### PR TITLE
v1.19.6: patch release notes

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -65,6 +65,9 @@ lvyanru8200
 vedauth
 CVE-2022-41717
 CVE-2023-29409
+CVE-2026-27145
+CVE-2026-42504
+CVE-2026-42507
 seccomp
 RedHat
 RoleBinding
@@ -608,6 +611,7 @@ v1.19.1
 v1.20.0
 v1.19.2
 v1.19.5
+v1.19.6
 v1.20.0
 v1.19.x
 v1.20.0
@@ -672,6 +676,7 @@ vendoring
 vendored
 versioning
 wallrj
+wallrj-cyberark
 webhook
 webhooks
 whitelist

--- a/content/docs/releases/release-notes/release-notes-1.19.md
+++ b/content/docs/releases/release-notes/release-notes-1.19.md
@@ -72,6 +72,33 @@ And finally, thanks to the cert-manager steering committee for their feedback in
 - [`@ssyno`](https://github.com/ssyno)
 {/* END steerers */}
 
+## `v1.19.6`
+
+This patch release fixes a security issue ([`GHSA-8rvj-mm4h-c258`](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258), HIGH) where the default `cert-manager-edit` aggregate ClusterRole granted namespace users permission to create ACME `Challenge` and `Order` resources directly. A user who could create a `Challenge` referencing a `ClusterIssuer` could supply attacker-controlled solver configuration while cert-manager loaded credentials from the `ClusterIssuer`'s namespace, bypassing Issuer solver selectors (`dnsZones`, `dnsNames`, `matchLabels`). With the acme-dns provider specifically, this could disclose DNS credentials to an attacker-controlled endpoint.
+
+This release also includes Go version bumps to address reported CVEs. All users should upgrade.
+
+### Restrict Challenge and Order RBAC in `cert-manager-edit` ClusterRole
+
+> ⚠️ Potentially breaking change
+
+The `cert-manager-edit` aggregate ClusterRole no longer grants `create` for `challenges.acme.cert-manager.io` or `create`, `patch`, `update` for `orders.acme.cert-manager.io`. These resources are internal to cert-manager's ACME workflow and are not intended to be created or modified directly by users.
+
+Challenge `patch` and `update` are retained because the Challenge spec is immutable after creation and users may need these verbs to remove stuck finalizers (cert-manager/cert-manager#3851, cert-manager/cert-manager#3870).
+
+If you have tooling or workflows that create Challenge or Order resources directly (outside of the normal Certificate → CertificateRequest → Order → Challenge flow), you will need to grant those permissions explicitly.
+
+### Changes by Kind
+
+#### Bug or Regression
+
+- Security (HIGH): Remove Challenge `create` and Order `create`, `patch`, `update` verbs from the `cert-manager-edit` aggregate ClusterRole ([`GHSA-8rvj-mm4h-c258`](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258)). ([#8941](https://github.com/cert-manager/cert-manager/pull/8941), [@wallrj-cyberark](https://github.com/wallrj-cyberark))
+
+#### Other (Cleanup or Flake)
+
+- Update Go to `v1.25.11` to fix CVE-2026-27145, CVE-2026-42504, and CVE-2026-42507 ([#8925](https://github.com/cert-manager/cert-manager/pull/8925), [@wallrj-cyberark](https://github.com/wallrj-cyberark))
+- Upgrade Go to 1.25.10 to fix reported vulnerabilities, along with other dependency bumps ([#8788](https://github.com/cert-manager/cert-manager/pull/8788), [@SgtCoDFish](https://github.com/SgtCoDFish))
+
 ## `v1.19.5`
 
 This is a simple patch release to fix some reported vulnerabilities. All users are recommended to upgrade.

--- a/content/docs/releases/upgrading/upgrading-1.18-1.19.md
+++ b/content/docs/releases/upgrading/upgrading-1.18-1.19.md
@@ -20,6 +20,12 @@ If you are using these metrics, you may need to update your dashboards and alert
 1. Update any dashboards and alerts that using the old `path` label, to use the new bounded `action` label.
 2. If you rely on the high-cardinality `path` label, consider adding a Prometheus relabeling or recording rule to preserve the prior semantics (but beware of storage and cost).
 
+## Potentially Breaking: Challenge and Order RBAC restricted in `cert-manager-edit` ClusterRole
+
+Starting in v1.19.6, the `cert-manager-edit` aggregate ClusterRole no longer grants `create` for `challenges.acme.cert-manager.io` or `create`, `patch`, `update` for `orders.acme.cert-manager.io`. This fixes a security issue ([`GHSA-8rvj-mm4h-c258`](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258)) where these permissions allowed namespace users to bypass Issuer solver selectors and abuse ClusterIssuer credentials.
+
+These resources are internal to cert-manager's ACME workflow and are not intended to be created or modified directly by users. If you have tooling or workflows that create Challenge or Order resources directly (outside of the normal Certificate → CertificateRequest → Order → Challenge flow), you will need to grant those permissions explicitly.
+
 ## Next Steps
 
 From here on, you can follow the [regular upgrade process](../../installation/upgrade.md).

--- a/content/v1.19-docs/variables.json
+++ b/content/v1.19-docs/variables.json
@@ -1,3 +1,3 @@
 {
-  "cert_manager_latest_version": "v1.19.5"
+  "cert_manager_latest_version": "v1.19.6"
 }


### PR DESCRIPTION
**Preview**:
 * https://deploy-preview-2175--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.19#v1196
 * https://deploy-preview-2175--cert-manager.netlify.app/docs/releases/upgrading/upgrading-1.18-1.19
 * https://deploy-preview-2175--cert-manager.netlify.app/v1.19-docs/installation/

## Summary

- Add release notes for cert-manager v1.19.6, including security advisory [`GHSA-8rvj-mm4h-c258`](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258) (HIGH) details and a potentially breaking change note for the `cert-manager-edit` ClusterRole RBAC restriction
- Add corresponding upgrade note to `upgrading-1.18-1.19.md`
- Bump `cert_manager_latest_version` to `v1.19.6` in `content/v1.19-docs/variables.json`
- Add new spelling entries for v1.19.6, CVE IDs, and `wallrj-cyberark`

## Motivation

Part of the cert-manager v1.19.6 [release process](https://cert-manager.io/docs/contributing/release-process/).

- GitHub release: https://github.com/cert-manager/cert-manager/releases/tag/v1.19.6
- Security advisory: https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258
- Slack release thread: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1782401786770389

## Test plan

- [x] Netlify deploy preview renders correctly
- [x] Release notes page shows GHSA-8rvj-mm4h-c258 advisory link and "Potentially breaking change" section
- [x] Upgrade notes page (`upgrading-1.18-1.19`) shows RBAC restriction note referencing v1.19.6
- [x] Spellcheck passes
- [x] `[[VAR::cert_manager_latest_version]]` resolves to `v1.19.6` in v1.19 docs
- [x] Release notes match the [GitHub release](https://github.com/cert-manager/cert-manager/releases/tag/v1.19.6)