### PR TITLE
Document configurable CertificateRequest max backoff duration for v1.21

### DIFF
--- a/content/docs/faq/README.md
+++ b/content/docs/faq/README.md
@@ -133,7 +133,12 @@ network connection errors and with a longer exponentially increasing delay after
 You can observe that latest issuance has terminally failed if the `Certificate`
 has `Issuing` condition set to false and has `status.lastFailureTime` set. In
 this case the issuance will be retried after an exponentially increasing delay
-(1 to 32 hours) by creating a new `CertificateRequest`. You can trigger an
+(1 to 32 hours by default; both limits are configurable via the
+`--certificate-request-minimum-backoff-duration` and
+`--certificate-request-maximum-backoff-duration` controller flags, or the
+equivalent `certificateRequestMinimumBackoffDuration` and
+`certificateRequestMaximumBackoffDuration` Helm values) by creating a new
+`CertificateRequest`. You can trigger an
 immediate renewal using the [`cmctl renew`
 command](../reference/cmctl.md#renew). Terminal failures occur if the issuer
 sets the `CertificateRequest` to failed (for example if CA rejected the request

--- a/content/docs/releases/release-notes/release-notes-1.21.md
+++ b/content/docs/releases/release-notes/release-notes-1.21.md
@@ -89,6 +89,39 @@ upgrading.
 ([cert-manager/cert-manager#8952](https://github.com/cert-manager/cert-manager/pull/8952),
 [@erikgb](https://github.com/erikgb))
 
+### Configurable CertificateRequest retry backoff duration
+
+cert-manager 1.21 adds the `--certificate-request-maximum-backoff-duration`
+controller flag (default: 32 hours), making the exponential backoff cap
+configurable alongside the existing `--certificate-request-minimum-backoff-duration`
+flag.
+
+When a CertificateRequest fails, cert-manager backs off exponentially — by
+default from 1 hour up to 32 hours. In environments with scheduled CA
+maintenance windows, the backoff can grow so large that cert-manager does not
+retry until hours after the CA comes back online. With this flag, cluster
+operators can lower the ceiling to match their CA's maintenance schedule. For
+example, `--certificate-request-maximum-backoff-duration=1h` ensures that
+cert-manager retries at most every hour regardless of how many consecutive
+failures have occurred.
+
+The default of 32 hours preserves the behavior of previous releases. The flag
+may also be set via the
+[`certificateRequestMaximumBackoffDuration`](../../reference/api-docs.md#controller.config.cert-manager.io/v1alpha1.ControllerConfiguration)
+field in the controller `ControllerConfiguration` API, or via the Helm chart:
+
+```yaml
+config:
+  certificateRequestMaximumBackoffDuration: 1h
+```
+
+See the [controller CLI reference](../../cli/controller.md) for the full list of
+flags, and [What happens if issuance fails? Will it be retried?](../../faq/README.md#what-happens-if-issuance-fails-will-it-be-retried)
+for background on how cert-manager retries failed issuances.
+
+([cert-manager/cert-manager#8893](https://github.com/cert-manager/cert-manager/pull/8893),
+[@lunarwhite](https://github.com/lunarwhite))
+
 ### Skip the self-check with `waitInsteadOfSelfCheck`
 
 cert-manager 1.21 adds the `waitInsteadOfSelfCheck` solver option for ACME


### PR DESCRIPTION
**Preview**:
- [Release notes 1.21](https://deploy-preview-2187--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.21/)
- [FAQ](https://deploy-preview-2187--cert-manager.netlify.app/docs/faq/)

## Summary

- Adds a Major Themes section in the v1.21 release notes for the new
  `--certificate-request-maximum-backoff-duration` controller flag, with links
  to the CLI reference, `ControllerConfiguration` API docs, and the FAQ retry
  section.
- Adds a Feature changelog entry for cert-manager/cert-manager#8893.
- Updates the FAQ to note that both the minimum and maximum backoff limits are
  now configurable via flags and Helm values.

## Motivation

Depends on cert-manager/cert-manager#8893 (not yet merged). Opened as a draft
so the release notes are ready to publish once the feature PR lands.

The auto-generated `content/docs/cli/controller.md` and
`content/docs/reference/api-docs.md` will be updated automatically when the
binary and API types are regenerated for the v1.21.0 tag.

## Test plan

- [x] Preview renders correctly once cert-manager/cert-manager#8893 is merged
  and this PR is marked ready for review.