### PR TITLE
Use npm version bundled with Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     }
   ],
   "engines": {
-    "npm": "12.x",
     "node": "24.x"
   },
   "scripts": {


### PR DESCRIPTION
The lockfile maintenance PRs are again loosing integrity checks, which I tried to fix in https://github.com/cert-manager/website/pull/2144. But now Renovate has suggested an upgrade of npm to version 12.x in https://github.com/cert-manager/website/pull/2204. Node still comes with npm 11.x, so I think the integrity checks are lost because of this mismatch. At least AI believe that it's the cause, and that this PR contains the correct fix: use the npm version bundled with Node.