### PR TITLE
fix: add allowedRoutes to Gateway HTTP listener in ListenerSet example

### DIFF
--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -740,6 +740,9 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
   allowedListeners:
     namespaces:
       from: All


### PR DESCRIPTION
The Gateway HTTP listener in the ListenerSet example was missing allowedRoutes, which defaults to Same namespace. Without it, cert-manager's HTTP-01 challenge HTTPRoute (created in the application namespace) won't attach to the listener and the challenge will fail.