### PR TITLE
Ignore @apply in stylelint at-rule-prelude-no-invalid

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,6 +3,7 @@
   "rules": {
     "selector-class-pattern": null,
     "import-notation": null,
-    "at-rule-no-unknown": null
+    "at-rule-no-unknown": null,
+    "at-rule-prelude-no-invalid": [true, { "ignoreAtRules": ["apply"] }]
   }
 }


### PR DESCRIPTION
Unblocks #2263. The lockfile refresh there bumps `@csstools/css-syntax-patches-for-csstree` to 1.1.12, which gives stylelint a grammar for `@apply` that only accepts `--dashed` identifiers. Every Tailwind `@apply` in `styles/` then fails `at-rule-prelude-no-invalid`.

This ignores `@apply` for that rule. Verified locally at the head of #2263: 27 errors to 0.

<details>
<summary>Evidence</summary>

- Grammar added in 1.1.11: https://github.com/csstools/postcss-plugins/blob/4e9406b8d5a9e745212deaa18e845f2597e5aca3/packages/css-syntax-patches-for-csstree/dist/index.json#L4-L6
- The rule's `ignoreAtRules` option: https://github.com/stylelint/stylelint/blob/17.14.1/lib/rules/at-rule-prelude-no-invalid/index.mjs#L47-L49
- Full analysis: https://github.com/cert-manager/website/pull/2263#issuecomment-5550717061

| Local run at #2263 head | stylelint errors |
|---|---|
| as-is, 1.1.12 | 27 |
| downgraded to 1.1.7 | 0 |
| 1.1.12 with this change | 0 |
</details>

[Claude Fable 5.1]
