### PR TITLE
Explain what to do when an application expects ca.crt in the certificate Secret

### DIFF
--- a/content/docs/faq/README.md
+++ b/content/docs/faq/README.md
@@ -113,6 +113,10 @@ for trust purposes, but rotating trusted certificates safely relies on being abl
 By consuming the CA directly from your Secret, it becomes impossible to do this; `ca.crt` will only ever contain the best effort guess
 for the CA for the current certificate, and will never include an older or a new CA.
 
+If your application expects `ca.crt` next to `tls.crt` and `tls.key`, see
+[My application expects `ca.crt` in the same Secret as the certificate](../trust/README.md#ca-crt-in-same-secret)
+for what to do instead.
+
 ### How can I see all the historic events related to a certificate object?
 
 cert-manager publishes all events to the Kubernetes events mechanism, you can get the events for your specific resources using `kubectl describe <resource> <name>`.

--- a/content/docs/trust/README.md
+++ b/content/docs/trust/README.md
@@ -108,8 +108,10 @@ It is tempting to have a second controller, a mutating webhook or a Job add
 `ca.crt` to the Secret that cert-manager manages. Do not do this. cert-manager
 reconciles that Secret and reads it back to decide whether to reissue. For example,
 if `keystores` are enabled, cert-manager treats the presence of `ca.crt` as proof that
-the issuer provided a CA and expects a matching truststore, which it cannot create
-for an ACME issuer, so it reissues on every reconcile.
+the issuer provided a CA and expects a matching trust store. cert-manager builds
+trust stores from the CA returned by the issuer, not from the Secret, and an ACME
+issuer returns none. The trust store is never written, so the check fails and
+cert-manager reissues on every reconcile.
 
 If the application accepts only a single Secret with all three keys and offers no
 separate CA option, ask the project to add one, and link to this page. In the

--- a/content/docs/trust/README.md
+++ b/content/docs/trust/README.md
@@ -28,3 +28,91 @@ the client will fail to connect to the compromised server.
 
 The same concept also applies when configuring a server for mutually-authenticated TLS;
 don't give the server access to Secret containing the client certificate and private key.
+
+<a id="ca-crt-in-same-secret"></a>
+## My application expects `ca.crt` in the same Secret as the certificate
+
+Many Helm charts and operators assume a `kubernetes.io/tls` Secret with three keys:
+`tls.crt`, `tls.key` and `ca.crt`. cert-manager only writes `ca.crt` when the issuer
+reports a CA. The ACME issuer never does, so that Secret has no `ca.crt`, and the
+application refuses to start or the volume mount fails with an error like
+`references non-existent secret key: ca.crt`.
+
+The question to answer first is what the application does with `ca.crt`. For most
+applications it is a trust store: the set of CAs allowed to sign client or peer
+certificates. For example, OpenSearch nodes use it to authenticate other nodes and
+admin clients, and Redis uses `tls-ca-cert-file` to
+[authenticate clients and replicas](https://github.com/redis/redis/blob/8.10.1/redis.conf#L233-L237).
+A trust store must contain only CAs you control. If the certificate was issued by a
+public CA such as Let's Encrypt, the issuing CA must not be used as a trust store,
+because anyone with a certificate from that CA could then authenticate to your
+application.
+
+So the CA you want in `ca.crt` is a decision you make, and its lifecycle is separate
+from the leaf certificate. Distribute it with trust-manager and connect the two
+Secrets in one of these ways.
+
+### Give the application a separate CA Secret
+
+Check whether the application accepts the CA separately. Many of the applications
+users report do:
+
+- The OpenSearch operator has
+  [`caSecret.name`](https://github.com/opensearch-project/opensearch-k8s-operator/blob/v2.8.0/docs/userguide/main.md?plain=1#L214)
+  next to `secret.name`.
+- The RabbitMQ cluster operator has
+  [`tls.caSecretName`](https://github.com/rabbitmq/cluster-operator/blob/v2.22.5/api/v1beta1/rabbitmqcluster_types.go#L374)
+  next to `tls.secretName`.
+- Istio Gateway reads the CA for mutual TLS from a Secret named
+  [`<credentialName>-cacert`](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings).
+- ingress-nginx reads the client CA from the Secret named in the
+  [`auth-tls-secret`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#client-certificate-authentication)
+  annotation.
+- Gateway API `BackendTLSPolicy` reads CAs from a
+  [ConfigMap](https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/).
+
+Point those fields at a trust-manager `Bundle` target. `Bundle` targets are
+ConfigMaps by default; enable Secret targets in trust-manager if the application
+only accepts a Secret. See [Targets](./trust-manager/README.md#targets).
+
+### Merge the two into one volume
+
+If you write the Pod spec yourself, a
+[projected volume](https://kubernetes.io/docs/concepts/storage/projected-volumes/)
+presents the cert-manager Secret and the trust-manager ConfigMap as one directory.
+The application sees `tls.crt`, `tls.key` and `ca.crt` side by side, and each file is
+updated independently by its own controller:
+
+```yaml
+volumes:
+  - name: tls
+    projected:
+      sources:
+        - secret:
+            name: my-app-tls # Certificate.spec.secretName
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+        - configMap:
+            name: my-org-roots # trust-manager Bundle name
+            items:
+              - key: trust-bundle.pem # Bundle.spec.target.configMap.key
+                path: ca.crt
+```
+
+### Do not write `ca.crt` into the cert-manager Secret
+
+It is tempting to have a second controller, a mutating webhook or a Job add
+`ca.crt` to the Secret that cert-manager manages. Do not do this. cert-manager
+reconciles that Secret and reads it back to decide whether to reissue. For example,
+if `keystores` are enabled, cert-manager treats the presence of `ca.crt` as proof that
+the issuer provided a CA and expects a matching truststore, which it cannot create
+for an ACME issuer, so it reissues on every reconcile.
+
+If the application accepts only a single Secret with all three keys and offers no
+separate CA option, ask the project to add one, and link to this page. In the
+meantime, build a derived Secret with a tool such as
+[secret-transform](https://github.com/maelvls/secret-transform) rather than editing
+the cert-manager Secret.


### PR DESCRIPTION
Rendered preview:

- [Trusting certificates: My application expects `ca.crt` in the same Secret as the certificate](https://deploy-preview-2271--cert-manager.netlify.app/docs/trust/#ca-crt-in-same-secret)
- [FAQ: Why isn't my certificate's chain in my issued Secret's `ca.crt`?](https://deploy-preview-2271--cert-manager.netlify.app/docs/faq/#chain-cacrt)

Fixes: https://github.com/cert-manager/cert-manager/issues/1571
Fixes: https://github.com/cert-manager/trust-manager/issues/222

The FAQ and the trust page explain why `ca.crt` must not be used as a trust store. They do not say what to do when a chart or operator insists on a single Secret with `tls.crt`, `tls.key` and `ca.crt`. That is the recurring question behind cert-manager/cert-manager#1571 and cert-manager/trust-manager#222, and it has kept both issues alive for years.

This PR adds a section to the trust page, "My application expects `ca.crt` in the same Secret as the certificate", and links to it from the FAQ entry. The section:

- explains that `ca.crt` is usually a trust store for client or peer authentication, so a public CA must never be used there;
- lists the applications users report and the separate CA option each one already has (OpenSearch operator `caSecret.name`, RabbitMQ cluster operator `caSecretName`, Istio Gateway `<credentialName>-cacert`, ingress-nginx `auth-tls-secret`, Gateway API `BackendTLSPolicy`);
- shows a projected volume that merges the cert-manager Secret and the trust-manager ConfigMap into one directory;
- explains why writing `ca.crt` into the cert-manager Secret from another controller is unsafe.

<details>
<summary>Evidence for the claims in the new section</summary>

- cert-manager only writes `ca.crt` when the issuer returns a CA: [issuing/internal/secret.go#L165-L167](https://github.com/cert-manager/cert-manager/blob/79dd67caae8e6ea319ac9cf7f0a380b77c3a9f2b/pkg/controller/certificates/issuing/internal/secret.go#L165-L167).
- The keystore check treats the presence of `ca.crt` in the Secret as "issuer provides CA" ([policies/checks.go#L107](https://github.com/cert-manager/cert-manager/blob/79dd67caae8e6ea319ac9cf7f0a380b77c3a9f2b/internal/controller/certificates/policies/checks.go#L107)), but truststores are built from the CertificateRequest CA ([secret.go#L305](https://github.com/cert-manager/cert-manager/blob/79dd67caae8e6ea319ac9cf7f0a380b77c3a9f2b/pkg/controller/certificates/issuing/internal/secret.go#L305), [#L363](https://github.com/cert-manager/cert-manager/blob/79dd67caae8e6ea319ac9cf7f0a380b77c3a9f2b/pkg/controller/certificates/issuing/internal/secret.go#L363)). An injected `ca.crt` with keystores enabled therefore never satisfies the check.
- OpenSearch operator `caSecret.name`: [userguide v2.8.0 line 214](https://github.com/opensearch-project/opensearch-k8s-operator/blob/v2.8.0/docs/userguide/main.md?plain=1#L214).
- RabbitMQ cluster operator `caSecretName`: [rabbitmqcluster_types.go v2.22.5 line 374](https://github.com/rabbitmq/cluster-operator/blob/v2.22.5/api/v1beta1/rabbitmqcluster_types.go#L374).
- Redis `tls-ca-cert-file` authenticates clients and peers: [redis.conf 8.10.1 lines 233-237](https://github.com/redis/redis/blob/8.10.1/redis.conf#L233-L237).

</details>

[Claude Fable 5.1]
