### PR TITLE
Document webhook certificate renewal after system suspend

### DIFF
--- a/content/docs/concepts/webhook.md
+++ b/content/docs/concepts/webhook.md
@@ -42,6 +42,11 @@ Then the webhook can be configured with either
 1. paths to a TLS certificate and key signed by the webhook CA, or
 2. a reference to the CA Secret for dynamic generation of the certificate and key on webhook startup
 
+When using dynamic generation, the webhook automatically renews its serving
+certificate before it expires. Since cert-manager 1.21, this renewal is
+resilient to system suspend (S3/S4) and VM live migration — events that can
+cause the renewal timer to miss its deadline.
+
 ## Known Problems and Solutions
 
 ### Webhook connection problems on GKE private cluster

--- a/content/docs/releases/release-notes/release-notes-1.21.md
+++ b/content/docs/releases/release-notes/release-notes-1.21.md
@@ -53,6 +53,25 @@ See [Skip the self-check with
 `waitInsteadOfSelfCheck`](../../configuration/acme/README.md#skip-the-self-check-with-waitinsteadofselfcheck)
 for configuration details.
 
+### Webhook Serving Certificate Renewal After System Suspend
+
+The cert-manager webhook generates and automatically renews its own self-signed
+serving certificate. Prior to 1.21, the renewal timer relied solely on Go's
+monotonic clock (`CLOCK_MONOTONIC`). During system suspend (S3/S4) or VM live
+migration, `CLOCK_MONOTONIC` stops advancing while wall-clock time
+(`CLOCK_REALTIME`) continues. When the system resumes, the renewal timer has not
+yet reached its deadline, so the webhook's serving certificate is never renewed
+— even though it has already expired. This causes `x509: certificate has expired
+or is not yet valid` errors for all admission and conversion webhook calls.
+
+cert-manager 1.21 adds a periodic ticker that polls wall-clock time against the
+renewal deadline, detecting missed renewals regardless of whether
+`CLOCK_MONOTONIC` advanced. The webhook now recovers within one minute of system
+resume.
+
+More details are available in the PR:
+https://github.com/cert-manager/cert-manager/pull/8464.
+
 ## Community
 
 As always, we'd like to thank all of the community members who helped in this release cycle, including all below who merged a PR and anyone that helped by commenting on issues, testing, or getting involved in cert-manager meetings. We're lucky to have you involved.
@@ -91,7 +110,10 @@ TODO
 
 ### Bug or Regression
 
-TODO
+- Fix webhook serving certificate not being renewed after system suspend or VM
+  live migration.
+  ([#8464](https://github.com/cert-manager/cert-manager/pull/8464),
+  [@Peac36](https://github.com/Peac36))
 
 ### Other (Cleanup or Flake)
 

--- a/content/docs/troubleshooting/webhook.md
+++ b/content/docs/troubleshooting/webhook.md
@@ -530,12 +530,19 @@ Internal error occurred: failed calling webhook "webhook.cert-manager.io":
     x509: certificate has expired or is not yet valid
 ```
 
-> This error message was reported once in Slack
-([1](https://kubernetes.slack.com/archives/C4NV3DWUC/p1618579222346800)).
+One known cause is system suspend (S3/S4) or VM live migration. The webhook
+generates and automatically renews its own self-signed serving certificate, but
+prior to cert-manager 1.21 the renewal timer relied on Go's monotonic clock
+(`CLOCK_MONOTONIC`), which stops advancing during system suspend. When the system
+resumes, the timer has not reached its deadline, so the certificate is never
+renewed — even though wall-clock time has advanced past its expiry.
 
-Please answer to the above Slack message since we are still unsure as to what
-may cause this issue; to get access to the Kubernetes Slack, visit
-[https://slack.k8s.io/](https://slack.k8s.io/).
+If you are running cert-manager 1.20 or earlier and encounter this error after
+resuming from suspend or after a VM migration, upgrading to cert-manager 1.21
+resolves the issue
+([#8464](https://github.com/cert-manager/cert-manager/pull/8464)). As a
+workaround, restarting the webhook pod forces it to regenerate its serving
+certificate.
 
 ## Error: `net/http: request canceled while waiting for connection`
 


### PR DESCRIPTION
**Preview**:
- [Release notes 1.21](https://deploy-preview-2181--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.21/)
- [Webhook concepts](https://deploy-preview-2181--cert-manager.netlify.app/docs/concepts/webhook/)
- [Webhook troubleshooting](https://deploy-preview-2181--cert-manager.netlify.app/docs/troubleshooting/webhook/#error-x509-certificate-has-expired-or-is-not-yet-valid)

### Pull Request Motivation

cert-manager/cert-manager#8464 fixes a bug where the webhook serving certificate
is not renewed after system suspend (S3/S4) or VM live migration. This PR adds
documentation for the fix ahead of the 1.21 release.

### Changes

- **Release notes** (`release-notes-1.21.md`): add a Major Themes entry
  explaining the bug (monotonic clock stops during suspend, one-shot timer never
  fires) and the fix (periodic ticker polling wall-clock time). Add a Bug or
  Regression changelog entry.
- **Webhook concepts** (`concepts/webhook.md`): note that since 1.21, automatic
  renewal is resilient to system suspend and VM live migration.
- **Webhook troubleshooting** (`troubleshooting/webhook.md`): expand the
  previously stub "x509: certificate has expired" section with the system suspend
  root cause, upgrade path, and restart workaround.

### Testing

Visual review of the three modified pages.