### PR TITLE
Install cmrel from master and drop the checkout requirement

### DIFF
--- a/content/docs/contributing/release-process.md
+++ b/content/docs/contributing/release-process.md
@@ -70,15 +70,20 @@ First, ensure that you have all the tools required to perform a cert-manager rel
 2. Install our [`cmrel`](https://github.com/cert-manager/release) CLI:
 
    ```bash
-   go install github.com/cert-manager/release/cmd/cmrel@latest
+   go install github.com/cert-manager/release/cmd/cmrel@master
    ```
 
-3. Clone the `cert-manager/release` repo:
+   Always install it this way, immediately before a release, so that you have the latest commit.
+   The binary carries its own Cloud Build config, and the privileged publish job installs the exact
+   commit of `cmrel` that you ran. Do not build `cmrel` from a local checkout: any uncommitted or
+   untracked file makes the build "dirty" and the publish job will refuse to run it.
+
+3. Clone the `cert-manager/release` repo. `cmrel` does not need it; the Helm chart step later on
+   runs a script from it:
 
    ```bash
    # Don't clone it from inside the cert-manager repo folder.
    git clone https://github.com/cert-manager/release
-   cd release
    ```
 
 4. Install the [`gcloud`](https://cloud.google.com/sdk/) CLI.
@@ -430,7 +435,6 @@ page if a step is missing or if it is outdated.
     2. Run the following command:
 
        ```bash
-       # Must be run from the "cert-manager/release" repo folder.
        cmrel publish --release-name "$RELEASE_VERSION"
        ```
 
@@ -443,7 +447,6 @@ page if a step is missing or if it is outdated.
        repository](https://charts.jetstack.io):
 
        ```bash
-       # Must be run from the "cert-manager/release" repo folder.
        cmrel publish --nomock --release-name "$RELEASE_VERSION"
        ```
 


### PR DESCRIPTION
/hold until cert-manager/release#376 merges, because the new text says `cmrel` no longer needs the checkout.

**Release managers install `cmrel` with `go install ...@master` and no longer run it from a clone of `cert-manager/release`.** The clone stays, but only for the chart signing script.

## Why

The v1.21.2 release found that `go install ...@latest` gave a binary from April 2024 that cannot publish, because the publish job now refuses to install an unpinned `cmrel` (cert-manager/release#334). Details: https://github.com/cert-manager/cert-manager/issues/9237#issuecomment-5631453407

Tagging `cert-manager/release` (v1.13.0) fixes `@latest` for now, but a tag and a checkout are two things to keep in sync, and nothing checks that they match. Building from the checkout is not safe either: Go stamps the binary `vcs.modified=true` if `git status` shows anything, including untracked files, and the pin then refuses to run. Evidence is in cert-manager/release#376.

## What changes

- Install step: `@master`, with two sentences on why, and a warning not to build from a local checkout.
- Clone step: kept, with its real purpose stated. The `cd release` is gone because nothing before the chart step needs it.
- The two `cmrel publish` commands lose their "must be run from the release repo folder" comment. The chart script keeps its comment.

[Claude Fable 5.1]
