### PR TITLE
docs: correct the Gateway API version requirement

### DIFF
--- a/content/docs/configuration/acme/http01/README.md
+++ b/content/docs/configuration/acme/http01/README.md
@@ -288,8 +288,12 @@ kubectl rollout restart deployment cert-manager -n cert-manager
 
 :::info
 
-🚧   cert-manager 1.14+ is tested with v1 Kubernetes Gateway API. It should also work
-with v1beta1 and v1alpha2 because of resource conversion, but has not been tested with it.
+🚧   cert-manager watches Gateway resources through the `gateway.networking.k8s.io/v1` API, so the
+Gateway API **v1** CRDs have to be installed. cert-manager refuses to start with Gateway API support
+enabled if the cluster only serves `v1beta1` or `v1alpha2`.
+
+Your own Gateway manifests may still be written as `v1beta1` or `v1alpha2`, since the API server converts
+between versions.
 
 :::
 

--- a/content/docs/usage/gateway.md
+++ b/content/docs/usage/gateway.md
@@ -23,8 +23,12 @@ HTTP-01](../configuration/acme/http01/README.md).
 
 :::info
 
-🚧   cert-manager 1.14+ is tested with v1 Kubernetes Gateway API. It should also work
-with v1beta1 and v1alpha2 because of resource conversion, but has not been tested with it.
+🚧   cert-manager watches Gateway resources through the `gateway.networking.k8s.io/v1` API, so the
+Gateway API **v1** CRDs have to be installed. cert-manager refuses to start with Gateway API support
+enabled if the cluster only serves `v1beta1` or `v1alpha2`.
+
+Your own Gateway manifests may still be written as `v1beta1` or `v1alpha2`, since the API server converts
+between versions.
 
 :::
 

--- a/content/v1.19-docs/configuration/acme/http01/README.md
+++ b/content/v1.19-docs/configuration/acme/http01/README.md
@@ -285,8 +285,12 @@ kubectl rollout restart deployment cert-manager -n cert-manager
 
 :::info
 
-🚧   cert-manager 1.14+ is tested with v1 Kubernetes Gateway API. It should also work
-with v1beta1 and v1alpha2 because of resource conversion, but has not been tested with it.
+🚧   cert-manager watches Gateway resources through the `gateway.networking.k8s.io/v1` API, so the
+Gateway API **v1** CRDs have to be installed. cert-manager refuses to start with Gateway API support
+enabled if the cluster only serves `v1beta1` or `v1alpha2`.
+
+Your own Gateway manifests may still be written as `v1beta1` or `v1alpha2`, since the API server converts
+between versions.
 
 :::
 

--- a/content/v1.19-docs/usage/gateway.md
+++ b/content/v1.19-docs/usage/gateway.md
@@ -23,8 +23,12 @@ HTTP-01](../configuration/acme/http01/README.md).
 
 :::info
 
-🚧   cert-manager 1.14+ is tested with v1 Kubernetes Gateway API. It should also work
-with v1beta1 and v1alpha2 because of resource conversion, but has not been tested with it.
+🚧   cert-manager watches Gateway resources through the `gateway.networking.k8s.io/v1` API, so the
+Gateway API **v1** CRDs have to be installed. cert-manager refuses to start with Gateway API support
+enabled if the cluster only serves `v1beta1` or `v1alpha2`.
+
+Your own Gateway manifests may still be written as `v1beta1` or `v1alpha2`, since the API server converts
+between versions.
 
 :::
 


### PR DESCRIPTION
Fixes #1623.

The note currently reads:

> 🚧 cert-manager 1.14+ is tested with v1 Kubernetes Gateway API. It should also work with v1beta1 and v1alpha2 because of resource conversion, but has not been tested with it.

That reads as though a cluster serving only `v1beta1`/`v1alpha2` is supported. It isn't — cert-manager will not start:

- `pkg/controller/context.go` imports `gwapi "sigs.k8s.io/gateway-api/apis/v1"` and calls `d.ServerResourcesForGroupVersion(gwapi.GroupVersion.String())` at startup, returning `the Gateway API CRDs do not seem to be present, but ExperimentalGatewayAPISupport is set to true` when they are not.
- The Gateway shim watches `ctx.GWShared.Gateway().V1().Gateways()`, so `gateway.networking.k8s.io/v1` is the only version it lists and watches.

That is exactly the crash loop reported in cert-manager/cert-manager#6649, and the resolution there was that the cluster had to serve the v1 CRDs. Once they are installed, the reporters confirmed that Gateway resources authored as `v1beta1` work fine, which is the part of the original sentence worth keeping.

So the replacement says the v1 CRDs are required, and that your own Gateway manifests may still be `v1beta1`/`v1alpha2` because the API server converts between versions.

The same paragraph appears in `usage/gateway.md` and `configuration/acme/http01/README.md`. Per the repo README ("add it to `docs/` and possibly to the specific version of cert-manager that's latest"), I changed `content/docs/` and `content/v1.19-docs/`. The identical text is also in the v1.11–v1.18 snapshots; I left those alone as frozen docs for released versions, but happy to extend if you would rather have them consistent.

### Testing

`npm ci`, then against the four changed files: `cspell` 0 issues, `remark --frail` exit 0. No links were added or changed.
