### PR TITLE
Delay cert-manager 1.21 release by 1 week

### DIFF
--- a/content/docs/releases/README.md
+++ b/content/docs/releases/README.md
@@ -28,7 +28,7 @@ should be stable enough to run.
 
 | Release  | Release Date | End of Life     | [Supported Kubernetes / OpenShift Versions][s] | [Tested Kubernetes Versions][test] |
 |:--------:|:------------:|:---------------:|:----------------------------------------------:|:----------------------------------:|
-| 1.21     | Jul 01, 2026 | Release of 1.23 | 1.33 → 1.36 / 4.20 → 4.22                      | 1.33 → 1.36                        |
+| 1.21     | Jul 08, 2026 | Release of 1.23 | 1.33 → 1.36 / 4.20 → 4.22                      | 1.33 → 1.36                        |
 
 Dates in the future are not firm commitments and are subject to change.
 


### PR DESCRIPTION
Deploy preview: https://deploy-preview-2191--cert-manager.netlify.app/docs/releases/

## Summary

- Move the planned release date for cert-manager 1.21 from Jul 01 to Jul 08, 2026

## Motivation

The beta.0 pre-release was published on 2026-07-01. Delaying by one week to allow time for:

- Testing of the beta release by the community
- Resolution of any issues discovered in beta

## Test plan

- [x] Verify the releases page renders correctly on the Netlify preview