### PR TITLE
docs: remove dynamic variable from frozen release notes and upgrade guides

### DIFF
--- a/content/docs/releases/release-notes/release-notes-1.16.md
+++ b/content/docs/releases/release-notes/release-notes-1.16.md
@@ -43,7 +43,7 @@ avoiding typos and mistakes in the default values file.
 > ```bash
 > helm template cert-manager \
 >   --repo https://charts.jetstack.io \
->   --version [[VAR::cert_manager_latest_version]] \
+>   --version v1.16.x \
 >   --values values.cert-manager.yaml
 > ```
 > Here's an example of an error that would be caught by the schema validation:

--- a/content/docs/releases/release-notes/release-notes-1.19.md
+++ b/content/docs/releases/release-notes/release-notes-1.19.md
@@ -11,7 +11,7 @@ Be sure to review all new features and changes below, and read the full release 
 
 ## Important Upgrade Notes
 
-When upgrading to cert-manager `1.19`, use the latest patch version: `[[VAR::cert_manager_latest_version]]`.
+When upgrading to cert-manager `1.19`, use the latest patch version of cert-manager `1.19`.
 There is a bug in `v1.19.0` which may cause certificates to be re-issued unnecessarily. We fixed this in `v1.19.1`.
 
 ## Major Themes

--- a/content/docs/releases/upgrading/upgrading-1.18-1.19.md
+++ b/content/docs/releases/upgrading/upgrading-1.18-1.19.md
@@ -5,9 +5,9 @@ description: 'cert-manager installation: Upgrading v1.18 to v1.19'
 
 Before upgrading cert-manager from 1.18 to 1.19, please read the following important notes about breaking changes:
 
-## Use the latest patch version: `[[VAR::cert_manager_latest_version]]`
+## Use the latest patch version
 
-When upgrading to cert-manager `1.19`, use the latest patch version: `[[VAR::cert_manager_latest_version]]`.
+When upgrading to cert-manager `1.19`, use the latest patch version of cert-manager `1.19`.
 Do not install `v1.19.0`, because it has a bug which may cause certificates to be re-issued unnecessarily.
 We fixed the bug in `v1.19.1`.
 


### PR DESCRIPTION
Preview:
- https://deploy-preview-2192--cert-manager.netlify.app/docs/releases/upgrading/upgrading-1.18-1.19
- https://deploy-preview-2192--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.16
- https://deploy-preview-2192--cert-manager.netlify.app/docs/releases/release-notes/release-notes-1.19

## Problem

The `[[VAR::cert_manager_latest_version]]` template variable resolves to the
current latest cert-manager version (presently `v1.20.3`). When this variable
appears inside frozen release notes and upgrade guides for older releases, it
produces confusing instructions such as:

> When upgrading to cert-manager 1.19, use the latest patch version: v1.20.3.

Reported in #2105 (and originally noted in #1433).

## Fix

Replace the dynamic variable with static text that does not embed a specific
patch version, so the wording stays accurate without requiring future updates:

- `upgrading-1.18-1.19.md`: heading and body now say "use the latest patch version of cert-manager 1.19"
- `release-notes-1.16.md`: `helm template` example uses `v1.16.x`
- `release-notes-1.19.md`: body now says "use the latest patch version of cert-manager 1.19"

## Testing

Verified with `grep` that no `[[VAR::cert_manager_latest_version]]` references
remain in `content/docs/releases/`.