### PR TITLE
Add cmp-issuer to external issuers list

### DIFF
--- a/content/docs/configuration/issuers.md
+++ b/content/docs/configuration/issuers.md
@@ -15,6 +15,7 @@ The following list contains all known cert-manager issuer integrations.
 | 🥈   | adcs-issuer                 | [📄][config:adcs-issuer]            | [Microsoft Active Directory<br/>Certificate Service][ca:adcs-issuer]   | -                                                 | [✔️][release:adcs-issuer]            | ✔️             |
 | 🥈   | aws-privateca-issuer        | [📄][config:aws-privateca-issuer]   | [AWS Private Certificate Authority][ca:aws-privateca-issuer]           | -                                                 | [✔️][release:aws-privateca-issuer]   | ✔️             |
 | 🥈   | ca-issuer (in-tree)         | [📄][config:ca-issuer]              | CA issuer                                                              | -                                                 | [✔️][release:cert-manager]           | ✔️             |
+| 🥈   | cmp-issuer                  | [📄][config:cmp-issuer]             | [Certificate Management Protocol (CMP)][ca:cmp-issuer]                 | -                                                 | [✔️][release:cmp-issuer]             | ✔️             |
 | 🥈   | czertainly-issuer           | [📄][config:czertainly-issuer]      | [CZERTAINLY][ca:czertainly-issuer]                                     | [supported][production:czertainly-issuer]         | [✔️][release:czertainly-issuer]      | ✔️             |
 | 🥈   | command-issuer              | [📄][config:command-issuer]         | [Keyfactor Command][ca:command-issuer]                                 | -                                                 | [✔️][release:command-issuer]         | ✔️             |
 | 🥈   | cview-issuer                | [📄][config:cview-issuer]           | [CView-issuer][ca:cview-issuer]                                        | -                                                 | [✔️][release:cview-issuer]           | ❌              |
@@ -65,6 +66,7 @@ The following list contains all known cert-manager issuer integrations.
 [config:adcs-issuer]: https://djkormo.github.io/adcs-issuer/
 [config:cfssl-issuer]: https://gerrit.wikimedia.org/r/plugins/gitiles/operations/software/cfssl-issuer
 [config:cfmtls-issuer]: https://github.com/k8stooling/cfmtls-issuer
+[config:cmp-issuer]: https://misiektoja.github.io/cmp-issuer/
 [config:zerossl-issuer]: https://github.com/topfreegames/zerossl-issuer
 [config:cview-issuer]: https://secure-ly.github.io/cview-issuer-chart
 [config:czertainly-issuer]: https://docs.czertainly.com/docs/certificate-key/integration-guides/cert-manager-issuer/create-czertainly-issuer
@@ -88,6 +90,7 @@ The following list contains all known cert-manager issuer integrations.
 [ca:venafi-issuer]: https://www.cyberark.com/products/certificate-manager/
 [ca:cfssl-issuer]: https://github.com/cloudflare/cfssl
 [ca:cfmtls-issuer]: https://developers.cloudflare.com/ssl/client-certificates/create-a-client-certificate/
+[ca:cmp-issuer]: https://www.rfc-editor.org/rfc/rfc9810.html
 [ca:zerossl-issuer]: https://zerossl.com/
 [ca:freeipa-issuer]: https://www.freeipa.org
 [ca:kms-issuer]: https://aws.amazon.com/kms/
@@ -115,6 +118,7 @@ The following list contains all known cert-manager issuer integrations.
 [release:adcs-issuer]: https://github.com/djkormo/adcs-issuer/releases
 [release:cfssl-issuer]: https://gerrit.wikimedia.org/r/plugins/gitiles/operations/software/cfssl-issuer/+refs
 [release:cfmtls-issuer]: https://github.com/k8stooling/cfmtls-issuer/releases/
+[release:cmp-issuer]: https://github.com/misiektoja/cmp-issuer/releases
 [release:zerossl-issuer]: https://github.com/topfreegames/zerossl-issuer/releases
 [release:cview-issuer]: https://github.com/secure-ly/cview-issuer-chart/releases
 [release:czertainly-issuer]: https://github.com/CZERTAINLY/CZERTAINLY-Cert-Manager-Issuer/releases


### PR DESCRIPTION
Adds [cmp-issuer](https://github.com/misiektoja/cmp-issuer) to the list of known cert-manager external issuers.

`cmp-issuer` is an Apache-2.0 licensed, vendor-neutral external issuer that enrolls cert-manager `CertificateRequest` resources against CMPv2 servers.

It currently supports P10CR enrollment, including renewal through P10CR re-enrollment or certificate-authenticated KUR using CRMF proof of possession. CMP messages use PasswordBasedMac (PSK) or certificate-signature message protection over HTTP or HTTPS, with interoperable or strict RFC 9483 response validation.

v0.2.0 has been interoperability-tested against Nokia NCM 26.7, EJBCA Community Edition 9.3.7 and OpenSSL 3.6.3.

The controller is built on cert-manager `issuer-lib`, honors `CertificateRequest` approval and denial and provides `CMPIssuer` and `CMPClusterIssuer` resources for use with normal cert-manager `Certificate` resources.

For context, I'm also a co-author and current maintainer of Nokia's [`ncm-issuer`](https://github.com/nokia/ncm-issuer).

Requested tier: **Tier 2 (Maintained)**, based on the v0.2.0 released in August 2026.

Related discussions: cert-manager/cert-manager#2619 and cert-manager/cert-manager#8716.

Links:

* Project: https://github.com/misiektoja/cmp-issuer
* Documentation: https://misiektoja.github.io/cmp-issuer/
* Release: https://github.com/misiektoja/cmp-issuer/releases/tag/v0.2.0
* License: https://github.com/misiektoja/cmp-issuer/blob/main/LICENSE
