### PR TITLE
Warn that cnameStrategy Follow also follows wildcard-synthesized CNAMEs

### DIFF
--- a/content/docs/configuration/acme/dns01/README.md
+++ b/content/docs/configuration/acme/dns01/README.md
@@ -138,6 +138,18 @@ _acme-challenge.bar.example.com	IN	CNAME	_acme-challenge.less-privileged.example
 With this configuration cert-manager will follow CNAME records recursively in order to determine
 which DNS zone to update during DNS01 challenges.
 
+> ⚠️ With `cnameStrategy: Follow`, cert-manager follows *any* CNAME record
+> found at `_acme-challenge.<domain>`, including one synthesized by a wildcard
+> record. For example, a record like `*.example.com IN CNAME
+> lb.example.org` also answers CNAME queries for
+> `_acme-challenge.example.com`, so cert-manager will try to create the
+> challenge TXT record at `lb.example.org` — typically failing with an
+> error such as Route 53's `RRSet with DNS name lb.example.org. is not
+> permitted in zone example.com.`. To avoid this, create an explicit record
+> at `_acme-challenge.<domain>` (an exact-match name prevents wildcard
+> synthesis), or use the default `cnameStrategy: None` if you are not
+> delegating challenges to another zone.
+
 
 ## Supported DNS01 providers
 

--- a/content/docs/configuration/acme/dns01/README.md
+++ b/content/docs/configuration/acme/dns01/README.md
@@ -139,16 +139,17 @@ With this configuration cert-manager will follow CNAME records recursively in or
 which DNS zone to update during DNS01 challenges.
 
 > ⚠️ With `cnameStrategy: Follow`, cert-manager follows *any* CNAME record
-> found at `_acme-challenge.<domain>`, including one synthesized by a wildcard
-> record. For example, a record like `*.example.com IN CNAME
-> lb.example.org` also answers CNAME queries for
+> found at `_acme-challenge.<domain>`, including one synthesized by a
+> wildcard record. For example, a record like
+> `*.example.com IN CNAME lb.example.org` also answers CNAME queries for
 > `_acme-challenge.example.com`, so cert-manager will try to create the
-> challenge TXT record at `lb.example.org` — typically failing with an
-> error such as Route 53's `RRSet with DNS name lb.example.org. is not
-> permitted in zone example.com.`. To avoid this, create an explicit record
-> at `_acme-challenge.<domain>` (an exact-match name prevents wildcard
-> synthesis), or use the default `cnameStrategy: None` if you are not
-> delegating challenges to another zone.
+> challenge TXT record at `lb.example.org` — typically failing with an error
+> such as Route 53's
+> `RRSet with DNS name lb.example.org. is not permitted in zone example.com.`.
+> To avoid this, create an explicit record at `_acme-challenge.<domain>`
+> (an exact-match name prevents wildcard synthesis), or use the default
+> `cnameStrategy: None` if you are not delegating challenges to another
+> zone.
 
 
 ## Supported DNS01 providers


### PR DESCRIPTION
Adds a warning to the "Delegated Domains for DNS01" section: with `cnameStrategy: Follow`, cert-manager also follows CNAMEs synthesised by wildcard records (RFC 4592), because they are indistinguishable from explicit ones in a DNS response. A wildcard CNAME covering `_acme-challenge.<domain>` therefore sends the challenge TXT record to the wildcard target, which the DNS provider rejects as out of zone.

This has caught several users; see the diagnosis in cert-manager/cert-manager#5716 (comment: https://github.com/cert-manager/cert-manager/issues/5716#issuecomment-5241140824) and the same failure with Cloudflare in cert-manager/cert-manager#5751.

Note that cert-manager/cert-manager#8639 proposes a code fix for #5751: detect a wildcard-synthesised CNAME (by querying `*.<domain>` directly and comparing targets) and skip following it. Until something like that merges, this warning documents the behaviour of all released versions.

*with claude fable-5*
