### PR TITLE
docs: rename tutorial 'Securing NGINX-ingress' to 'Securing ingress-nginx'

### DIFF
--- a/content/docs/manifest.json
+++ b/content/docs/manifest.json
@@ -625,7 +625,7 @@
               "path": "/docs/tutorials/README.md"
             },
             {
-              "title": "Securing NGINX-ingress",
+              "title": "Securing ingress-nginx",
               "path": "/docs/tutorials/acme/nginx-ingress.md"
             },
             {

--- a/content/docs/tutorials/acme/nginx-ingress.md
+++ b/content/docs/tutorials/acme/nginx-ingress.md
@@ -1,12 +1,12 @@
 ---
-title: Securing NGINX-ingress
+title: Securing ingress-nginx
 description: 'cert-manager tutorials: Using ingress-nginx to solve an ACME HTTP-01 challenge'
 ---
 
 > **Upcoming change:** ingress-nginx is scheduled for end of life in March 2026. See [Ingress-nginx End-of-Life: What cert-manager Supports Today and What's Coming](/announcements/2025/11/26/ingress-nginx-eol-and-gateway-api) for migration guidance and Gateway API plans.
 
 This tutorial will detail how to install and secure ingress to your cluster
-using NGINX.
+using ingress-nginx.
 
 ## Step 1 - Install Helm
 
@@ -24,7 +24,7 @@ For example, on MacOS:
 brew install kubernetes-helm
 ```
 
-## Step 2 - Deploy the NGINX Ingress Controller
+## Step 2 - Deploy the ingress-nginx Controller
 
 A [`kubernetes ingress controller`](https://kubernetes.io/docs/concepts/services-networking/ingress) is
 designed to be the access point for HTTP and HTTPS traffic to the software


### PR DESCRIPTION
## Summary

Renames the ACME tutorial **"Securing NGINX-ingress"** to **"Securing ingress-nginx"** to match the project actually used in the tutorial.

The tutorial installs and configures [`ingress-nginx`](https://kubernetes.github.io/ingress-nginx/) (the community Kubernetes project), but the page title said *NGINX-ingress*, which is easily confused with the unrelated commercial [NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/) maintained by F5/NGINX.

This is a documentation-only, wording change. No logic, commands, or steps are modified.

Changes (current `content/docs/` only — versioned snapshots left untouched):
- `content/docs/tutorials/acme/nginx-ingress.md`: frontmatter `title`, intro sentence, and the "Step 2" heading aligned to `ingress-nginx`.
- `content/docs/manifest.json`: navigation entry title updated to match.

## Validation

- `manifest.json` re-validated as well-formed JSON locally (`python3 -c "import json; json.load(...)"`).
- Verified no internal links target the old `Step 2 - Deploy the NGINX Ingress Controller` heading anchor, so the heading rename breaks no cross-references.
- The tutorial file path/URL is unchanged, so no redirects are needed.
- Collision check: no open PR references issue #1608 or this tutorial title.

Closes #1608
