### PR TITLE
docs: document the Vault issuer caBundleSecretRef field

### DIFF
--- a/content/docs/configuration/vault.md
+++ b/content/docs/configuration/vault.md
@@ -47,6 +47,36 @@ spec:
       ...
 ```
 
+### Trusting the Vault server's CA
+
+When connecting to Vault over HTTPS, cert-manager validates the certificate chain that Vault
+presents. There are two mutually exclusive ways to supply the CA bundle, and both are ignored for
+plain HTTP connections:
+
+- `caBundle`: a base64-encoded bundle of PEM CAs, inlined in the issuer as in the example above.
+- `caBundleSecretRef`: a reference to a `Secret` holding a bundle of PEM-encoded CAs. If you do not
+  set `key`, cert-manager reads `ca.crt` from that `Secret`.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: vault-issuer
+  namespace: sandbox
+spec:
+  vault:
+    path: pki_int/sign/example-dot-com
+    server: https://vault.local
+    caBundleSecretRef:
+      name: vault-ca
+      key: ca.crt
+    auth:
+      ...
+```
+
+If neither field is set, cert-manager validates the connection against the CA certificates bundled
+in its own controller container.
+
 ### Accessing a Vault Server with mTLS enforced
 
 In certain use cases, the [Vault Server could be configured to enforce clients to present a

--- a/content/v1.19-docs/configuration/vault.md
+++ b/content/v1.19-docs/configuration/vault.md
@@ -47,6 +47,36 @@ spec:
       ...
 ```
 
+### Trusting the Vault server's CA
+
+When connecting to Vault over HTTPS, cert-manager validates the certificate chain that Vault
+presents. There are two mutually exclusive ways to supply the CA bundle, and both are ignored for
+plain HTTP connections:
+
+- `caBundle`: a base64-encoded bundle of PEM CAs, inlined in the issuer as in the example above.
+- `caBundleSecretRef`: a reference to a `Secret` holding a bundle of PEM-encoded CAs. If you do not
+  set `key`, cert-manager reads `ca.crt` from that `Secret`.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: vault-issuer
+  namespace: sandbox
+spec:
+  vault:
+    path: pki_int/sign/example-dot-com
+    server: https://vault.local
+    caBundleSecretRef:
+      name: vault-ca
+      key: ca.crt
+    auth:
+      ...
+```
+
+If neither field is set, cert-manager validates the connection against the CA certificates bundled
+in its own controller container.
+
 ### Accessing a Vault Server with mTLS enforced
 
 In certain use cases, the [Vault Server could be configured to enforce clients to present a


### PR DESCRIPTION
Fixes #1425.

`caBundleSecretRef` was only ever visible on this page inside the mTLS example, with no prose saying what it is or how it relates to `caBundle` — which is why @wallrj's search of cert-manager.io turned up nothing but a release note.

This documents both fields where `caBundle` is first introduced, taken from the API definitions in `pkg/apis/certmanager/v1/types_issuer.go`:

- they are mutually exclusive;
- both are only used for HTTPS and ignored for plain HTTP;
- `caBundleSecretRef` defaults to reading `ca.crt` when no `key` is given;
- if neither is set, the CA bundle in the cert-manager controller container is used.

The `caBundleSecretRef` example in the mTLS section further down now has something to point back to.

Per the repo README ("add it to `docs/` and possibly to the specific version of cert-manager that's latest"), this changes `content/docs/` and `content/v1.19-docs/`, whose `vault.md` files were identical.

### Testing

`npm ci`, then against both changed files: `cspell` 0 issues, `remark --frail` exit 0, `markdown-link-check` 17 links checked with no errors.
