### PR TITLE
docs: add certforge-issuer to external issuers list

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -550,6 +550,7 @@ runtimes
 signoff
 sigstore
 solidserver
+certforge
 status.condition
 stdout
 subchart

--- a/content/docs/configuration/issuers.md
+++ b/content/docs/configuration/issuers.md
@@ -15,6 +15,7 @@ The following list contains all known cert-manager issuer integrations.
 | 🥈   | adcs-issuer                 | [📄][config:adcs-issuer]            | [Microsoft Active Directory<br/>Certificate Service][ca:adcs-issuer]   | -                                                 | [✔️][release:adcs-issuer]            | ✔️             |
 | 🥈   | aws-privateca-issuer        | [📄][config:aws-privateca-issuer]   | [AWS Private Certificate Authority][ca:aws-privateca-issuer]           | -                                                 | [✔️][release:aws-privateca-issuer]   | ✔️             |
 | 🥈   | ca-issuer (in-tree)         | [📄][config:ca-issuer]              | CA issuer                                                              | -                                                 | [✔️][release:cert-manager]           | ✔️             |
+| 🥈   | certforge-issuer            | [📄][config:certforge-issuer]       | [CertForge][ca:certforge-issuer]                                       | -                                                 | [✔️][release:certforge-issuer]       | ✔️             |
 | 🥈   | czertainly-issuer           | [📄][config:czertainly-issuer]      | [CZERTAINLY][ca:czertainly-issuer]                                     | [supported][production:czertainly-issuer]         | [✔️][release:czertainly-issuer]      | ✔️             |
 | 🥈   | command-issuer              | [📄][config:command-issuer]         | [Keyfactor Command][ca:command-issuer]                                 | -                                                 | [✔️][release:command-issuer]         | ✔️             |
 | 🥈   | cview-issuer                | [📄][config:cview-issuer]           | [CView-issuer][ca:cview-issuer]                                        | -                                                 | [✔️][release:cview-issuer]           | ❌              |
@@ -70,6 +71,7 @@ The following list contains all known cert-manager issuer integrations.
 [config:cview-issuer]: https://secure-ly.github.io/cview-issuer-chart
 [config:czertainly-issuer]: https://docs.czertainly.com/docs/certificate-key/integration-guides/cert-manager-issuer/create-czertainly-issuer
 [config:keyvault-issuer]: https://github.com/gonicus/azure-keyvault-issuer
+[config:certforge-issuer]: https://github.com/CertForge-LLC/certforge-issuer#readme
 [config:digi-issuer]: https://github.com/digicert/digi-issuer
 
 [//]: # (CA docs)
@@ -97,6 +99,7 @@ The following list contains all known cert-manager issuer integrations.
 [ca:cview-issuer]: https://secure-ly.github.io/cview-issuer-chart
 [ca:czertainly-issuer]: https://www.czertainly.com
 [ca:keyvault-issuer]: https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys
+[ca:certforge-issuer]: https://certgov.app
 [ca:digi-issuer]: https://www.digicert.com/
 
 [//]: # (Release pages)
@@ -122,6 +125,7 @@ The following list contains all known cert-manager issuer integrations.
 [release:cview-issuer]: https://github.com/secure-ly/cview-issuer-chart/releases
 [release:czertainly-issuer]: https://github.com/CZERTAINLY/CZERTAINLY-Cert-Manager-Issuer/releases
 [release:keyvault-issuer]: https://github.com/gonicus/azure-keyvault-issuer/releases
+[release:certforge-issuer]: https://github.com/CertForge-LLC/certforge-issuer/releases
 [release:digi-issuer]: https://github.com/digicert/digi-issuer/releases
 
 - The issuers are sorted by their tier and then alphabetically.


### PR DESCRIPTION
Adds certforge-issuer to the 🥈 tier external issuers list.

- Apache 2.0 license added to https://github.com/CertForge-LLC/certforge-issuer
- Links updated to https://certgov.app
- `certforge` added to `.spelling`
- Reference link sections formatted with correct blank line separators
- Single clean commit rebased directly onto current master