### PR TITLE
docs: document OpenShift incompatibility with ACMEHTTP01IngressPathTypeExact

### DIFF
--- a/content/docs/installation/compatibility.md
+++ b/content/docs/installation/compatibility.md
@@ -114,3 +114,34 @@ the webhook listens. See the warning at the top of this page for more details.
 Because Fargate forces you to use its networking, you cannot manually set the networking
 type and options such as `webhook.hostNetwork` on the helm chart will cause your
 cert-manager deployment to fail in surprising ways.
+
+## OpenShift
+
+### HTTP01 challenges fail with a 503 when using the built-in router
+
+Since cert-manager 1.18, the HTTP01 solver `Ingress` uses `pathType: Exact`
+for the challenge path (feature gate `ACMEHTTP01IngressPathTypeExact`, on by
+default). OpenShift's `route-controller-manager` converts `Ingress` resources
+into `Route` resources for the built-in HAProxy router, but it
+[skips any rule which uses `pathType: Exact`](https://github.com/openshift/route-controller-manager/blob/59697cf7af4517dd44e28179a57f7f35b6ea0e22/pkg/route/ingress/ingress.go#L460-L464),
+because the `Route` API has no equivalent exact path matching mode.
+The solver `Ingress` is therefore never converted into a `Route`, the challenge
+URL is not served, and the challenge fails with a 503 response.
+
+Support for the `Exact` path type has to be added to OpenShift's
+Ingress-to-Route conversion. Until then, disable the feature gate to reinstate
+the old `PathType: ImplementationSpecific` behavior:
+
+```yaml
+# values.yaml
+config:
+  featureGates:
+    # Disable the use of Exact PathType in Ingress resources, because OpenShift's
+    # Ingress-to-Route conversion does not support it
+    ACMEHTTP01IngressPathTypeExact: false
+```
+
+You are not affected if you install cert-manager using the cert-manager
+Operator for Red Hat OpenShift, which has
+[disabled this feature gate by default](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-operator-1-18-0-known-issues_cert-manager-operator-release-notes)
+since its 1.18.0 release.

--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -84,22 +84,9 @@ See the [fix commit](https://github.com/kubernetes/ingress-nginx/commit/618aae18
 
 #### OpenShift's built-in Ingress-to-Route conversion
 
-This change is also incompatible with the OpenShift built-in router (this is unrelated to the ingress-nginx-specific options above).
-
-OpenShift's `route-controller-manager` converts `Ingress` resources into `Route` resources for the built-in HAProxy router, but it [skips any rule which uses `pathType: Exact`](https://github.com/openshift/route-controller-manager/blob/59697cf7af4517dd44e28179a57f7f35b6ea0e22/pkg/route/ingress/ingress.go#L460-L464), because the `Route` API has no equivalent exact path matching mode.
-The HTTP01 solver `Ingress` is therefore never converted into a `Route`, so the challenge URL is not served and the challenge fails with a 503 response.
-Support for the `Exact` path type has to be added to OpenShift's Ingress-to-Route conversion; until then, disable the `ACMEHTTP01IngressPathTypeExact` feature gate to reinstate the old `PathType: ImplementationSpecific` behavior:
-
-```yaml
-# values.yaml
-config:
-  featureGates:
-    # Disable the use of Exact PathType in Ingress resources, because OpenShift's
-    # Ingress-to-Route conversion does not support it
-    ACMEHTTP01IngressPathTypeExact: false
-```
-
-You are not affected if you install cert-manager using the cert-manager Operator for Red Hat OpenShift, which has [disabled this feature gate by default](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-operator-1-18-0-known-issues_cert-manager-operator-release-notes) since its 1.18.0 release.
+This change is also incompatible with OpenShift's built-in router, which is unrelated to the ingress-nginx options above.
+OpenShift's Ingress-to-Route conversion skips rules which use `pathType: Exact`, so the HTTP01 challenge fails with a 503 response.
+See [OpenShift](../../installation/compatibility.md#openshift) on the compatibility page for details and the feature gate to disable.
 
 ### ACME Certificate Profiles
 

--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -84,14 +84,11 @@ See the [fix commit](https://github.com/kubernetes/ingress-nginx/commit/618aae18
 
 #### OpenShift's built-in Ingress-to-Route conversion
 
-This change is also incompatible with the OpenShift built-in router.
+This change is also incompatible with the OpenShift built-in router (this is unrelated to the ingress-nginx-specific options above).
 
 OpenShift's `route-controller-manager` converts `Ingress` resources into `Route` resources for the built-in HAProxy router, but it [skips any rule which uses `pathType: Exact`](https://github.com/openshift/route-controller-manager/blob/59697cf7af4517dd44e28179a57f7f35b6ea0e22/pkg/route/ingress/ingress.go#L460-L464), because the `Route` API has no equivalent exact path matching mode.
 The HTTP01 solver `Ingress` is therefore never converted into a `Route`, so the challenge URL is not served and the challenge fails with a 503 response.
-Support for the `Exact` path type has to be added to OpenShift's Ingress-to-Route conversion; until then, use the feature gate.
-
-If you use the OpenShift built-in router, disable the `ACMEHTTP01IngressPathTypeExact` feature,
-to reinstate the old `PathType: ImplementationSpecific` behavior:
+Support for the `Exact` path type has to be added to OpenShift's Ingress-to-Route conversion; until then, disable the `ACMEHTTP01IngressPathTypeExact` feature gate to reinstate the old `PathType: ImplementationSpecific` behavior:
 
 ```yaml
 # values.yaml

--- a/content/docs/releases/release-notes/release-notes-1.18.md
+++ b/content/docs/releases/release-notes/release-notes-1.18.md
@@ -82,6 +82,28 @@ If you are running ingress-nginx `v1.13.2+` or `v1.12.6+`, you do not need to ap
 
 See the [fix commit](https://github.com/kubernetes/ingress-nginx/commit/618aae18515213bcf3fb820e6f8c234703d844b2)
 
+#### OpenShift's built-in Ingress-to-Route conversion
+
+This change is also incompatible with the OpenShift built-in router.
+
+OpenShift's `route-controller-manager` converts `Ingress` resources into `Route` resources for the built-in HAProxy router, but it [skips any rule which uses `pathType: Exact`](https://github.com/openshift/route-controller-manager/blob/59697cf7af4517dd44e28179a57f7f35b6ea0e22/pkg/route/ingress/ingress.go#L460-L464), because the `Route` API has no equivalent exact path matching mode.
+The HTTP01 solver `Ingress` is therefore never converted into a `Route`, so the challenge URL is not served and the challenge fails with a 503 response.
+Support for the `Exact` path type has to be added to OpenShift's Ingress-to-Route conversion; until then, use the feature gate.
+
+If you use the OpenShift built-in router, disable the `ACMEHTTP01IngressPathTypeExact` feature,
+to reinstate the old `PathType: ImplementationSpecific` behavior:
+
+```yaml
+# values.yaml
+config:
+  featureGates:
+    # Disable the use of Exact PathType in Ingress resources, because OpenShift's
+    # Ingress-to-Route conversion does not support it
+    ACMEHTTP01IngressPathTypeExact: false
+```
+
+You are not affected if you install cert-manager using the cert-manager Operator for Red Hat OpenShift, which has [disabled this feature gate by default](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-operator-1-18-0-known-issues_cert-manager-operator-release-notes) since its 1.18.0 release.
+
 ### ACME Certificate Profiles
 
 cert-manager now supports the selection of ACME certificate profiles, allowing

--- a/content/docs/troubleshooting/acme.md
+++ b/content/docs/troubleshooting/acme.md
@@ -229,6 +229,13 @@ If your challenge self-check fails with a 404 not found error. Make sure to chec
 * the ACME solver pod is up and running
 * use `kubectl describe ingress` to check the status of the HTTP01 solver ingress. (unless you use `acme.cert-manager.io/http01-edit-in-place`, then check the same ingress as your domain)
 
+#### Got 503 status code
+If your challenge self-check fails with a 503 error on OpenShift and you use the
+built-in router, the solver `Ingress` is probably not being converted into a
+`Route` because it uses `pathType: Exact`. See
+[OpenShift](../installation/compatibility.md#openshift) on the compatibility page
+for the explanation and the feature gate to disable.
+
 ### DNS01 troubleshooting
 If you see no error events about your DNS provider you can check the following.
 Check if you can see the `_acme_challenge.domain` TXT DNS record from the public internet, or in your DNS provider's interface.


### PR DESCRIPTION
Documents the OpenShift incompatibility with the `ACMEHTTP01IngressPathTypeExact` feature gate, as a new subsection of the existing "ACME HTTP01 challenge paths now use `PathType` `Exact` in Ingress routes" section in the v1.18 release notes.

OpenShift's `route-controller-manager` converts `Ingress` resources into `Route` resources for the built-in HAProxy router, but it [skips any rule which uses `pathType: Exact`](https://github.com/openshift/route-controller-manager/blob/59697cf7af4517dd44e28179a57f7f35b6ea0e22/pkg/route/ingress/ingress.go#L460-L464) — the `Route` API has no equivalent exact path matching mode. The HTTP-01 solver `Ingress` is therefore never converted into a `Route`, so the challenge URL is not served and the challenge fails with a 503.

The new subsection mirrors the `ingress-nginx` treatment directly above it: what breaks, why, and the feature-gate workaround. It also notes that the cert-manager Operator for Red Hat OpenShift already disables the gate by default from its 1.18.0 release, so users of that distribution are unaffected, and that the durable fix is `Exact` path type support in OpenShift's Ingress-to-Route conversion.

This replaces cert-manager/cert-manager#9219, which documented the same thing in the cert-manager repository. @lunarwhite and @erikgb pointed out there that the website is the right place for it:

> As I said: cert-manager/cert-manager#9210 (comment), I'm afraid having it documented in cert-manager codebase would be way too narrow. If we really want to document something, I suggest open a PR against doc site

I will close #9219 in favour of this.

Refs cert-manager/cert-manager#9210

**Testing**

`npm ci` then, against the changed file: `cspell` 0 issues, `remark --frail` clean, `eslint` clean, `markdown-link-check` clean.
