### PR TITLE
ngts: document the Strata service account prerequisites

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1568,3 +1568,4 @@ sklirg
 Tardif
 texasich
 workqueue
+panserviceaccount

--- a/content/docs/configuration/venafi.md
+++ b/content/docs/configuration/venafi.md
@@ -293,6 +293,66 @@ username/password is required.
 
 [ngts]: https://www.paloaltonetworks.com/network-security/next-gen-trust-security
 
+### Prerequisites
+
+Access to NGTS is managed by Strata Cloud Manager rather than by NGTS itself.
+Users and machine identities belong to a Tenant Service Group (TSG) and are
+granted permissions there, so the credentials for your `Issuer` are created in
+Strata Cloud Manager, not in the NGTS console. See [Access Management for New
+and Migrating Users][ngts-access] for a full description of this model.
+
+[ngts-access]: https://docs.paloaltonetworks.com/next-gen-trust-security/next-gen-trust-security/about-vaas/gs-Cloud-Discovery/c-user-account-management-overview
+[strata-service-account]: https://docs.paloaltonetworks.com/common-services/identity-and-access-access-management/manage-identity-and-access/add-service-accounts
+[vcert-ngts]: https://github.com/Venafi/vcert/blob/master/README-CLI-NGTS.md#prerequisites
+
+1. **Create a Strata service account.**
+
+   cert-manager reaches NGTS through the Strata API gateway, so it requires a
+   [Strata service account][strata-service-account]. NGTS also offers
+   "built-in accounts", but those authenticate directly against the NGTS data
+   plane and are reserved for product-delivered integrations, so they cannot
+   be used with the CyberArk `Issuer`.
+
+   Creating the service account gives you the **Client ID** and **Client
+   Secret** used below. The client secret is displayed only once, so record it
+   before leaving the page.
+
+2. **Note the Tenant Service Group ID.**
+
+   The service account's display name has the form
+   `<name>@<tsg-id>.iam.panserviceaccount`, where `<tsg-id>` is the ten-digit
+   ID of the Tenant Service Group that owns the account. cert-manager sends
+   the `tsgID` field of the `Issuer` as the OAuth 2.0 scope `tsg_id:<tsg-id>`
+   when requesting an access token.
+
+   `tsgID` need not be the TSG in the display name. It may be any TSG which
+   the service account is authorized for, including a child TSG, so set it to
+   the TSG which owns the Certificate Issuing Template that you intend to
+   issue from. Note that NGTS is activated in a parent TSG and is not shared
+   with child TSGs automatically, and that a child TSG must be in the same
+   data region as its parent.
+
+3. **Grant the NGTS permissions that cert-manager requires.**
+
+   Assign the service account a role which grants the following NGTS
+   permissions:
+
+   - `ngts.certificate_issuing_template.get`
+   - `ngts.certificate_request.create`
+   - `ngts.certificate_request.get`
+   - `ngts.certificate_content.get`
+   - `ngts.certificate.get`
+   - `ngts.edge_encryption_key.get`
+
+   This is the union of the permissions which [VCert][vcert-ngts] documents
+   for its `enroll` and `pickup` commands, which are the only NGTS operations
+   that the `Issuer` performs. A read-only role such as *View Only Admin* is
+   not sufficient, because requesting a certificate is a write.
+
+   > ⚠️ If you grant *Superuser* rather than a narrower role, constrain it to
+   > the Next-Gen Trust Security application. An unconstrained *Superuser*
+   > role grants Superuser rights across the whole Strata platform.
+
 In order to set up an NGTS `Issuer`, you must first create a Kubernetes
 `Secret` resource containing your OAuth 2.0 client credentials. The secret
 must have the keys `client-id` and `client-secret`:
@@ -320,7 +380,7 @@ or `ClusterIssuer` resource. If you are creating a `ClusterIssuer` resource,
 you must change the `kind` field to `ClusterIssuer` and remove the
 `metadata.namespace` field.
 
-The `zone` is the name of the Certificate Issuing Template (CIT) in NGTS that will be used to issue certificates. Unlike CyberArk Certificate Manager SaaS which requires both an Application name and CIT alias in the format `Application\CIT`, NGTS only requires the CIT name.
+The `zone` is the name of the Certificate Issuing Template (CIT) in NGTS that will be used to issue certificates. Unlike CyberArk Certificate Manager SaaS which requires both an Application name and CIT alias in the format `Application\CIT`, NGTS only requires the CIT name. NGTS has no equivalent of the CyberArk Certificate Manager SaaS *Application*; certificates are instead owned by the Tenant Service Group in which they are requested.
 
 Save the below content after making your amendments to a file named
 `issuer.yaml`.


### PR DESCRIPTION
## Preview

- [Prerequisites (the new section)](https://deploy-preview-2243--cert-manager.netlify.app/docs/configuration/venafi/#prerequisites)
- [Creating an Issuer for Palo Alto Networks Next-Generation Trust Security (the whole section, in context)](https://deploy-preview-2243--cert-manager.netlify.app/docs/configuration/venafi/#creating-an-issuer-for-palo-alto-networks-next-generation-trust-security)

## Motivation

The NGTS section of the CyberArk issuer documentation tells you which keys the credentials `Secret` must contain (`client-id` and `client-secret`) and that `tsgID` is a "Tenant Service Group ID", but it never says where any of those three values come from. There is no path from reading the page to obtaining the credentials.

The gap is not merely a missing link. A reader looking for machine credentials in the NGTS console will find "built-in accounts" and reasonably conclude that those are what an integration such as cert-manager should use. They are not: built-in accounts authenticate directly against the NGTS data plane and are reserved for product-delivered integrations, whereas the issuer talks to the Strata API gateway (`https://api.strata.paloaltonetworks.com/ngts`) and so needs a *Strata* service account. Following the obvious route therefore produces credentials that cannot work, with no indication as to why.

Palo Alto Networks documents the underlying model in [Access Management for New and Migrating Users][ngts-access], and the credential creation steps in [Add Service Accounts][strata-service-account]. This change works the relevant parts of both into the issuer documentation.

## Changes

A new `### Prerequisites` subsection under *Creating an Issuer for Palo Alto Networks Next-Generation Trust Security*, covering:

- **Where credentials come from.** Access to NGTS is managed by Strata Cloud Manager, not by NGTS itself, so the client ID and client secret are created there. The client secret is displayed only once.
- **Strata service account vs. NGTS built-in account**, and why the latter cannot be used, as described above.
- **Where the Tenant Service Group ID comes from** — it is embedded in the service account display name, `<name>@<tsg-id>.iam.panserviceaccount`. The section also notes that `tsgID` need not be that TSG: it may be any TSG the service account is authorized for, including a child TSG, so it should be set to whichever TSG owns the Certificate Issuing Template. A child TSG must be in the same data region as its parent, since activation is not shared with child TSGs automatically.
- **Which permissions are required**, as a least-privilege list rather than a role name. The `Issuer` only ever performs the equivalent of VCert's `enroll` and `pickup`, so the union of the permissions [VCert's NGTS documentation][vcert-ngts] gives for those two commands is exactly what it needs: `ngts.certificate_issuing_template.get`, `ngts.certificate_request.create`, `ngts.certificate_request.get`, `ngts.certificate_content.get`, `ngts.certificate.get` and `ngts.edge_encryption_key.get`. *View Only Admin* is read-only and cannot request certificates. There is still a warning that *Superuser*, if used, must be constrained to the Next-Gen Trust Security application, as an unconstrained grant confers Superuser rights across the whole Strata platform.

One sentence is also added to the existing `zone` paragraph. That paragraph already noted that NGTS needs only the CIT name rather than `Application\CIT`, but not why: NGTS has no equivalent of the Certificate Manager SaaS *Application*, and certificates are owned by the Tenant Service Group in which they are requested.

## Testing

This is a documentation-only change, so there is no behaviour to exercise. What I did check:

- The rendered output on the deploy preview linked above: the ordered list, the two external links and the warning blockquote nested inside item 3 all render as intended.
- The claim that the TSG ID is sent as the OAuth 2.0 scope `tsg_id:<id>` is verified against the implementation in `pkg/issuer/venafi/client/venaficlient.go` in cert-manager itself, rather than inferred from the vendor documentation. This is consistent with the default token endpoint being Strata's, and with the `--scope` flag documented in [VCert's NGTS documentation][vcert-ngts].
- The permission list is derived rather than guessed at. cert-manager's Venafi client calls exactly three VCert operations — `ReadZoneConfiguration`, `RequestCertificate` and `RetrieveCertificate` — which correspond to the `enroll` and `pickup` rows of VCert's permissions table. I checked `ReadZoneConfiguration` in `pkg/venafi/ngts/connector.go` in VCert to confirm it only fetches the issuing template, so the `ngts.certificate_authority_account.get` permission that VCert lists for `getpolicy` is deliberately not included.
- Both external links resolve, and both reference-style link definitions are used.
- The new `### Prerequisites` heading does not collide with another heading on the page.

The single `.spelling` entry is empirically justified rather than guessed at. I had no Node.js toolchain available locally, so I established which entries were genuinely required by pushing without them and reading the CI failure: `panserviceaccount` is flagged, because the angle brackets in `<name>@<tsg-id>.iam.panserviceaccount` stop it matching cspell's built-in email pattern. Lowercase `tsg` is *not* flagged, so no entry was added for it.

[ngts-access]: https://docs.paloaltonetworks.com/next-gen-trust-security/next-gen-trust-security/about-vaas/gs-Cloud-Discovery/c-user-account-management-overview
[strata-service-account]: https://docs.paloaltonetworks.com/common-services/identity-and-access-access-management/manage-identity-and-access/add-service-accounts
[vcert-ngts]: https://github.com/Venafi/vcert/blob/master/README-CLI-NGTS.md#prerequisites
