### PR TITLE
docs: fix 'an the Certificate' typo in rotationPolicy note

### DIFF
--- a/content/docs/usage/certificate.md
+++ b/content/docs/usage/certificate.md
@@ -527,7 +527,7 @@ Adding the following annotation on an ingress will automatically set "issue-temp
 > the private key **is not** rotated automatically.
 
 With the setting `rotationPolicy: Always`, the private key Secret associated with a Certificate
-object can be configured to be rotated as soon as an the Certificate is reissued (see
+object can be configured to be rotated as soon as the Certificate is reissued (see
 [Issuance triggers](#issuance-triggers)).
 
 With `rotationPolicy: Always`, cert-manager waits until the Certificate


### PR DESCRIPTION
Fixes #2283

Removes the stray `an` in the `rotationPolicy: Always` note so it reads \"as soon as the Certificate is reissued\".

Signed-off with DCO.